### PR TITLE
fix: normalizePath does not handle all base64 characters

### DIFF
--- a/.changeset/warm-feet-cry.md
+++ b/.changeset/warm-feet-cry.md
@@ -1,0 +1,8 @@
+---
+"@codecov/bundler-plugin-core": patch
+"@codecov/webpack-plugin": patch
+"@codecov/rollup-plugin": patch
+"@codecov/vite-plugin": patch
+---
+
+Fix normalizePath not handling all base64 characters and dashes

--- a/integration-tests/fixtures/generate-bundle-stats/rollup/__snapshots__/rollup-plugin.test.ts.snap
+++ b/integration-tests/fixtures/generate-bundle-stats/rollup/__snapshots__/rollup-plugin.test.ts.snap
@@ -765,7 +765,7 @@ exports[`Generating rollup stats 4 {"format":"cjs","expected":"cjs"} matches the
   "assets": [
     {
       "name": "main-MVbZZknk.js",
-      "normalized": "main-MVbZZknk.js",
+      "normalized": "main-*.js",
       "size": 560886,
     },
   ],
@@ -841,7 +841,7 @@ exports[`Generating rollup stats 4 {"format":"es","expected":"esm"} matches the 
   "assets": [
     {
       "name": "main-v-vWaFyT.js",
-      "normalized": "main-v-vWaFyT.js",
+      "normalized": "main-*.js",
       "size": 560871,
     },
   ],
@@ -917,7 +917,7 @@ exports[`Generating rollup stats 4 {"format":"esm","expected":"esm"} matches the
   "assets": [
     {
       "name": "main-v-vWaFyT.js",
-      "normalized": "main-v-vWaFyT.js",
+      "normalized": "main-*.js",
       "size": 560871,
     },
   ],
@@ -993,7 +993,7 @@ exports[`Generating rollup stats 4 {"format":"module","expected":"esm"} matches 
   "assets": [
     {
       "name": "main-v-vWaFyT.js",
-      "normalized": "main-v-vWaFyT.js",
+      "normalized": "main-*.js",
       "size": 560871,
     },
   ],
@@ -1069,7 +1069,7 @@ exports[`Generating rollup stats 4 {"format":"iife","expected":"iife"} matches t
   "assets": [
     {
       "name": "main-ChwnvxRF.js",
-      "normalized": "main-ChwnvxRF.js",
+      "normalized": "main-*.js",
       "size": 577066,
     },
   ],
@@ -1145,7 +1145,7 @@ exports[`Generating rollup stats 4 {"format":"umd","expected":"umd"} matches the
   "assets": [
     {
       "name": "main-ymXr0nql.js",
-      "normalized": "main-ymXr0nql.js",
+      "normalized": "main-*.js",
       "size": 577165,
     },
   ],
@@ -1221,7 +1221,7 @@ exports[`Generating rollup stats 4 {"format":"system","expected":"system"} match
   "assets": [
     {
       "name": "main-VyFuBFOR.js",
-      "normalized": "main-VyFuBFOR.js",
+      "normalized": "main-*.js",
       "size": 609444,
     },
   ],
@@ -1297,7 +1297,7 @@ exports[`Generating rollup stats 4 {"format":"systemjs","expected":"system"} mat
   "assets": [
     {
       "name": "main-VyFuBFOR.js",
-      "normalized": "main-VyFuBFOR.js",
+      "normalized": "main-*.js",
       "size": 609444,
     },
   ],

--- a/integration-tests/fixtures/generate-bundle-stats/vite/__snapshots__/vite-plugin.test.ts.snap
+++ b/integration-tests/fixtures/generate-bundle-stats/vite/__snapshots__/vite-plugin.test.ts.snap
@@ -815,7 +815,7 @@ exports[`Generating vite stats v5 {"format":"amd","expected":"amd"} matches the 
   "assets": [
     {
       "name": "assets/index-neb5ATfh.js",
-      "normalized": "assets/index-neb5ATfh.js",
+      "normalized": "assets/index-*.js",
       "size": 72360,
     },
   ],
@@ -905,7 +905,7 @@ exports[`Generating vite stats v5 {"format":"cjs","expected":"cjs"} matches the 
   "assets": [
     {
       "name": "assets/index-9JQbcWYj.js",
-      "normalized": "assets/index-9JQbcWYj.js",
+      "normalized": "assets/index-*.js",
       "size": 72342,
     },
   ],
@@ -995,7 +995,7 @@ exports[`Generating vite stats v5 {"format":"es","expected":"esm"} matches the s
   "assets": [
     {
       "name": "assets/index-snsAD2Cg.js",
-      "normalized": "assets/index-snsAD2Cg.js",
+      "normalized": "assets/index-*.js",
       "size": 73071,
     },
   ],
@@ -1085,7 +1085,7 @@ exports[`Generating vite stats v5 {"format":"esm","expected":"esm"} matches the 
   "assets": [
     {
       "name": "assets/index-snsAD2Cg.js",
-      "normalized": "assets/index-snsAD2Cg.js",
+      "normalized": "assets/index-*.js",
       "size": 73071,
     },
   ],
@@ -1175,7 +1175,7 @@ exports[`Generating vite stats v5 {"format":"module","expected":"esm"} matches t
   "assets": [
     {
       "name": "assets/index-snsAD2Cg.js",
-      "normalized": "assets/index-snsAD2Cg.js",
+      "normalized": "assets/index-*.js",
       "size": 73071,
     },
   ],
@@ -1265,7 +1265,7 @@ exports[`Generating vite stats v5 {"format":"iife","expected":"iife"} matches th
   "assets": [
     {
       "name": "assets/index-HczW45b9.js",
-      "normalized": "assets/index-HczW45b9.js",
+      "normalized": "assets/index-*.js",
       "size": 72356,
     },
   ],
@@ -1355,7 +1355,7 @@ exports[`Generating vite stats v5 {"format":"umd","expected":"umd"} matches the 
   "assets": [
     {
       "name": "assets/index-5tDKlLKo.js",
-      "normalized": "assets/index-5tDKlLKo.js",
+      "normalized": "assets/index-*.js",
       "size": 72423,
     },
   ],

--- a/packages/bundler-plugin-core/src/utils/__tests__/normalizePath.test.ts
+++ b/packages/bundler-plugin-core/src/utils/__tests__/normalizePath.test.ts
@@ -19,6 +19,14 @@ const tests: Test[] = [
     expected: "test.*.chunk.js",
   },
   {
+    name: "can handle all base64 characters and '-'",
+    input: {
+      path: "test.ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=-.js",
+      format: "[name].[hash].js",
+    },
+    expected: "test.*.js",
+  },
+  {
     name: "should replace '[contenthash]' with '*'",
     input: {
       path: "test.123.chunk.js",

--- a/packages/bundler-plugin-core/src/utils/normalizePath.ts
+++ b/packages/bundler-plugin-core/src/utils/normalizePath.ts
@@ -39,7 +39,9 @@ export const normalizePath = (path: string, format: string): string => {
     const endingRegex = `(?<endingDelimiter>${escapeRegex(endingDelimiter)})`;
 
     // create a regex that will match the hash
-    const regexString = `(${leadingRegex}(?<hash>[0-9a-f]+)${endingRegex})`;
+    // potential values gathered from: https://en.wikipedia.org/wiki/Base64
+    // added in `\-` to account for the `-` character which seems to be used by Rollup through testing
+    const regexString = `(${leadingRegex}(?<hash>[0-9a-zA-Z\/\+\=\-]+)${endingRegex})`;
     const HASH_REPLACE_REGEX = new RegExp(regexString, "i");
 
     // replace the hash with a wildcard and the delimiters


### PR DESCRIPTION
# Description

This PR updates the `normalizePath` function, updating the regex expression to account for all base64 characters as well as `-` (found from testing). As these are the valid characters for the various hash functions that are used in the bundlers.

# Notable Changes

- Update `normalizePath` regex expression
- Update tests
- Update integration test snapshots
