### PR TITLE
docs: Add in disclaimer in the plugin README's

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ It supports the following features:
 
 ## More information
 
+- [Plugin Config Docs](https://codecov.github.io/codecov-javascript-bundler-plugins/index.html)
 - [Codecov Documentation](https://docs.codecov.com/docs)
 - [Codecov Feedback](https://github.com/codecov/feedback/discussions)
 - [Sentry Discord](https://discord.gg/Ww9hbqr)

--- a/packages/bundler-plugin-core/README.md
+++ b/packages/bundler-plugin-core/README.md
@@ -9,6 +9,8 @@
 > [!WARNING]  
 > These plugins are currently in beta and are subject to change.
 
+> The bundler-plugin-core is not to be used individually and is meant to be used in conjunction with the bundler specific plugins.
+
 Core package containing the bundler-agnostic logic for the Codecov Bundler Plugins.
 
 Checkout the individual packages for more information and examples:
@@ -25,6 +27,7 @@ The Codecov Bundler Core package contains the following functionality:
 
 ## More information
 
+- [Bundler Config Docs](https://codecov.github.io/codecov-javascript-bundler-plugins/modules/_codecov_bundler_plugin_core.html)
 - [Codecov Documentation](https://docs.codecov.com/docs)
 - [Codecov Feedback](https://github.com/codecov/feedback/discussions)
 - [Sentry Discord](https://discord.gg/Ww9hbqr)

--- a/packages/rollup-plugin/README.md
+++ b/packages/rollup-plugin/README.md
@@ -10,6 +10,8 @@
 > These plugins are currently in beta and are subject to change.
 
 > A Rollup plugin that provides bundle analysis support for Codecov.
+>
+> The plugin does not support code coverage, see our [docs](https://docs.codecov.com/docs/quick-start) to set up coverage today!
 
 ## Installation
 
@@ -52,6 +54,7 @@ export default defineConfig({
 
 ## More information
 
+- [Rollup Config Docs](https://codecov.github.io/codecov-javascript-bundler-plugins/modules/_codecov_rollup_plugin.html)
 - [Codecov Documentation](https://docs.codecov.com/docs)
 - [Codecov Feedback](https://github.com/codecov/feedback/discussions)
 - [Sentry Discord](https://discord.gg/Ww9hbqr)

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -10,6 +10,8 @@
 > These plugins are currently in beta and are subject to change.
 
 > A Vite plugin that provides bundle analysis support for Codecov.
+>
+> The plugin does not support code coverage, see our [docs](https://docs.codecov.com/docs/quick-start) to set up coverage today!
 
 ## Installation
 
@@ -52,6 +54,7 @@ export default defineConfig({
 
 ## More information
 
+- [Vite Config Docs](https://codecov.github.io/codecov-javascript-bundler-plugins/modules/_codecov_vite_plugin.html)
 - [Codecov Documentation](https://docs.codecov.com/docs)
 - [Codecov Feedback](https://github.com/codecov/feedback/discussions)
 - [Sentry Discord](https://discord.gg/Ww9hbqr)

--- a/packages/webpack-plugin/README.md
+++ b/packages/webpack-plugin/README.md
@@ -10,6 +10,8 @@
 > These plugins are currently in beta and are subject to change.
 
 > A Webpack plugin that provides bundle analysis support for Codecov.
+>
+> The plugin does not support code coverage, see our [docs](https://docs.codecov.com/docs/quick-start) to set up coverage today!
 
 ## Installation
 
@@ -58,6 +60,7 @@ module.exports = {
 
 ## More information
 
+- [Webpack Config Docs](https://codecov.github.io/codecov-javascript-bundler-plugins/modules/_codecov_webpack_plugin.html)
 - [Codecov Documentation](https://docs.codecov.com/docs)
 - [Codecov Feedback](https://github.com/codecov/feedback/discussions)
 - [Sentry Discord](https://discord.gg/Ww9hbqr)


### PR DESCRIPTION
# Description

This PR updates the README's for the plugins to add in a disclaimer that they don't support coverage uploading, as well add in links to the new TypeDocs for config references.