### PR TITLE
fix: update github merge commit matcher

### DIFF
--- a/packages/bundler-plugin-core/src/utils/providers/GitHubActions.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/GitHubActions.ts
@@ -115,7 +115,7 @@ function _getSHA(inputs: ProviderUtilInputs): string {
 
   let commit = envs?.GITHUB_SHA;
   if (pr) {
-    const mergeCommitRegex = /^[a-z0-9]{40} [a-z0-9]{40}$/;
+    const mergeCommitRegex = /^(Merge )?[a-z0-9]{40} (into )?[a-z0-9]{40}$/;
     const mergeCommitMessage = runExternalProgram("git", [
       "show",
       "--no-patch",

--- a/packages/bundler-plugin-core/src/utils/providers/GitHubActions.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/GitHubActions.ts
@@ -115,17 +115,21 @@ function _getSHA(inputs: ProviderUtilInputs): string {
 
   let commit = envs?.GITHUB_SHA;
   if (pr) {
-    const mergeCommitRegex = /^(Merge )?[a-z0-9]{40} (into )?[a-z0-9]{40}$/;
+    const mergeCommitRegex =
+      /^Merge (?<commit>[a-z0-9]{40}) into ?[a-z0-9]{40}$/;
     const mergeCommitMessage = runExternalProgram("git", [
       "show",
       "--no-patch",
       "--format=%P",
     ]);
 
-    if (mergeCommitRegex.exec(mergeCommitMessage)) {
-      const mergeCommit = mergeCommitMessage.split(" ")[1];
+    const mergeCommitResult = mergeCommitRegex.exec(mergeCommitMessage);
 
-      commit = mergeCommit;
+    if (mergeCommitMessage) {
+      const mergeCommit = mergeCommitResult?.groups?.commit;
+      if (mergeCommit) {
+        commit = mergeCommit;
+      }
     }
   }
 

--- a/packages/bundler-plugin-core/src/utils/providers/GitHubActions.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/GitHubActions.ts
@@ -125,7 +125,7 @@ function _getSHA(inputs: ProviderUtilInputs): string {
 
     const mergeCommitResult = mergeCommitRegex.exec(mergeCommitMessage);
 
-    if (mergeCommitMessage) {
+    if (mergeCommitResult) {
       const mergeCommit = mergeCommitResult?.groups?.commit;
       if (mergeCommit) {
         commit = mergeCommit;

--- a/packages/bundler-plugin-core/src/utils/providers/__tests__/GitHubActions.test.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/__tests__/GitHubActions.test.ts
@@ -288,7 +288,7 @@ describe("GitHub Actions Params", () => {
       }),
     ).thenReturn({
       stdout: Buffer.from(
-        "testingsha123456789012345678901234567890 testingmergecommitsha2345678901234567890",
+        "Merge testingmergecommitsha2345678901234567890 into testingsha123456789012345678901234567890",
       ),
     });
     const params = await GitHubActions.getServiceParams(inputs);


### PR DESCRIPTION
# Description

GitHub updates their merge commit format, so we have to update the matcher.

Some examples:

https://app.codecov.io/gh/Zxilly/go-size-analyzer/pull/42/commits
https://github.com/Zxilly/go-size-analyzer/commit/484cc3ea411dcc1da9e9b68a1c6485a83a99689c

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
