### PR TITLE
feat: Add in debug option, and log out short sha for commit being uploaded

### DIFF
--- a/.changeset/popular-chicken-confess.md
+++ b/.changeset/popular-chicken-confess.md
@@ -1,0 +1,8 @@
+---
+"@codecov/bundler-plugin-core": patch
+"@codecov/webpack-plugin": patch
+"@codecov/rollup-plugin": patch
+"@codecov/vite-plugin": patch
+---
+
+Add in debug option that will enable more in-depth logs

--- a/packages/bundler-plugin-core/src/bundle-analysis/__tests__/bundleAnalysisPluginFactory.test.ts
+++ b/packages/bundler-plugin-core/src/bundle-analysis/__tests__/bundleAnalysisPluginFactory.test.ts
@@ -10,6 +10,7 @@ describe("bundleAnalysisPluginFactory", () => {
         enableBundleAnalysis: true,
         retryCount: 3,
         uploadToken: "test-token",
+        debug: false,
       },
       bundleAnalysisUploadPlugin: () => ({
         version: "1",

--- a/packages/bundler-plugin-core/src/bundle-analysis/bundleAnalysisPluginFactory.ts
+++ b/packages/bundler-plugin-core/src/bundle-analysis/bundleAnalysisPluginFactory.ts
@@ -9,6 +9,7 @@ import { getPreSignedURL } from "../utils/getPreSignedURL.ts";
 import { type NormalizedOptions } from "../utils/normalizeOptions.ts";
 import { detectProvider } from "../utils/provider.ts";
 import { uploadStats } from "../utils/uploadStats.ts";
+import { debug } from "../utils/logging.ts";
 
 interface BundleAnalysisUploadPluginArgs {
   options: NormalizedOptions;
@@ -54,6 +55,10 @@ export const bundleAnalysisPluginFactory = ({
       const envs = process.env;
       const inputs: ProviderUtilInputs = { envs, args };
       const provider = await detectProvider(inputs);
+
+      if (options.debug) {
+        debug(`Uploading stats for commit: ${provider.commit.slice(0, 7)}`);
+      }
 
       let url = "";
       try {

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -105,6 +105,9 @@ export interface Options {
 
   /** Override values for passing custom information to API. */
   uploadOverrides?: UploadOverrides;
+
+  /** Option to enable debug logs for the plugin. */
+  debug?: boolean;
 }
 
 export type BundleAnalysisUploadPlugin = (

--- a/packages/bundler-plugin-core/src/utils/__tests__/normalizeOptions.test.ts
+++ b/packages/bundler-plugin-core/src/utils/__tests__/normalizeOptions.test.ts
@@ -28,6 +28,7 @@ const tests: Test[] = [
         dryRun: false,
         retryCount: 3,
         enableBundleAnalysis: false,
+        debug: false,
       },
     },
   },
@@ -48,6 +49,7 @@ const tests: Test[] = [
           slug: "test-slug",
           pr: "1234",
         },
+        debug: true,
       },
     },
     expected: {
@@ -66,6 +68,7 @@ const tests: Test[] = [
           slug: "test-slug",
           pr: "1234",
         },
+        debug: true,
       },
     },
   },

--- a/packages/bundler-plugin-core/src/utils/normalizeOptions.ts
+++ b/packages/bundler-plugin-core/src/utils/normalizeOptions.ts
@@ -80,6 +80,11 @@ const optionsSchemaFactory = (options: Options) =>
       .string({ invalid_type_error: "`uploadToken` must be a string." })
       .optional(),
     uploadOverrides: UploadOverridesSchema.optional(),
+    debug: z
+      .boolean({
+        invalid_type_error: "`debug` must be a boolean.",
+      })
+      .default(false),
   });
 
 interface NormalizedOptionsFailure {

--- a/packages/bundler-plugin-core/src/utils/providers/GitHubActions.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/GitHubActions.ts
@@ -126,7 +126,6 @@ function _getSHA(inputs: ProviderUtilInputs): string {
       const mergeCommit = mergeCommitMessage.split(" ")[1];
 
       commit = mergeCommit;
-    } else if (mergeCommitMessage === "") {
     }
   }
 

--- a/packages/rollup-plugin/src/rollup-bundle-analysis/__tests__/rollupBundleAnalysisPlugin.test.ts
+++ b/packages/rollup-plugin/src/rollup-bundle-analysis/__tests__/rollupBundleAnalysisPlugin.test.ts
@@ -13,6 +13,7 @@ describe("rollupBundleAnalysisPlugin", () => {
           dryRun: true,
           enableBundleAnalysis: true,
           retryCount: 1,
+          debug: false,
         },
       });
 

--- a/packages/vite-plugin/src/vite-bundle-analysis/__tests__/viteBundleAnalysisPlugin.test.ts
+++ b/packages/vite-plugin/src/vite-bundle-analysis/__tests__/viteBundleAnalysisPlugin.test.ts
@@ -13,6 +13,7 @@ describe("viteBundleAnalysisPlugin", () => {
           dryRun: true,
           enableBundleAnalysis: true,
           retryCount: 1,
+          debug: false,
         },
       });
 

--- a/packages/webpack-plugin/src/webpack-bundle-analysis/__tests__/webpackBundleAnalysisPlugin.test.ts
+++ b/packages/webpack-plugin/src/webpack-bundle-analysis/__tests__/webpackBundleAnalysisPlugin.test.ts
@@ -13,6 +13,7 @@ describe("webpackBundleAnalysisPlugin", () => {
           dryRun: true,
           enableBundleAnalysis: true,
           retryCount: 1,
+          debug: false,
         },
       });
 


### PR DESCRIPTION
# Description

Add in `debug` option to plugin configs, as well when `debug` is `true` log out the short sha.
