### PR TITLE
fix: Support grabbing branch in Vercel

### DIFF
--- a/.changeset/early-phones-prove.md
+++ b/.changeset/early-phones-prove.md
@@ -1,0 +1,8 @@
+---
+"@codecov/bundler-plugin-core": patch
+"@codecov/rollup-plugin": patch
+"@codecov/vite-plugin": patch
+"@codecov/webpack-plugin": patch
+---
+
+Grab branch name inside Vercel helper so that we for sure have a branch value

--- a/packages/bundler-plugin-core/src/utils/providers/Vercel.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/Vercel.ts
@@ -21,9 +21,9 @@ function _getBuildURL(): string {
 }
 
 function _getBranch(inputs: ProviderUtilInputs): string {
-  const { args } = inputs;
+  const { args, envs } = inputs;
 
-  return args?.branch ?? "";
+  return args?.branch ?? envs.VERCEL_GIT_COMMIT_REF ?? "";
 }
 
 function _getJob(): string {

--- a/packages/bundler-plugin-core/src/utils/providers/Vercel.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/Vercel.ts
@@ -23,7 +23,7 @@ function _getBuildURL(): string {
 function _getBranch(inputs: ProviderUtilInputs): string {
   const { args, envs } = inputs;
 
-  return args?.branch ?? envs.VERCEL_GIT_COMMIT_REF ?? "";
+  return args?.branch ?? envs?.VERCEL_GIT_COMMIT_REF ?? "";
 }
 
 function _getJob(): string {

--- a/packages/bundler-plugin-core/src/utils/providers/__tests__/Vercel.test.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/__tests__/Vercel.test.ts
@@ -44,11 +44,12 @@ describe("Vercel Params", () => {
         VERCEL_GIT_COMMIT_SHA: "testingsha",
         VERCEL_GIT_REPO_SLUG: "testRepo",
         VERCEL_GIT_REPO_OWNER: "testOrg",
+        VERCEL_GIT_COMMIT_REF: "super-cool-branch",
       },
     };
 
     const expected: ProviderServiceParams = {
-      branch: "",
+      branch: "super-cool-branch",
       build: "",
       buildURL: "",
       commit: "testingsha",
@@ -76,6 +77,7 @@ describe("Vercel Params", () => {
         VERCEL_GIT_COMMIT_SHA: "testingsha",
         VERCEL_GIT_REPO_SLUG: "testRepo",
         VERCEL_GIT_REPO_OWNER: "testOrg",
+        VERCEL_GIT_COMMIT_REF: "super-cool-branch",
       },
     };
 


### PR DESCRIPTION
# Description

Totally missed that Vercel does in fact have an env var that contains the branch name it's just labelled as `VERCEL_GIT_COMMIT_REF`

# Notable Changes

- Grab branch name from in Vercel helper from env
- Update tests