### PR TITLE
ref(core): improve logging for upload stats

### DIFF
--- a/.changeset/many-peas-repeat.md
+++ b/.changeset/many-peas-repeat.md
@@ -1,0 +1,8 @@
+---
+"@codecov/bundler-plugin-core": patch
+"@codecov/rollup-plugin": patch
+"@codecov/vite-plugin": patch
+"@codecov/webpack-plugin": patch
+---
+
+Add more detailed logging for upload stats

--- a/packages/bundler-plugin-core/src/bundle-analysis/bundleAnalysisPluginFactory.ts
+++ b/packages/bundler-plugin-core/src/bundle-analysis/bundleAnalysisPluginFactory.ts
@@ -70,6 +70,7 @@ export const bundleAnalysisPluginFactory = ({
       try {
         await uploadStats({
           preSignedUrl: url,
+          bundleName: output.bundleName,
           message: JSON.stringify(output),
           retryCount: userOptions?.retryCount,
         });

--- a/packages/bundler-plugin-core/src/utils/__tests__/uploadStats.test.ts
+++ b/packages/bundler-plugin-core/src/utils/__tests__/uploadStats.test.ts
@@ -60,6 +60,7 @@ describe("uploadStats", () => {
       setup({ sendError: false });
 
       const data = await uploadStats({
+        bundleName: "cool-bundle-cjs",
         message: "cool-message",
         preSignedUrl: "http://localhost/upload/stats/",
         retryCount: 0,
@@ -77,6 +78,7 @@ describe("uploadStats", () => {
         let error;
         try {
           await uploadStats({
+            bundleName: "cool-bundle-cjs",
             message: "cool-message",
             preSignedUrl: "",
             retryCount: 1,
@@ -96,6 +98,7 @@ describe("uploadStats", () => {
         let error;
         try {
           await uploadStats({
+            bundleName: "cool-bundle-cjs",
             message: "cool-message",
             preSignedUrl: "http://localhost/upload/stats/",
             retryCount: 0,
@@ -115,6 +118,7 @@ describe("uploadStats", () => {
         let error;
         try {
           await uploadStats({
+            bundleName: "cool-bundle-cjs",
             message: "cool-message",
             preSignedUrl: "http://localhost/upload/stats/",
             retryCount: 0,

--- a/packages/bundler-plugin-core/src/utils/uploadStats.ts
+++ b/packages/bundler-plugin-core/src/utils/uploadStats.ts
@@ -9,12 +9,14 @@ import { FailedFetchError } from "../errors/FailedFetchError";
 
 interface UploadStatsArgs {
   message: string;
+  bundleName: string;
   preSignedUrl: string;
   retryCount?: number;
 }
 
 export async function uploadStats({
   message,
+  bundleName,
   preSignedUrl,
   retryCount = DEFAULT_RETRY_COUNT,
 }: UploadStatsArgs) {
@@ -59,10 +61,12 @@ export async function uploadStats({
   }
 
   if (!response.ok) {
-    red("Failed to upload stats, bad response");
+    red(
+      `Failed to upload stats, bad response. Response ${response.status} - ${response.statusText}`,
+    );
     throw new FailedUploadError("Failed to upload stats");
   }
 
-  green("Successfully uploaded stats");
+  green(`Successfully uploaded stats for bundle: ${bundleName}`);
   return true;
 }


### PR DESCRIPTION
- log out status for failed responses
- add bundle name to success message

Main change is logging out `bundleName`, should hopefully make iteration speed quicker. 
