### PR TITLE
ref(core): Add codecov prefix to log messages

### DIFF
--- a/.changeset/khaki-lions-glow.md
+++ b/.changeset/khaki-lions-glow.md
@@ -1,0 +1,8 @@
+---
+"@codecov/bundler-plugin-core": patch
+"@codecov/rollup-plugin": patch
+"@codecov/vite-plugin": patch
+"@codecov/webpack-plugin": patch
+---
+
+Add codecov prefix to log messages

--- a/packages/bundler-plugin-core/src/utils/logging.ts
+++ b/packages/bundler-plugin-core/src/utils/logging.ts
@@ -13,7 +13,7 @@ export function prepareMessage(msg: unknown): string {
 export function l(msg: string): void {
   // Required to properly log to the console
   // eslint-disable-next-line no-console
-  console.log(msg);
+  console.log(`[codecov] ${msg}`);
 }
 
 export function nl(): void {


### PR DESCRIPTION
Makes the grepping the logs in CI a little easier while debugging setups.