### PR TITLE
feat: Auto gen type docs via TypeDoc

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,8 @@ const config = {
     "**/test-apps/**",
     "**/integration-tests/**/*.cjs",
     "**/integration-tests/test-api/**/*",
+    "**/scripts/publish-docs.js",
+    "**/typedoc/plugin-remove-references.js",
   ],
   parserOptions: {
     ecmaVersion: "latest",

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,3 +41,6 @@ jobs:
         with:
           publish: pnpm changeset:publish
           createGithubReleases: true
+
+      - name: Publish new docs
+        run: node scripts/publish-docs.js

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "prepare": "husky install",
     "changeset:add": "pnpm changeset",
     "changeset:consume": "pnpm changeset version",
-    "changeset:publish": "pnpm run build && pnpm changeset publish"
+    "changeset:publish": "pnpm run build && pnpm changeset publish",
+    "generate:typedoc": "typedoc --options ./typedoc.json",
+    "generate:typedoc:packages": "pnpm -r --filter='./packages/*' run generate:typedoc"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1",
@@ -39,6 +41,7 @@
     "husky": "^8.0.3",
     "lint-staged": "^15.2.1",
     "prettier": "^3.2.4",
+    "typedoc": "^0.25.12",
     "typescript": "^5.3.3"
   },
   "lint-staged": {

--- a/packages/bundler-plugin-core/package.json
+++ b/packages/bundler-plugin-core/package.json
@@ -48,7 +48,7 @@
     "@types/jest": "^29.5.11",
     "@types/node": "^20.11.15",
     "@types/semver": "^7.5.6",
-    "codecovProdRollupPlugin": "npm:@codecov/rollup-plugin@0.0.1-beta.2",
+    "codecovProdRollupPlugin": "npm:@codecov/rollup-plugin@0.0.1-beta.3",
     "jest": "^29.7.0",
     "jest-junit": "^16.0.0",
     "msw": "^2.1.5",

--- a/packages/bundler-plugin-core/package.json
+++ b/packages/bundler-plugin-core/package.json
@@ -33,7 +33,8 @@
     "format": "prettier '**/*.{cjs,mjs,ts,tsx,md,json}' --ignore-path ../.gitignore --ignore-unknown --no-error-on-unmatched-pattern --write",
     "format:check": "prettier '**/*.{cjs,mjs,ts,tsx,md,json}' --ignore-path ../.gitignore --ignore-unknown --no-error-on-unmatched-pattern --check",
     "test:unit": "jest",
-    "test:unit:ci": "JEST_JUNIT_OUTPUT_NAME='bundler-plugin-core.junit.xml' jest --coverage --reporters=jest-junit"
+    "test:unit:ci": "JEST_JUNIT_OUTPUT_NAME='bundler-plugin-core.junit.xml' jest --coverage --reporters=jest-junit",
+    "generate:typedoc": "typedoc --options ./typedoc.json"
   },
   "dependencies": {
     "chalk": "4.1.2",
@@ -54,6 +55,7 @@
     "testdouble": "^3.20.1",
     "testdouble-jest": "^2.0.0",
     "ts-node": "^10.9.2",
+    "typedoc": "^0.25.12",
     "typescript": "^5.3.3",
     "unbuild": "^2.0.0"
   },

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -51,6 +51,7 @@ export interface BundleAnalysisUploadPluginArgs {
   options: NormalizedOptions;
 }
 
+/** Configuration ptions for the Codcov bundler plugin. */
 export interface Options {
   /**
    * The upload token to use for uploading the bundle analysis information.
@@ -105,6 +106,7 @@ export interface Options {
   /** Override values for passing custom information to API. */
   uploadOverrides?: UploadOverrides;
 
+  /** A set of options to configure Sentry settings inside the plugin. */
   sentry?: {
     /**
      * Only send bundle stats to sentry (used within sentry bundler plugin).
@@ -141,6 +143,7 @@ export type BundleAnalysisUploadPlugin = (
   version: string;
 };
 
+/** A set of overrides that are passed to Codecov. */
 export interface UploadOverrides {
   /** Specify the branch manually. */
   branch?: string;

--- a/packages/bundler-plugin-core/typedoc.json
+++ b/packages/bundler-plugin-core/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -50,7 +50,7 @@
     "@swc/jest": "^0.2.33",
     "@types/jest": "^29.5.11",
     "@types/node": "^20.11.15",
-    "codecovProdRollupPlugin": "npm:@codecov/rollup-plugin@0.0.1-beta.2",
+    "codecovProdRollupPlugin": "npm:@codecov/rollup-plugin@0.0.1-beta.3",
     "jest": "^29.7.0",
     "jest-junit": "^16.0.0",
     "msw": "^2.1.5",

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -39,7 +39,8 @@
     "format": "prettier '**/*.{cjs,mjs,ts,tsx,md,json}' --ignore-path ../.gitignore --ignore-unknown --no-error-on-unmatched-pattern --write",
     "format:check": "prettier '**/*.{cjs,mjs,ts,tsx,md,json}' --ignore-path ../.gitignore --ignore-unknown --no-error-on-unmatched-pattern --check",
     "test:unit": "jest",
-    "test:unit:ci": "JEST_JUNIT_OUTPUT_NAME='rollup-plugin.junit.xml' jest --coverage --reporters=jest-junit"
+    "test:unit:ci": "JEST_JUNIT_OUTPUT_NAME='rollup-plugin.junit.xml' jest --coverage --reporters=jest-junit",
+    "generate:typedoc": "typedoc --options ./typedoc.json"
   },
   "dependencies": {
     "@codecov/bundler-plugin-core": "workspace:^"
@@ -55,6 +56,7 @@
     "msw": "^2.1.5",
     "rollup": "4.9.6",
     "ts-node": "^10.9.2",
+    "typedoc": "^0.25.12",
     "typescript": "^5.3.3",
     "unbuild": "^2.0.0"
   },

--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   codecovUnpluginFactory,
   type Options,
@@ -9,6 +10,30 @@ const codecovUnplugin = codecovUnpluginFactory({
   bundleAnalysisUploadPlugin: rollupBundleAnalysisPlugin,
 });
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line isaacscript/complete-sentences-jsdoc
+/**
+ * Details for the Codecov Rollup plugin.
+ *
+ * @param {Options} options - See {@link @codecov/bundler-plugin-core!Options | Options} for more
+ *        details.
+ *
+ * @example
+ * ```typescript
+ * // rollup.config.js
+ * import { defineConfig } from "rollup";
+ * import { codecovRollupPlugin } from "@codecov/rollup-plugin";
+ *
+ * export default defineConfig({
+ *   plugins: [
+ *     // Put the Codecov rollup plugin after all other plugins
+ *     codecovRollupPlugin({
+ *       enableBundleAnalysis: true,
+ *       bundleName: "example-rollup-bundle",
+ *       uploadToken: process.env.CODECOV_TOKEN,
+ *     }),
+ *   ],
+ * });
+ * ```
+ */
 export const codecovRollupPlugin: (options: Options) => any =
   codecovUnplugin.rollup;

--- a/packages/rollup-plugin/typedoc.json
+++ b/packages/rollup-plugin/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -50,7 +50,7 @@
     "@swc/jest": "^0.2.33",
     "@types/jest": "^29.5.11",
     "@types/node": "^20.11.15",
-    "codecovProdRollupPlugin": "npm:@codecov/rollup-plugin@0.0.1-beta.2",
+    "codecovProdRollupPlugin": "npm:@codecov/rollup-plugin@0.0.1-beta.3",
     "jest": "^29.7.0",
     "jest-junit": "^16.0.0",
     "msw": "^2.1.5",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -39,7 +39,8 @@
     "format": "prettier '**/*.{cjs,mjs,ts,tsx,md,json}' --ignore-path ../.gitignore --ignore-unknown --no-error-on-unmatched-pattern --write",
     "format:check": "prettier '**/*.{cjs,mjs,ts,tsx,md,json}' --ignore-path ../.gitignore --ignore-unknown --no-error-on-unmatched-pattern --check",
     "test:unit": "jest",
-    "test:unit:ci": "JEST_JUNIT_OUTPUT_NAME='vite-plugin.junit.xml' jest --coverage --reporters=jest-junit"
+    "test:unit:ci": "JEST_JUNIT_OUTPUT_NAME='vite-plugin.junit.xml' jest --coverage --reporters=jest-junit",
+    "generate:typedoc": "typedoc --options ./typedoc.json"
   },
   "dependencies": {
     "@codecov/bundler-plugin-core": "workspace:^"
@@ -54,6 +55,7 @@
     "jest-junit": "^16.0.0",
     "msw": "^2.1.5",
     "ts-node": "^10.9.2",
+    "typedoc": "^0.25.12",
     "typescript": "^5.3.3",
     "unbuild": "^2.0.0",
     "vite": "5.0.12"

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   codecovUnpluginFactory,
   type Options,
@@ -14,6 +15,28 @@ const codecovUnplugin = codecovUnpluginFactory({
   bundleAnalysisUploadPlugin: viteBundleAnalysisPlugin,
 });
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+/**
+ * Details for the Codecov Vite plugin.
+ *
+ * @example
+ * ```typescript
+ * // vite.config.js
+ * import { defineConfig } from "vite";
+ * import { codecovVitePlugin } from "@codecov/vite-plugin";
+ *
+ * export default defineConfig({
+ *   plugins: [
+ *     // Put the Codecov vite plugin after all other plugins
+ *     codecovVitePlugin({
+ *       enableBundleAnalysis: true,
+ *       bundleName: "example-vite-bundle",
+ *       uploadToken: process.env.CODECOV_TOKEN,
+ *     }),
+ *   ],
+ * });
+ * ```
+ *
+ * @see {@link @codecov/bundler-plugin-core!Options | Options} for list of options.
+ */
 export const codecovVitePlugin: (options: Options) => any =
   codecovUnplugin.vite;

--- a/packages/vite-plugin/typedoc.json
+++ b/packages/vite-plugin/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -39,7 +39,8 @@
     "format": "prettier '**/*.{cjs,mjs,ts,tsx,md,json}' --ignore-path ../.gitignore --ignore-unknown --no-error-on-unmatched-pattern --write",
     "format:check": "prettier '**/*.{cjs,mjs,ts,tsx,md,json}' --ignore-path ../.gitignore --ignore-unknown --no-error-on-unmatched-pattern --check",
     "test:unit": "jest",
-    "test:unit:ci": "JEST_JUNIT_OUTPUT_NAME='webpack-plugin.junit.xml' jest --coverage --reporters=jest-junit"
+    "test:unit:ci": "JEST_JUNIT_OUTPUT_NAME='webpack-plugin.junit.xml' jest --coverage --reporters=jest-junit",
+    "generate:typedoc": "typedoc --options ./typedoc.json"
   },
   "dependencies": {
     "@codecov/bundler-plugin-core": "workspace:^"
@@ -55,6 +56,7 @@
     "jest-junit": "^16.0.0",
     "msw": "^2.1.5",
     "ts-node": "^10.9.2",
+    "typedoc": "^0.25.12",
     "typescript": "^5.3.3",
     "unbuild": "^2.0.0",
     "webpack": "^5.90.0"

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -51,7 +51,7 @@
     "@types/jest": "^29.5.11",
     "@types/node": "^20.10.0",
     "@types/webpack": "^5.28.5",
-    "codecovProdRollupPlugin": "npm:@codecov/rollup-plugin@0.0.1-beta.2",
+    "codecovProdRollupPlugin": "npm:@codecov/rollup-plugin@0.0.1-beta.3",
     "jest": "^29.7.0",
     "jest-junit": "^16.0.0",
     "msw": "^2.1.5",

--- a/packages/webpack-plugin/src/index.ts
+++ b/packages/webpack-plugin/src/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   codecovUnpluginFactory,
   type Options,
@@ -9,6 +10,34 @@ const codecovUnplugin = codecovUnpluginFactory({
   bundleAnalysisUploadPlugin: webpackBundleAnalysisPlugin,
 });
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+/**
+ * Details for the Codecov Webpack plugin.
+ *
+ * @example
+ * ```typescript
+ * // webpack.config.js
+ * const path = require("path");
+ * const { codecovWebpackPlugin } = require("@codecov/webpack-plugin");
+ *
+ * module.exports = {
+ *   entry: "./src/index.js",
+ *   mode: "production",
+ *   output: {
+ *     filename: "main.js",
+ *     path: path.resolve(__dirname, "dist"),
+ *   },
+ *   plugins: [
+ *     // Put the Codecov vite plugin after all other plugins
+ *     codecovWebpackPlugin({
+ *       enableBundleAnalysis: true,
+ *       bundleName: "example-webpack-bundle",
+ *       uploadToken: process.env.CODECOV_TOKEN,
+ *     }),
+ *    ],
+ * };
+ * ```
+ *
+ * @see {@link @codecov/bundler-plugin-core!Options | Options} for list of options.
+ */
 export const codecovWebpackPlugin: (options: Options) => any =
   codecovUnplugin.webpack;

--- a/packages/webpack-plugin/typedoc.json
+++ b/packages/webpack-plugin/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       prettier:
         specifier: ^3.2.4
         version: 3.2.4
+      typedoc:
+        specifier: ^0.25.12
+        version: 0.25.12(typescript@5.3.3)
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
@@ -268,7 +271,7 @@ importers:
         version: 7.5.6
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.2
-        version: link:../rollup-plugin
+        version: /@codecov/rollup-plugin@0.0.1-beta.2(rollup@4.9.6)
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.11.15)(ts-node@10.9.2)
@@ -287,6 +290,9 @@ importers:
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.3.107)(@types/node@20.11.15)(typescript@5.3.3)
+      typedoc:
+        specifier: ^0.25.12
+        version: 0.25.12(typescript@5.3.3)
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
@@ -314,7 +320,7 @@ importers:
         version: 20.11.15
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.2
-        version: 'link:'
+        version: /@codecov/rollup-plugin@0.0.1-beta.2(rollup@4.9.6)
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.11.15)(ts-node@10.9.2)
@@ -330,6 +336,9 @@ importers:
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.3.107)(@types/node@20.11.15)(typescript@5.3.3)
+      typedoc:
+        specifier: ^0.25.12
+        version: 0.25.12(typescript@5.3.3)
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
@@ -357,7 +366,7 @@ importers:
         version: 20.11.15
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.2
-        version: link:../rollup-plugin
+        version: /@codecov/rollup-plugin@0.0.1-beta.2(rollup@4.9.6)
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.11.15)(ts-node@10.9.2)
@@ -370,6 +379,9 @@ importers:
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.3.107)(@types/node@20.11.15)(typescript@5.3.3)
+      typedoc:
+        specifier: ^0.25.12
+        version: 0.25.12(typescript@5.3.3)
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
@@ -403,7 +415,7 @@ importers:
         version: 5.28.5(@swc/core@1.3.107)
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.2
-        version: link:../rollup-plugin
+        version: /@codecov/rollup-plugin@0.0.1-beta.2(rollup@4.9.6)
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.10.0)(ts-node@10.9.2)
@@ -416,6 +428,9 @@ importers:
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.3.107)(@types/node@20.10.0)(typescript@5.3.3)
+      typedoc:
+        specifier: ^0.25.12
+        version: 0.25.12(typescript@5.3.3)
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
@@ -1146,6 +1161,26 @@ packages:
       fs-extra: 7.0.1
       human-id: 1.0.2
       prettier: 2.8.8
+    dev: true
+
+  /@codecov/bundler-plugin-core@0.0.1-beta.4:
+    resolution: {integrity: sha512-rxPmTCoO/G/KcbQCQECenVfTpWSkuNTEJL4v37zetQ4Wr1ydh2dt+53uK9Hp1s8C+ogEjpMPG8X8bHK4tp+y/g==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      chalk: 4.1.2
+      semver: 7.5.4
+      unplugin: 1.6.0
+      zod: 3.22.4
+    dev: true
+
+  /@codecov/rollup-plugin@0.0.1-beta.2(rollup@4.9.6):
+    resolution: {integrity: sha512-gUeKPK7vCICO+PxnhQojtx72n4o9vBjYQYGaHfdM0Z6qEYGhs/C6P3KMMrUq4pT4+dn6M88J2NrtZwzN0beOVw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      rollup: 3.x || 4.x
+    dependencies:
+      '@codecov/bundler-plugin-core': 0.0.1-beta.4
+      rollup: 4.9.6
     dev: true
 
   /@cspotcode/source-map-support@0.8.1:
@@ -3169,6 +3204,10 @@ packages:
   /ansi-regex@6.0.1:
     resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
     engines: {node: '>=12'}
+    dev: true
+
+  /ansi-sequence-parser@1.1.1:
+    resolution: {integrity: sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==}
     dev: true
 
   /ansi-styles@3.2.1:
@@ -5971,7 +6010,7 @@ packages:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.2(@swc/core@1.3.107)(@types/node@20.11.15)(typescript@5.3.3)
+      ts-node: 10.9.2(@swc/core@1.3.107)(@types/node@20.10.0)(typescript@5.3.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -6604,6 +6643,10 @@ packages:
     dependencies:
       yallist: 4.0.0
 
+  /lunr@2.3.9:
+    resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
+    dev: true
+
   /magic-string@0.30.5:
     resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
     engines: {node: '>=12'}
@@ -6636,6 +6679,12 @@ packages:
   /map-obj@4.3.0:
     resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
     engines: {node: '>=8'}
+    dev: true
+
+  /marked@4.3.0:
+    resolution: {integrity: sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==}
+    engines: {node: '>= 12'}
+    hasBin: true
     dev: true
 
   /memorystream@0.3.1:
@@ -8000,6 +8049,15 @@ packages:
     resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
     dev: true
 
+  /shiki@0.14.7:
+    resolution: {integrity: sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==}
+    dependencies:
+      ansi-sequence-parser: 1.1.1
+      jsonc-parser: 3.2.0
+      vscode-oniguruma: 1.7.0
+      vscode-textmate: 8.0.0
+    dev: true
+
   /side-channel@1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
     dependencies:
@@ -8729,6 +8787,20 @@ packages:
       is-typed-array: 1.1.12
     dev: true
 
+  /typedoc@0.25.12(typescript@5.3.3):
+    resolution: {integrity: sha512-F+qhkK2VoTweDXd1c42GS/By2DvI2uDF4/EpG424dTexSHdtCH52C6IcAvMA6jR3DzAWZjHpUOW+E02kyPNUNw==}
+    engines: {node: '>= 16'}
+    hasBin: true
+    peerDependencies:
+      typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x
+    dependencies:
+      lunr: 2.3.9
+      marked: 4.3.0
+      minimatch: 9.0.3
+      shiki: 0.14.7
+      typescript: 5.3.3
+    dev: true
+
   /typescript@5.3.3:
     resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
     engines: {node: '>=14.17'}
@@ -8808,7 +8880,6 @@ packages:
       chokidar: 3.5.3
       webpack-sources: 3.2.3
       webpack-virtual-modules: 0.6.1
-    dev: false
 
   /untyped@1.4.0:
     resolution: {integrity: sha512-Egkr/s4zcMTEuulcIb7dgURS6QpN7DyqQYdf+jBtiaJvQ+eRsrtWUoX84SbvQWuLkXsOjM+8sJC9u6KoMK/U7Q==}
@@ -8966,6 +9037,14 @@ packages:
       fsevents: 2.3.3
     dev: true
 
+  /vscode-oniguruma@1.7.0:
+    resolution: {integrity: sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==}
+    dev: true
+
+  /vscode-textmate@8.0.0:
+    resolution: {integrity: sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==}
+    dev: true
+
   /walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
     dependencies:
@@ -9034,7 +9113,6 @@ packages:
 
   /webpack-virtual-modules@0.6.1:
     resolution: {integrity: sha512-poXpCylU7ExuvZK8z+On3kX+S8o/2dQ/SVYueKA0D4WEMXROXgY8Ez50/bQEUmvoSMMrWcrJqCHuhAbsiwg7Dg==}
-    dev: false
 
   /webpack@5.90.0(@swc/core@1.3.107):
     resolution: {integrity: sha512-bdmyXRCXeeNIePv6R6tGPyy20aUobw4Zy8r0LUS2EWO+U+Ke/gYDgsCh7bl5rB6jPpr4r0SZa6dPxBxLooDT3w==}
@@ -9346,4 +9424,3 @@ packages:
 
   /zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
-    dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,8 +270,8 @@ importers:
         specifier: ^7.5.6
         version: 7.5.6
       codecovProdRollupPlugin:
-        specifier: npm:@codecov/rollup-plugin@0.0.1-beta.2
-        version: /@codecov/rollup-plugin@0.0.1-beta.2(rollup@4.9.6)
+        specifier: npm:@codecov/rollup-plugin@0.0.1-beta.3
+        version: /@codecov/rollup-plugin@0.0.1-beta.3(rollup@4.9.6)
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.11.15)(ts-node@10.9.2)
@@ -319,8 +319,8 @@ importers:
         specifier: ^20.11.15
         version: 20.11.15
       codecovProdRollupPlugin:
-        specifier: npm:@codecov/rollup-plugin@0.0.1-beta.2
-        version: /@codecov/rollup-plugin@0.0.1-beta.2(rollup@4.9.6)
+        specifier: npm:@codecov/rollup-plugin@0.0.1-beta.3
+        version: /@codecov/rollup-plugin@0.0.1-beta.3(rollup@4.9.6)
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.11.15)(ts-node@10.9.2)
@@ -365,8 +365,8 @@ importers:
         specifier: ^20.11.15
         version: 20.11.15
       codecovProdRollupPlugin:
-        specifier: npm:@codecov/rollup-plugin@0.0.1-beta.2
-        version: /@codecov/rollup-plugin@0.0.1-beta.2(rollup@4.9.6)
+        specifier: npm:@codecov/rollup-plugin@0.0.1-beta.3
+        version: /@codecov/rollup-plugin@0.0.1-beta.3(rollup@4.9.6)
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.11.15)(ts-node@10.9.2)
@@ -414,8 +414,8 @@ importers:
         specifier: ^5.28.5
         version: 5.28.5(@swc/core@1.3.107)
       codecovProdRollupPlugin:
-        specifier: npm:@codecov/rollup-plugin@0.0.1-beta.2
-        version: /@codecov/rollup-plugin@0.0.1-beta.2(rollup@4.9.6)
+        specifier: npm:@codecov/rollup-plugin@0.0.1-beta.3
+        version: /@codecov/rollup-plugin@0.0.1-beta.3(rollup@4.9.6)
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.10.0)(ts-node@10.9.2)
@@ -1173,8 +1173,8 @@ packages:
       zod: 3.22.4
     dev: true
 
-  /@codecov/rollup-plugin@0.0.1-beta.2(rollup@4.9.6):
-    resolution: {integrity: sha512-gUeKPK7vCICO+PxnhQojtx72n4o9vBjYQYGaHfdM0Z6qEYGhs/C6P3KMMrUq4pT4+dn6M88J2NrtZwzN0beOVw==}
+  /@codecov/rollup-plugin@0.0.1-beta.3(rollup@4.9.6):
+    resolution: {integrity: sha512-cmtMPrSzWxsKUAYX90N0czaYHXl9IJR+Fy4UndHBi+4R7gyhrCAXW6ALM2/0JsSwmHYmf8svVeobUNHUl16tQw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       rollup: 3.x || 4.x
@@ -6010,7 +6010,7 @@ packages:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.2(@swc/core@1.3.107)(@types/node@20.10.0)(typescript@5.3.3)
+      ts-node: 10.9.2(@swc/core@1.3.107)(@types/node@20.11.15)(typescript@5.3.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color

--- a/scripts/publish-docs.js
+++ b/scripts/publish-docs.js
@@ -1,0 +1,26 @@
+import { execSync } from "child_process";
+
+function buildDocs() {
+  execSync("rm -rf ./typedoc/docs");
+  execSync("pnpm run generate:typedoc");
+}
+
+function publishDocs() {
+  execSync(`rm -rf /tmp/js-docs | true
+	mkdir /tmp/js-docs
+	cp -r ./typedoc/docs /tmp/js-docs/docs
+	cd /tmp/js-docs && \
+	git clone --single-branch --branch gh-pages git@github.com:codecov/codecov-javascript-bundler-plugins.git && \
+	cp -r /tmp/js-docs/docs/* /tmp/js-docs/codecov-javascript-bundler-plugins/ && \
+	cd /tmp/js-docs/codecov-javascript-bundler-plugins && \
+	git add --all && \
+	git commit -m "meta: Update docs" && \
+	git push origin gh-pages`);
+}
+
+function run() {
+  buildDocs();
+  publishDocs();
+}
+
+run();

--- a/typedoc.base.json
+++ b/typedoc.base.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "includeVersion": true,
+  "excludePrivate": true,
+  "excludeExternals": true,
+  "excludeReferences": true,
+  "excludeNotDocumented": true,
+  "githubPages": true,
+  "plugin": ["./typedoc/plugin-remove-references.js"]
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "readme": "README.md",
+  "name": "Codecov JavaScript Bundler PLugins",
+  "entryPoints": ["packages/*"],
+  "entryPointStrategy": "packages",
+  "out": "./typedoc/docs",
+  "includeVersion": true,
+  "excludePrivate": true,
+  "excludeExternals": true,
+  "excludeReferences": true,
+  "excludeNotDocumented": true,
+  "useTsLinkResolution": true,
+  "githubPages": true,
+  "plugin": ["./typedoc/plugin-remove-references.js"]
+}

--- a/typedoc/plugin-remove-references.js
+++ b/typedoc/plugin-remove-references.js
@@ -1,0 +1,37 @@
+// Vendored from https://github.com/eyworldwide/typedoc-plugin-remove-references/blob/f9e5e264a1eb75567e763d7a0bb270046f5e9329/
+
+// MIT License
+
+// Copyright (c) 2020 Bob
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+const { ReflectionKind, Converter } = require("typedoc");
+
+function load({ application }) {
+  application.converter.on(Converter.EVENT_RESOLVE_BEGIN, (context) => {
+    for (const reflection of context.project.getReflectionsByKind(
+      ReflectionKind.Reference,
+    )) {
+      context.project.removeReflection(reflection);
+    }
+  });
+}
+
+module.exports = { load };


### PR DESCRIPTION
# Description

This PR adds in the supporting foundation for using TypeDoc to auto generate docs for the bundler plugins, and eventually host them on gh-pages for this repo.

Closes #50 

# Notable Changes

- Add in `typedoc` dep
- Configure `typedoc`
- Add in supporting scripts and plugins
- Update comments to have types show up in TypeDoc