### PR TITLE
build: Update publish command to also build the packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prepare": "husky install",
     "changeset:add": "pnpm changeset",
     "changeset:consume": "pnpm changeset version",
-    "changeset:publish": "pnpm changeset publish"
+    "changeset:publish": "pnpm run build && pnpm changeset publish"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1",


### PR DESCRIPTION
# Description

We actually need to build the packages before we can actually publish them.
