### PR TITLE
fix: Keep JSDoc comments in dts files

### DIFF
--- a/.changeset/cool-sheep-care.md
+++ b/.changeset/cool-sheep-care.md
@@ -1,0 +1,8 @@
+---
+"@codecov/bundler-plugin-core": patch
+"@codecov/webpack-plugin": patch
+"@codecov/rollup-plugin": patch
+"@codecov/vite-plugin": patch
+---
+
+Preserve JSDoc comments during build process for the bundler plugins

--- a/packages/bundler-plugin-core/build.config.ts
+++ b/packages/bundler-plugin-core/build.config.ts
@@ -6,6 +6,11 @@ export default defineBuildConfig({
   declaration: "compatible",
   sourcemap: true,
   rollup: {
+    dts: {
+      compilerOptions: {
+        removeComments: false,
+      },
+    },
     emitCJS: true,
     esbuild: {
       minify: true,

--- a/packages/rollup-plugin/build.config.ts
+++ b/packages/rollup-plugin/build.config.ts
@@ -7,6 +7,11 @@ export default defineBuildConfig({
   sourcemap: true,
   externals: ["rollup"],
   rollup: {
+    dts: {
+      compilerOptions: {
+        removeComments: false,
+      },
+    },
     emitCJS: true,
     esbuild: {
       minify: true,

--- a/packages/vite-plugin/build.config.ts
+++ b/packages/vite-plugin/build.config.ts
@@ -7,6 +7,11 @@ export default defineBuildConfig({
   sourcemap: true,
   externals: ["vite"],
   rollup: {
+    dts: {
+      compilerOptions: {
+        removeComments: false,
+      },
+    },
     emitCJS: true,
     esbuild: {
       minify: true,

--- a/packages/webpack-plugin/build.config.ts
+++ b/packages/webpack-plugin/build.config.ts
@@ -6,6 +6,11 @@ export default defineBuildConfig({
   declaration: "compatible",
   sourcemap: true,
   rollup: {
+    dts: {
+      compilerOptions: {
+        removeComments: false,
+      },
+    },
     emitCJS: true,
     esbuild: {
       minify: true,


### PR DESCRIPTION
# Description

Small tweak to the build config to preserve the JSDoc comments as they were getting stripped out before.
