### PR TITLE
fix: Manually  create Git slug for Vercel

### DIFF
--- a/.changeset/four-houses-drive.md
+++ b/.changeset/four-houses-drive.md
@@ -1,0 +1,8 @@
+---
+"@codecov/bundler-plugin-core": patch
+"@codecov/rollup-plugin": patch
+"@codecov/vite-plugin": patch
+"@codecov/webpack-plugin": patch
+---
+
+Update Vercel env helper function to create full git slug

--- a/packages/bundler-plugin-core/src/utils/providers/Vercel.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/Vercel.ts
@@ -48,7 +48,15 @@ function _getSHA(inputs: ProviderUtilInputs): string {
 function _getSlug(inputs: ProviderUtilInputs): string {
   const { args, envs } = inputs;
   if (args?.slug && args?.slug !== "") return args?.slug;
-  return envs?.VERCEL_GIT_REPO_SLUG ?? "";
+  const owner = envs?.VERCEL_GIT_REPO_OWNER ?? "";
+  const repo = envs?.VERCEL_GIT_REPO_SLUG ?? "";
+
+  let slug = "";
+  if (owner && repo) {
+    slug = `${owner}/${repo}`;
+  }
+
+  return slug;
 }
 
 // eslint-disable-next-line @typescript-eslint/require-await

--- a/packages/bundler-plugin-core/src/utils/providers/Vercel.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/Vercel.ts
@@ -1,3 +1,6 @@
+// VERCEL ENV DOCS
+// https://vercel.com/docs/projects/environment-variables/system-environment-variables
+
 import {
   type ProviderEnvs,
   type ProviderServiceParams,

--- a/packages/bundler-plugin-core/src/utils/providers/__tests__/Vercel.test.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/__tests__/Vercel.test.ts
@@ -42,7 +42,8 @@ describe("Vercel Params", () => {
       envs: {
         VERCEL: "true",
         VERCEL_GIT_COMMIT_SHA: "testingsha",
-        VERCEL_GIT_REPO_SLUG: "testOrg/testRepo",
+        VERCEL_GIT_REPO_SLUG: "testRepo",
+        VERCEL_GIT_REPO_OWNER: "testOrg",
       },
     };
 
@@ -73,7 +74,8 @@ describe("Vercel Params", () => {
       envs: {
         VERCEL: "true",
         VERCEL_GIT_COMMIT_SHA: "testingsha",
-        VERCEL_GIT_REPO_SLUG: "other-org/testRepo",
+        VERCEL_GIT_REPO_SLUG: "testRepo",
+        VERCEL_GIT_REPO_OWNER: "testOrg",
       },
     };
 


### PR DESCRIPTION
# Description

Vercel does not provide a whole slug that includes both the owner and repo so we need to create our own version of it.
