### PR TITLE
feat: Add in better debugging logs

### DIFF
--- a/.changeset/shaggy-snakes-sip.md
+++ b/.changeset/shaggy-snakes-sip.md
@@ -1,0 +1,9 @@
+---
+"@codecov/bundler-plugin-core": patch
+"@codecov/nuxt-plugin": patch
+"@codecov/rollup-plugin": patch
+"@codecov/vite-plugin": patch
+"@codecov/webpack-plugin": patch
+---
+
+Add in better debug logging around choosing the commit sha

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -138,10 +138,11 @@ export interface ProviderUtilInputs {
 }
 
 export interface ProviderUtil {
-  detect: (arg0: ProviderEnvs) => boolean;
+  detect: (envs: ProviderEnvs) => boolean;
   getServiceName: () => string;
   getServiceParams: (
-    arg0: ProviderUtilInputs,
+    inputs: ProviderUtilInputs,
+    output: Output,
   ) => Promise<ProviderServiceParams>;
   getEnvVarNames: () => string[];
 }

--- a/packages/bundler-plugin-core/src/utils/Output.ts
+++ b/packages/bundler-plugin-core/src/utils/Output.ts
@@ -135,7 +135,7 @@ class Output {
     };
     const envs = process.env;
     const inputs: ProviderUtilInputs = { envs, args };
-    const provider = await detectProvider(inputs);
+    const provider = await detectProvider(inputs, this);
 
     let url = "";
     try {

--- a/packages/bundler-plugin-core/src/utils/__tests__/provider.test.ts
+++ b/packages/bundler-plugin-core/src/utils/__tests__/provider.test.ts
@@ -11,7 +11,7 @@ import {
 import { type ProviderUtilInputs } from "src/types.ts";
 import { detectProvider, setSlug } from "../provider.ts";
 import { isProgramInstalled } from "../isProgramInstalled";
-
+import { Output } from "../Output.ts";
 vi.mock("../isProgramInstalled");
 const mockedIsProgramInstalled = isProgramInstalled as Mock;
 
@@ -40,8 +40,16 @@ describe("detectProvider", () => {
         },
       };
 
-      const result = await detectProvider(inputs);
+      const output = new Output({
+        apiUrl: "http://localhost",
+        bundleName: "provider-test",
+        debug: false,
+        dryRun: true,
+        enableBundleAnalysis: true,
+        retryCount: 0,
+      });
 
+      const result = await detectProvider(inputs, output);
       expect(result.service).toEqual("appveyor");
     });
   });
@@ -50,13 +58,22 @@ describe("detectProvider", () => {
     it("throws an error", async () => {
       let error;
 
+      const output = new Output({
+        apiUrl: "http://localhost",
+        bundleName: "provider-test",
+        debug: false,
+        dryRun: true,
+        enableBundleAnalysis: true,
+        retryCount: 0,
+      });
+
       try {
         const inputs: ProviderUtilInputs = {
           args: {},
           envs: {},
         };
 
-        await detectProvider(inputs);
+        await detectProvider(inputs, output);
       } catch (e) {
         error = e;
       }

--- a/packages/bundler-plugin-core/src/utils/fetchWithRetry.ts
+++ b/packages/bundler-plugin-core/src/utils/fetchWithRetry.ts
@@ -20,7 +20,7 @@ export const fetchWithRetry = async ({
 
   for (let i = 0; i < retryCount + 1; i++) {
     try {
-      debug(`Attempting to fetch ${name}, attempt: ${i}`);
+      debug(`Attempting to fetch ${name}, attempt: ${i + 1}`);
       await delay(DEFAULT_RETRY_DELAY * i);
       response = await fetch(url, requestData);
 
@@ -29,7 +29,7 @@ export const fetchWithRetry = async ({
       }
       break;
     } catch (err) {
-      debug(`${name} fetch attempt ${i} failed`);
+      debug(`${name} fetch attempt ${i + 1} failed`);
       const isLastAttempt = i + 1 === retryCount;
 
       if (isLastAttempt) {

--- a/packages/bundler-plugin-core/src/utils/logging.ts
+++ b/packages/bundler-plugin-core/src/utils/logging.ts
@@ -40,8 +40,17 @@ export function cyan(msg: string): void {
   return l(Chalk.cyan(prepareMessage(msg)));
 }
 
-// Disable eslint because we want to allow any type of message when debugging
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function debug(msg: any): void {
-  return l(Chalk.italic.yellow(prepareMessage(msg)));
+interface DebugOptions {
+  enabled?: boolean;
+}
+
+export function debug(
+  // Disable eslint because we want to allow any type of message when debugging
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  msg: any,
+  { enabled = true }: DebugOptions = { enabled: true },
+): void {
+  if (enabled) {
+    return l(Chalk.italic.yellow(prepareMessage(msg)));
+  }
 }

--- a/packages/bundler-plugin-core/src/utils/provider.ts
+++ b/packages/bundler-plugin-core/src/utils/provider.ts
@@ -2,17 +2,19 @@ import {
   type ProviderServiceParams,
   type ProviderUtilInputs,
 } from "../types.ts";
+import { type Output } from "./Output.ts";
 import { cyan, red } from "./logging.ts";
 import { providerList } from "./providers";
 
 export async function detectProvider(
   inputs: ProviderUtilInputs,
+  output: Output,
 ): Promise<ProviderServiceParams> {
   cyan("Detecting CI provider");
   for (const provider of providerList) {
     if (provider.detect(inputs.envs)) {
       cyan(`Detected CI provider: ${provider.getServiceName()}`);
-      return await provider.getServiceParams(inputs);
+      return await provider.getServiceParams(inputs, output);
     }
   }
   red("Could not detect CI provider");

--- a/packages/bundler-plugin-core/src/utils/providers/Bitbucket.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/Bitbucket.ts
@@ -65,10 +65,7 @@ function _getSHA(inputs: ProviderUtilInputs, output: Output): string {
     commit = runExternalProgram("git", ["rev-parse", commit]);
   }
 
-  if (output.debug) {
-    debug(`Using commit: ${commit ?? ""}`);
-  }
-
+  debug(`Using commit: ${commit ?? ""}`, { enabled: output.debug });
   return commit ?? "";
 }
 

--- a/packages/bundler-plugin-core/src/utils/providers/Cirrus.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/Cirrus.ts
@@ -3,6 +3,8 @@ import {
   type ProviderServiceParams,
   type ProviderUtilInputs,
 } from "../../types.ts";
+import { type Output } from "../Output.ts";
+import { debug } from "../logging.ts";
 import { setSlug } from "../provider.ts";
 
 export function detect(envs: ProviderEnvs): boolean {
@@ -11,7 +13,10 @@ export function detect(envs: ProviderEnvs): boolean {
 
 function _getBuild(inputs: ProviderUtilInputs): string {
   const { args, envs } = inputs;
-  return args?.build ?? envs?.CIRRUS_BUILD_ID ?? "";
+  if (args?.build && args.build !== "") {
+    return args.build;
+  }
+  return envs?.CIRRUS_BUILD_ID ?? "";
 }
 
 function _getBuildURL(): string {
@@ -20,7 +25,10 @@ function _getBuildURL(): string {
 
 function _getBranch(inputs: ProviderUtilInputs): string {
   const { args, envs } = inputs;
-  return args?.branch ?? envs?.CIRRUS_BRANCH ?? "";
+  if (args?.branch && args.branch !== "") {
+    return args.branch;
+  }
+  return envs?.CIRRUS_BRANCH ?? "";
 }
 
 function _getJob(envs: ProviderEnvs): string {
@@ -29,7 +37,10 @@ function _getJob(envs: ProviderEnvs): string {
 
 function _getPR(inputs: ProviderUtilInputs): string {
   const { args, envs } = inputs;
-  return args?.pr ?? envs?.CIRRUS_PR ?? "";
+  if (args?.pr && args.pr !== "") {
+    return args.pr;
+  }
+  return envs?.CIRRUS_PR ?? "";
 }
 
 function _getService(): string {
@@ -40,9 +51,15 @@ export function getServiceName(): string {
   return "Cirrus CI";
 }
 
-function _getSHA(inputs: ProviderUtilInputs): string {
+function _getSHA(inputs: ProviderUtilInputs, output: Output): string {
   const { args, envs } = inputs;
-  return args?.sha ?? envs?.CIRRUS_CHANGE_IN_REPO ?? "";
+  if (args?.sha && args.sha !== "") {
+    debug(`Using commit: ${args.sha}`, { enabled: output.debug });
+    return args.sha;
+  }
+  const sha = envs?.CIRRUS_CHANGE_IN_REPO ?? "";
+  debug(`Using commit: ${sha}`, { enabled: output.debug });
+  return sha;
 }
 
 function _getSlug(inputs: ProviderUtilInputs): string {
@@ -53,12 +70,13 @@ function _getSlug(inputs: ProviderUtilInputs): string {
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function getServiceParams(
   inputs: ProviderUtilInputs,
+  output: Output,
 ): Promise<ProviderServiceParams> {
   return {
     branch: _getBranch(inputs),
     build: _getBuild(inputs),
     buildURL: _getBuildURL(),
-    commit: _getSHA(inputs),
+    commit: _getSHA(inputs, output),
     job: _getJob(inputs.envs),
     pr: _getPR(inputs),
     service: _getService(),

--- a/packages/bundler-plugin-core/src/utils/providers/CodeBuild.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/CodeBuild.ts
@@ -3,6 +3,8 @@ import {
   type ProviderServiceParams,
   type ProviderUtilInputs,
 } from "../../types.ts";
+import { type Output } from "../Output.ts";
+import { debug } from "../logging.ts";
 
 export function detect(envs: ProviderEnvs): boolean {
   return Boolean(envs?.CODEBUILD_CI);
@@ -10,7 +12,10 @@ export function detect(envs: ProviderEnvs): boolean {
 
 function _getBuild(inputs: ProviderUtilInputs): string {
   const { args, envs } = inputs;
-  return args?.build ?? envs?.CODEBUILD_BUILD_ID ?? "";
+  if (args?.build && args.build !== "") {
+    return args.build;
+  }
+  return envs?.CODEBUILD_BUILD_ID ?? "";
 }
 
 function _getBuildURL(): string {
@@ -19,12 +24,12 @@ function _getBuildURL(): string {
 
 function _getBranch(inputs: ProviderUtilInputs): string {
   const { args, envs } = inputs;
-  return (
-    args?.branch ??
-    (envs?.CODEBUILD_WEBHOOK_HEAD_REF
-      ? envs?.CODEBUILD_WEBHOOK_HEAD_REF.replace(/^refs\/heads\//, "")
-      : "")
-  );
+  if (args?.branch && args.branch !== "") {
+    return args.branch;
+  }
+  return envs?.CODEBUILD_WEBHOOK_HEAD_REF
+    ? envs?.CODEBUILD_WEBHOOK_HEAD_REF.replace(/^refs\/heads\//, "")
+    : "";
 }
 
 function _getJob(envs: ProviderEnvs): string {
@@ -33,13 +38,14 @@ function _getJob(envs: ProviderEnvs): string {
 
 function _getPR(inputs: ProviderUtilInputs): string {
   const { args, envs } = inputs;
-  return (
-    args?.pr ??
-    (envs?.CODEBUILD_SOURCE_VERSION &&
+  if (args?.pr && args.pr !== "") {
+    return args.pr;
+  }
+
+  return envs?.CODEBUILD_SOURCE_VERSION &&
     envs?.CODEBUILD_SOURCE_VERSION.startsWith("pr/")
-      ? envs?.CODEBUILD_SOURCE_VERSION.replace(/^pr\//, "")
-      : "")
-  );
+    ? envs?.CODEBUILD_SOURCE_VERSION.replace(/^pr\//, "")
+    : "";
 }
 
 function _getService(): string {
@@ -50,14 +56,24 @@ export function getServiceName(): string {
   return "AWS CodeBuild";
 }
 
-function _getSHA(inputs: ProviderUtilInputs): string {
+function _getSHA(inputs: ProviderUtilInputs, output: Output): string {
   const { args, envs } = inputs;
-  return args?.sha ?? envs?.CODEBUILD_RESOLVED_SOURCE_VERSION ?? "";
+  if (args?.sha && args.sha !== "") {
+    debug(`Using commit: ${args.sha}`, { enabled: output.debug });
+    return args.sha;
+  }
+
+  const sha = envs?.CODEBUILD_RESOLVED_SOURCE_VERSION ?? "";
+  debug(`Using commit: ${sha}`, { enabled: output.debug });
+  return sha;
 }
 
 function _getSlug(inputs: ProviderUtilInputs): string {
   const { args, envs } = inputs;
-  if (args?.slug && args?.slug !== "") return args?.slug;
+  if (args?.slug && args?.slug !== "") {
+    return args?.slug;
+  }
+
   return envs?.CODEBUILD_SOURCE_REPO_URL
     ? envs?.CODEBUILD_SOURCE_REPO_URL.toString()
         .replace(/^.*github.com\//, "") // lgtm [js/incomplete-hostname-regexp] - We want this to match all subdomains.
@@ -68,12 +84,13 @@ function _getSlug(inputs: ProviderUtilInputs): string {
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function getServiceParams(
   inputs: ProviderUtilInputs,
+  output: Output,
 ): Promise<ProviderServiceParams> {
   return {
     branch: _getBranch(inputs),
     build: _getBuild(inputs),
     buildURL: _getBuildURL(),
-    commit: _getSHA(inputs),
+    commit: _getSHA(inputs, output),
     job: _getJob(inputs.envs),
     pr: _getPR(inputs),
     service: _getService(),

--- a/packages/bundler-plugin-core/src/utils/providers/Drone.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/Drone.ts
@@ -3,6 +3,8 @@ import {
   type ProviderServiceParams,
   type ProviderUtilInputs,
 } from "../../types.ts";
+import { type Output } from "../Output.ts";
+import { debug } from "../logging.ts";
 
 export function detect(envs: ProviderEnvs): boolean {
   return Boolean(envs?.DRONE);
@@ -10,7 +12,10 @@ export function detect(envs: ProviderEnvs): boolean {
 
 function _getBuild(inputs: ProviderUtilInputs): string {
   const { args, envs } = inputs;
-  return args?.build ?? envs?.DRONE_BUILD_NUMBER ?? "";
+  if (args?.build && args.build !== "") {
+    return args.build;
+  }
+  return envs?.DRONE_BUILD_NUMBER ?? "";
 }
 
 function _getBuildURL(inputs: ProviderUtilInputs): string {
@@ -22,7 +27,10 @@ function _getBuildURL(inputs: ProviderUtilInputs): string {
 
 function _getBranch(inputs: ProviderUtilInputs): string {
   const { args, envs } = inputs;
-  return args?.branch ?? envs?.DRONE_BRANCH ?? "";
+  if (args?.branch && args.branch !== "") {
+    return args?.branch;
+  }
+  return envs?.DRONE_BRANCH ?? "";
 }
 
 function _getJob(): string {
@@ -31,7 +39,10 @@ function _getJob(): string {
 
 function _getPR(inputs: ProviderUtilInputs): string {
   const { args, envs } = inputs;
-  return args?.pr ?? envs?.DRONE_PULL_REQUEST ?? "";
+  if (args?.pr && args.pr !== "") {
+    return args?.pr;
+  }
+  return envs?.DRONE_PULL_REQUEST ?? "";
 }
 
 function _getService(): string {
@@ -42,26 +53,36 @@ export function getServiceName(): string {
   return "Drone";
 }
 
-function _getSHA(inputs: ProviderUtilInputs): string {
+function _getSHA(inputs: ProviderUtilInputs, output: Output): string {
   const { args, envs } = inputs;
-  return args?.sha ?? envs?.DRONE_COMMIT_SHA ?? "";
+  if (args?.sha && args.sha !== "") {
+    debug(`Using commit: ${args.sha}`, { enabled: output.debug });
+    return args.sha;
+  }
+
+  const sha = envs?.DRONE_COMMIT_SHA ?? "";
+  debug(`Using commit: ${sha}`, { enabled: output.debug });
+  return sha;
 }
 
 function _getSlug(inputs: ProviderUtilInputs): string {
   const { args, envs } = inputs;
-  if (args?.slug && args?.slug !== "") return args?.slug;
+  if (args?.slug && args?.slug !== "") {
+    return args?.slug;
+  }
   return envs?.DRONE_REPO ?? "";
 }
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function getServiceParams(
   inputs: ProviderUtilInputs,
+  output: Output,
 ): Promise<ProviderServiceParams> {
   return {
     branch: _getBranch(inputs),
     build: _getBuild(inputs),
     buildURL: _getBuildURL(inputs),
-    commit: _getSHA(inputs),
+    commit: _getSHA(inputs, output),
     job: _getJob(),
     pr: _getPR(inputs),
     service: _getService(),

--- a/packages/bundler-plugin-core/src/utils/providers/JenkinsCI.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/JenkinsCI.ts
@@ -3,7 +3,9 @@ import {
   type ProviderServiceParams,
   type ProviderUtilInputs,
 } from "../../types.ts";
+import { type Output } from "../Output.ts";
 import { parseSlugFromRemoteAddr } from "../git.ts";
+import { debug } from "../logging.ts";
 
 export function detect(envs: ProviderEnvs): boolean {
   return Boolean(envs?.JENKINS_URL);
@@ -11,7 +13,10 @@ export function detect(envs: ProviderEnvs): boolean {
 
 function _getBuild(inputs: ProviderUtilInputs): string {
   const { args, envs } = inputs;
-  return args?.build ?? envs?.BUILD_NUMBER ?? "";
+  if (args?.build && args.build !== "") {
+    return args.build;
+  }
+  return envs?.BUILD_NUMBER ?? "";
 }
 
 function _getBuildURL(inputs: ProviderUtilInputs): string {
@@ -21,8 +26,10 @@ function _getBuildURL(inputs: ProviderUtilInputs): string {
 
 function _getBranch(inputs: ProviderUtilInputs): string {
   const { args, envs } = inputs;
+  if (args?.branch && args.branch !== "") {
+    return args.branch;
+  }
   return (
-    args?.branch ??
     envs?.ghprbSourceBranch ??
     envs?.CHANGE_BRANCH ??
     envs?.GIT_BRANCH ??
@@ -37,7 +44,10 @@ function _getJob() {
 
 function _getPR(inputs: ProviderUtilInputs): string {
   const { args, envs } = inputs;
-  return args?.pr ?? envs?.ghprbPullId ?? envs?.CHANGE_ID ?? "";
+  if (args?.pr && args.pr !== "") {
+    return args.pr;
+  }
+  return envs?.ghprbPullId ?? envs?.CHANGE_ID ?? "";
 }
 
 function _getService(): string {
@@ -48,29 +58,39 @@ export function getServiceName(): string {
   return "Jenkins CI";
 }
 
-function _getSHA(inputs: ProviderUtilInputs): string {
+function _getSHA(inputs: ProviderUtilInputs, output: Output): string {
   const { args, envs } = inputs;
+  if (args?.sha && args.sha !== "") {
+    debug(`Using commit: ${args.sha}`, { enabled: output.debug });
+    return args.sha;
+  }
+
   // Note that the value of GIT_COMMIT may not be accurate if Jenkins
   // is merging `master` in to the working branch first. In these cases
   // there is no envvar representing the actual submitted commit
-  return args?.sha ?? envs?.ghprbActualCommit ?? envs?.GIT_COMMIT ?? "";
+  const sha = envs?.ghprbActualCommit ?? envs?.GIT_COMMIT ?? "";
+  debug(`Using commit: ${sha}`, { enabled: output.debug });
+  return sha;
 }
 
 function _getSlug(inputs: ProviderUtilInputs): string {
   const { args } = inputs;
-  if (args?.slug && args?.slug !== "") return args?.slug;
+  if (args?.slug && args?.slug !== "") {
+    return args?.slug;
+  }
   return parseSlugFromRemoteAddr("");
 }
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function getServiceParams(
   inputs: ProviderUtilInputs,
+  output: Output,
 ): Promise<ProviderServiceParams> {
   return {
     branch: _getBranch(inputs),
     build: _getBuild(inputs),
     buildURL: _getBuildURL(inputs),
-    commit: _getSHA(inputs),
+    commit: _getSHA(inputs, output),
     job: _getJob(),
     pr: _getPR(inputs),
     service: _getService(),

--- a/packages/bundler-plugin-core/src/utils/providers/Render.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/Render.ts
@@ -3,6 +3,8 @@ import {
   type ProviderServiceParams,
   type ProviderUtilInputs,
 } from "../../types.ts";
+import { type Output } from "../Output.ts";
+import { debug } from "../logging.ts";
 
 export function detect(envs: ProviderEnvs): boolean {
   return Boolean(envs?.RENDER);
@@ -19,8 +21,10 @@ function _getBuildURL(): string {
 
 function _getBranch(inputs: ProviderUtilInputs): string {
   const { args, envs } = inputs;
-
-  return args?.branch ?? envs?.RENDER_GIT_BRANCH ?? "";
+  if (args?.branch && args.branch !== "") {
+    return args.branch;
+  }
+  return envs?.RENDER_GIT_BRANCH ?? "";
 }
 
 function _getJob(): string {
@@ -40,26 +44,36 @@ export function getServiceName(): string {
   return "Render";
 }
 
-function _getSHA(inputs: ProviderUtilInputs): string {
+function _getSHA(inputs: ProviderUtilInputs, output: Output): string {
   const { args, envs } = inputs;
-  return args?.sha ?? envs?.RENDER_GIT_COMMIT ?? "";
+  if (args?.sha && args.sha !== "") {
+    debug(`Using commit: ${args.sha}`, { enabled: output.debug });
+    return args.sha;
+  }
+
+  const sha = envs?.RENDER_GIT_COMMIT ?? "";
+  debug(`Using commit: ${sha}`, { enabled: output.debug });
+  return sha;
 }
 
 function _getSlug(inputs: ProviderUtilInputs): string {
   const { args, envs } = inputs;
-  if (args?.slug && args?.slug !== "") return args?.slug;
+  if (args?.slug && args?.slug !== "") {
+    return args?.slug;
+  }
   return envs?.RENDER_GIT_REPO_SLUG ?? "";
 }
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function getServiceParams(
   inputs: ProviderUtilInputs,
+  output: Output,
 ): Promise<ProviderServiceParams> {
   return {
     branch: _getBranch(inputs),
     build: _getBuild(inputs),
     buildURL: _getBuildURL(),
-    commit: _getSHA(inputs),
+    commit: _getSHA(inputs, output),
     job: _getJob(),
     pr: _getPR(inputs),
     service: _getService(),

--- a/packages/bundler-plugin-core/src/utils/providers/__tests__/AppVeyorCI.test.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/__tests__/AppVeyorCI.test.ts
@@ -5,6 +5,7 @@ import {
   type ProviderUtilInputs,
 } from "../../../types.ts";
 import * as AppVeyorCI from "../AppVeyorCI.ts";
+import { Output } from "../../Output.ts";
 
 describe("AppveyorCI Params", () => {
   describe("detect()", () => {
@@ -79,7 +80,16 @@ describe("AppveyorCI Params", () => {
       service: "appveyor",
       slug: "testOrg/testRepo",
     };
-    const params = await AppVeyorCI.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "AppVeyorCI-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await AppVeyorCI.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -112,7 +122,16 @@ describe("AppveyorCI Params", () => {
       service: "appveyor",
       slug: "testOrg/testRepo",
     };
-    const params = await AppVeyorCI.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "AppVeyorCI-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await AppVeyorCI.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -145,7 +164,15 @@ describe("AppveyorCI Params", () => {
       slug: "testOrg/testRepo",
     };
 
-    const params = await AppVeyorCI.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "AppVeyorCI-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await AppVeyorCI.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -166,7 +193,15 @@ describe("AppveyorCI Params", () => {
       slug: "",
     };
 
-    const params = await AppVeyorCI.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "AppVeyorCI-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await AppVeyorCI.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 });

--- a/packages/bundler-plugin-core/src/utils/providers/__tests__/AzurePipelines.test.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/__tests__/AzurePipelines.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../../../types.ts";
 import { SPAWN_PROCESS_BUFFER_SIZE } from "../../constants.ts";
 import * as AzurePipelines from "../AzurePipelines.ts";
+import { Output } from "../../Output.ts";
 
 describe("Azure Pipelines CI Params", () => {
   describe("detect()", () => {
@@ -57,7 +58,15 @@ describe("Azure Pipelines CI Params", () => {
       }),
     ).thenReturn({ stdout: Buffer.from("") });
 
-    const params = await AzurePipelines.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "AzurePipelines-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await AzurePipelines.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -90,7 +99,16 @@ describe("Azure Pipelines CI Params", () => {
     td.when(
       execFileSync("git", ["show", "--no-patch", "--format=%P"]),
     ).thenReturn(Buffer.from("nonmergesha23456789012345678901234567890"));
-    const params = await AzurePipelines.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "AzurePipelines-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await AzurePipelines.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -123,7 +141,16 @@ describe("Azure Pipelines CI Params", () => {
     td.when(
       execFileSync("git", ["show", "--no-patch", "--format=%P"]),
     ).thenReturn(Buffer.from("nonmergesha23456789012345678901234567890"));
-    const params = await AzurePipelines.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "AzurePipelines-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await AzurePipelines.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -159,7 +186,16 @@ describe("Azure Pipelines CI Params", () => {
     ).thenReturn({
       stdout: Buffer.from("https://github.com/testOrg/testRepo.git"),
     });
-    const params = await AzurePipelines.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "AzurePipelines-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await AzurePipelines.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -196,7 +232,16 @@ describe("Azure Pipelines CI Params", () => {
         "testingsha123456789012345678901234567890 testingmergecommitsha2345678901234567890",
       ),
     );
-    const params = await AzurePipelines.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "AzurePipelines-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await AzurePipelines.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -228,7 +273,15 @@ describe("Azure Pipelines CI Params", () => {
       slug: "testOrg/otherTestRepo",
     };
 
-    const params = await AzurePipelines.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "AzurePipelines-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await AzurePipelines.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 });

--- a/packages/bundler-plugin-core/src/utils/providers/__tests__/Bitbucket.test.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/__tests__/Bitbucket.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../../../types.ts";
 import { SPAWN_PROCESS_BUFFER_SIZE } from "../../constants.ts";
 import * as Bitbucket from "../Bitbucket.ts";
+import { Output } from "../../Output.ts";
 
 describe("Bitbucket Params", () => {
   afterEach(() => {
@@ -60,7 +61,16 @@ describe("Bitbucket Params", () => {
       service: "bitbucket",
       slug: "",
     };
-    const params = await Bitbucket.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Bitbucket-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await Bitbucket.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -86,7 +96,16 @@ describe("Bitbucket Params", () => {
       service: "bitbucket",
       slug: "testOwner/testSlug",
     };
-    const params = await Bitbucket.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Bitbucket-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await Bitbucket.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -111,7 +130,16 @@ describe("Bitbucket Params", () => {
       service: "bitbucket",
       slug: "testOwner/testSlug",
     };
-    const params = await Bitbucket.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Bitbucket-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await Bitbucket.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -145,7 +173,15 @@ describe("Bitbucket Params", () => {
       }),
     ).thenReturn({ stdout: Buffer.from("0e8f15380b54") });
 
-    const params = await Bitbucket.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Bitbucket-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await Bitbucket.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -180,7 +216,16 @@ describe("Bitbucket Params", () => {
       service: "bitbucket",
       slug: "overwriteOwner/overwriteRepo",
     };
-    const params = await Bitbucket.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Bitbucket-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await Bitbucket.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 });

--- a/packages/bundler-plugin-core/src/utils/providers/__tests__/Bitrise.test.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/__tests__/Bitrise.test.ts
@@ -8,6 +8,7 @@ import {
   type ProviderUtilInputs,
 } from "../../../types.ts";
 import { SPAWN_PROCESS_BUFFER_SIZE } from "../../constants.ts";
+import { Output } from "../../Output.ts";
 
 import * as Bitrise from "../Bitrise.ts";
 
@@ -76,7 +77,15 @@ describe("Bitrise Params", () => {
       }),
     ).thenReturn({ stdout: Buffer.from("") });
 
-    const params = await Bitrise.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Bitrise-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await Bitrise.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -111,7 +120,16 @@ describe("Bitrise Params", () => {
     ).thenReturn({
       stdout: Buffer.from("https://github.com/testOrg/testRepo.git"),
     });
-    const params = await Bitrise.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Bitrise-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await Bitrise.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -146,7 +164,16 @@ describe("Bitrise Params", () => {
     ).thenReturn({
       stdout: Buffer.from("https://github.com/testOrg/testRepo.git"),
     });
-    const params = await Bitrise.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Bitrise-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await Bitrise.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -191,7 +218,16 @@ describe("Bitrise Params", () => {
     ).thenReturn({
       stdout: Buffer.from("https://github.com/testOrg/testRepo.git"),
     });
-    const params = await Bitrise.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Bitrise-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await Bitrise.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 });

--- a/packages/bundler-plugin-core/src/utils/providers/__tests__/Buildkite.test.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/__tests__/Buildkite.test.ts
@@ -5,6 +5,7 @@ import {
   type ProviderServiceParams,
   type ProviderUtilInputs,
 } from "../../../types.ts";
+import { Output } from "../../Output.ts";
 import * as Buildkite from "../Buildkite.ts";
 
 describe("Buildkite Params", () => {
@@ -59,7 +60,16 @@ describe("Buildkite Params", () => {
       service: "buildkite",
       slug: "testOrg/testRepo",
     };
-    const params = await Buildkite.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Buildkite-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await Buildkite.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -91,7 +101,15 @@ describe("Buildkite Params", () => {
       slug: "testOrg/testRepo",
     };
 
-    const params = await Buildkite.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Buildkite-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await Buildkite.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 });

--- a/packages/bundler-plugin-core/src/utils/providers/__tests__/CircleCI.test.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/__tests__/CircleCI.test.ts
@@ -5,6 +5,7 @@ import {
   type ProviderServiceParams,
   type ProviderUtilInputs,
 } from "../../../types.ts";
+import { Output } from "../../Output.ts";
 import * as CircleCI from "../CircleCI.ts";
 
 describe("CircleCI Params", () => {
@@ -63,7 +64,15 @@ describe("CircleCI Params", () => {
       slug: "testOrg/testRepo",
     };
 
-    const params = await CircleCI.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "CircleCI-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await CircleCI.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -92,7 +101,16 @@ describe("CircleCI Params", () => {
       service: "circleci",
       slug: "testOrg/testRepo",
     };
-    const params = await CircleCI.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "CircleCI-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await CircleCI.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -128,7 +146,16 @@ describe("CircleCI Params", () => {
       service: "circleci",
       slug: "testOrg/testRepo",
     };
-    const params = await CircleCI.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "CircleCI-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await CircleCI.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 });

--- a/packages/bundler-plugin-core/src/utils/providers/__tests__/Cirrus.test.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/__tests__/Cirrus.test.ts
@@ -5,6 +5,7 @@ import {
   type ProviderServiceParams,
   type ProviderUtilInputs,
 } from "../../../types.ts";
+import { Output } from "../../Output.ts";
 import * as Cirrus from "../Cirrus.ts";
 
 describe("Cirrus Params", () => {
@@ -59,7 +60,16 @@ describe("Cirrus Params", () => {
       service: "cirrus-ci",
       slug: "testOrg/testRepo",
     };
-    const params = await Cirrus.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Cirrus-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await Cirrus.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -97,7 +107,15 @@ describe("Cirrus Params", () => {
       slug: "testOrg/testRepo",
     };
 
-    const params = await Cirrus.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Cirrus-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await Cirrus.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 });

--- a/packages/bundler-plugin-core/src/utils/providers/__tests__/CloudflarePages.test.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/__tests__/CloudflarePages.test.ts
@@ -5,6 +5,7 @@ import {
   type ProviderServiceParams,
   type ProviderUtilInputs,
 } from "../../../types.ts";
+import { Output } from "../../Output.ts";
 import * as CloudflarePages from "../CloudflarePages.ts";
 
 describe("CloudflarePages Params", () => {
@@ -57,7 +58,15 @@ describe("CloudflarePages Params", () => {
       slug: "",
     };
 
-    const params = await CloudflarePages.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "CloudflarePages-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await CloudflarePages.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -88,7 +97,15 @@ describe("CloudflarePages Params", () => {
       slug: "testOrg/testRepo",
     };
 
-    const params = await CloudflarePages.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "CloudflarePages-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await CloudflarePages.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -109,7 +126,15 @@ describe("CloudflarePages Params", () => {
       slug: "",
     };
 
-    const params = await CloudflarePages.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "CloudflarePages-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await CloudflarePages.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 });

--- a/packages/bundler-plugin-core/src/utils/providers/__tests__/CodeBuild.test.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/__tests__/CodeBuild.test.ts
@@ -5,6 +5,7 @@ import {
   type ProviderServiceParams,
   type ProviderUtilInputs,
 } from "../../../types.ts";
+import { Output } from "../../Output.ts";
 import * as CodeBuild from "../CodeBuild.ts";
 
 describe("CodeBuild Params", () => {
@@ -59,7 +60,16 @@ describe("CodeBuild Params", () => {
         service: "codebuild",
         slug: "repo",
       };
-      const params = await CodeBuild.getServiceParams(inputs);
+
+      const output = new Output({
+        apiUrl: "http://localhost",
+        bundleName: "CodeBuild-test",
+        debug: false,
+        dryRun: true,
+        enableBundleAnalysis: true,
+        retryCount: 0,
+      });
+      const params = await CodeBuild.getServiceParams(inputs, output);
       expect(params).toMatchObject(expected);
     });
 
@@ -96,7 +106,15 @@ describe("CodeBuild Params", () => {
         slug: "testOrg/testRepo",
       };
 
-      const params = await CodeBuild.getServiceParams(inputs);
+      const output = new Output({
+        apiUrl: "http://localhost",
+        bundleName: "CodeBuild-test",
+        debug: false,
+        dryRun: true,
+        enableBundleAnalysis: true,
+        retryCount: 0,
+      });
+      const params = await CodeBuild.getServiceParams(inputs, output);
       expect(params).toMatchObject(expected);
     });
   });

--- a/packages/bundler-plugin-core/src/utils/providers/__tests__/Drone.test.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/__tests__/Drone.test.ts
@@ -73,6 +73,53 @@ describe("Drone Params", () => {
     expect(params).toMatchObject(expected);
   });
 
+  it("gets correct params from overrides", async () => {
+    const inputs: ProviderUtilInputs = {
+      args: {
+        ...createEmptyArgs(),
+        ...{
+          branch: "branch",
+          build: "5",
+          pr: "123",
+          sha: "test-sha",
+          slug: "cool-slug",
+        },
+      },
+      envs: {
+        CI: "true",
+        DRONE: "true",
+        DRONE_BRANCH: "master",
+        DRONE_COMMIT_SHA: "testingsha",
+        DRONE_BUILD_NUMBER: "2",
+        DRONE_PULL_REQUEST: "1",
+        DRONE_BUILD_LINK: "https://www.drone.io/",
+        DRONE_REPO: "testOrg/testRepo",
+      },
+    };
+
+    const expected: ProviderServiceParams = {
+      branch: "branch",
+      build: "5",
+      buildURL: "https://www.drone.io/",
+      commit: "test-sha",
+      job: "",
+      pr: "123",
+      service: "drone.io",
+      slug: "cool-slug",
+    };
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Drone-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await Drone.getServiceParams(inputs, output);
+    expect(params).toMatchObject(expected);
+  });
+
   it("gets correct params for DRONE_BUILD_URL", async () => {
     const inputs: ProviderUtilInputs = {
       args: { ...createEmptyArgs() },

--- a/packages/bundler-plugin-core/src/utils/providers/__tests__/Drone.test.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/__tests__/Drone.test.ts
@@ -5,6 +5,7 @@ import {
   type ProviderServiceParams,
   type ProviderUtilInputs,
 } from "../../../types.ts";
+import { Output } from "../../Output.ts";
 import * as Drone from "../Drone.ts";
 
 describe("Drone Params", () => {
@@ -59,7 +60,16 @@ describe("Drone Params", () => {
       service: "drone.io",
       slug: "testOrg/testRepo",
     };
-    const params = await Drone.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Drone-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await Drone.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -87,7 +97,16 @@ describe("Drone Params", () => {
       service: "drone.io",
       slug: "testOrg/testRepo",
     };
-    const params = await Drone.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Drone-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await Drone.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 });

--- a/packages/bundler-plugin-core/src/utils/providers/__tests__/GitHubActions.test.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/__tests__/GitHubActions.test.ts
@@ -9,6 +9,7 @@ import {
   type ProviderUtilInputs,
 } from "../../../types.ts";
 import { SPAWN_PROCESS_BUFFER_SIZE } from "../../constants.ts";
+import { Output } from "../../Output.ts";
 import * as GitHubActions from "../GitHubActions.ts";
 
 const server = setupServer();
@@ -95,7 +96,15 @@ describe("GitHub Actions Params", () => {
       slug: "testOrg/testRepo",
     };
 
-    const params = await GitHubActions.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "GHA-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await GitHubActions.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -133,7 +142,16 @@ describe("GitHub Actions Params", () => {
     ).thenReturn({
       stdout: Buffer.from("testingsha"),
     });
-    const params = await GitHubActions.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "GHA-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await GitHubActions.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -193,7 +211,15 @@ describe("GitHub Actions Params", () => {
       stdout: Buffer.from("testingsha"),
     });
 
-    const params = await GitHubActions.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "GHA-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await GitHubActions.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -251,7 +277,15 @@ describe("GitHub Actions Params", () => {
       stdout: Buffer.from("testingsha"),
     });
 
-    const params = await GitHubActions.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "GHA-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await GitHubActions.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -291,7 +325,16 @@ describe("GitHub Actions Params", () => {
         "testingsha123456789012345678901234567890 testingmergecommitsha2345678901234567890",
       ),
     });
-    const params = await GitHubActions.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "GHA-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await GitHubActions.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -330,7 +373,16 @@ describe("GitHub Actions Params", () => {
         maxBuffer: SPAWN_PROCESS_BUFFER_SIZE,
       }),
     ).thenReturn({ stdout: Buffer.from("testsha") });
-    const params = await GitHubActions.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "GHA-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await GitHubActions.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -366,7 +418,16 @@ describe("GitHub Actions Params", () => {
         maxBuffer: SPAWN_PROCESS_BUFFER_SIZE,
       }),
     ).thenReturn({ stdout: Buffer.from("") });
-    const params = await GitHubActions.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "GHA-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await GitHubActions.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 });

--- a/packages/bundler-plugin-core/src/utils/providers/__tests__/GitLabCI.test.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/__tests__/GitLabCI.test.ts
@@ -7,6 +7,7 @@ import {
   type ProviderUtilInputs,
 } from "../../../types.ts";
 import { SPAWN_PROCESS_BUFFER_SIZE } from "../../constants.ts";
+import { Output } from "../../Output.ts";
 import * as GitLabCI from "../GitLabCI.ts";
 
 describe("GitLabCI Params", () => {
@@ -59,7 +60,16 @@ describe("GitLabCI Params", () => {
         maxBuffer: SPAWN_PROCESS_BUFFER_SIZE,
       }),
     ).thenReturn({ stdout: Buffer.from("") });
-    const params = await GitLabCI.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "GLCI-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await GitLabCI.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -87,7 +97,16 @@ describe("GitLabCI Params", () => {
       service: "gitlab",
       slug: "testOrg/testRepo",
     };
-    const params = await GitLabCI.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "GLCI-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await GitLabCI.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -112,7 +131,16 @@ describe("GitLabCI Params", () => {
       service: "gitlab",
       slug: "testOrg/testRepo",
     };
-    const params = await GitLabCI.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "GLCI-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await GitLabCI.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -124,15 +152,25 @@ describe("GitLabCI Params", () => {
       },
     };
 
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "GLCI-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+
     it("can get the slug from http", async () => {
       inputs.envs.CI_BUILD_REPO = "https://gitlab.com/testOrg/testRepo.git";
-      const params = await GitLabCI.getServiceParams(inputs);
+
+      const params = await GitLabCI.getServiceParams(inputs, output);
       expect(params.slug).toBe("testOrg/testRepo");
     });
 
     it("can get the slug from git url", async () => {
       inputs.envs.CI_BUILD_REPO = "git@gitlab.com:testOrg/testRepo.git";
-      const params = await GitLabCI.getServiceParams(inputs);
+      const params = await GitLabCI.getServiceParams(inputs, output);
       expect(params.slug).toBe("testOrg/testRepo");
     });
 
@@ -147,7 +185,7 @@ describe("GitLabCI Params", () => {
         stdout: Buffer.from("https://gitlab.com/testOrg/testRepo.git"),
       });
 
-      const params = await GitLabCI.getServiceParams(inputs);
+      const params = await GitLabCI.getServiceParams(inputs, output);
       expect(params.slug).toBe("testOrg/testRepo");
     });
 
@@ -160,7 +198,7 @@ describe("GitLabCI Params", () => {
         }),
       ).thenReturn({ stdout: Buffer.from("git@gitlab.com:/") });
 
-      const params = await GitLabCI.getServiceParams(inputs);
+      const params = await GitLabCI.getServiceParams(inputs, output);
       expect(params.slug).toBe("");
     });
 
@@ -173,7 +211,7 @@ describe("GitLabCI Params", () => {
         }),
       ).thenReturn({ stdout: Buffer.from("") });
 
-      const params = await GitLabCI.getServiceParams(inputs);
+      const params = await GitLabCI.getServiceParams(inputs, output);
       expect(params.slug).toBe("");
     });
   });
@@ -205,7 +243,15 @@ describe("GitLabCI Params", () => {
       slug: "testOrg/testRepo",
     };
 
-    const params = await GitLabCI.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "GLCI-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await GitLabCI.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 });

--- a/packages/bundler-plugin-core/src/utils/providers/__tests__/HerokuCI.test.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/__tests__/HerokuCI.test.ts
@@ -7,6 +7,7 @@ import {
   type ProviderUtilInputs,
 } from "../../../types.ts";
 import { SPAWN_PROCESS_BUFFER_SIZE } from "../../constants.ts";
+import { Output } from "../../Output.ts";
 import * as HerokuCI from "../HerokuCI.ts";
 
 describe("HerokuCI Params", () => {
@@ -58,7 +59,16 @@ describe("HerokuCI Params", () => {
         maxBuffer: SPAWN_PROCESS_BUFFER_SIZE,
       }),
     ).thenReturn({ stdout: Buffer.from("") });
-    const params = await HerokuCI.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Heroku-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await HerokuCI.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -90,7 +100,16 @@ describe("HerokuCI Params", () => {
     ).thenReturn({
       stdout: Buffer.from("https://github.com/testOrg/testRepo.git"),
     });
-    const params = await HerokuCI.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Heroku-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await HerokuCI.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -118,7 +137,16 @@ describe("HerokuCI Params", () => {
       service: "heroku",
       slug: "testOrg/testRepo",
     };
-    const params = await HerokuCI.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Heroku-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await HerokuCI.getServiceParams(inputs, output);
     expect(expected).toBeTruthy();
     expect(params).toMatchObject(expected);
   });

--- a/packages/bundler-plugin-core/src/utils/providers/__tests__/JenkinsCI.test.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/__tests__/JenkinsCI.test.ts
@@ -7,6 +7,7 @@ import {
   type ProviderUtilInputs,
 } from "../../../types.ts";
 import { SPAWN_PROCESS_BUFFER_SIZE } from "../../constants.ts";
+import { Output } from "../../Output.ts";
 import * as JenkinsCI from "../JenkinsCI.ts";
 
 describe("Jenkins CI Params", () => {
@@ -68,7 +69,16 @@ describe("Jenkins CI Params", () => {
         maxBuffer: SPAWN_PROCESS_BUFFER_SIZE,
       }),
     ).thenReturn({ stdout: Buffer.from("") });
-    const params = await JenkinsCI.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Jenkins-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await JenkinsCI.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -93,7 +103,15 @@ describe("Jenkins CI Params", () => {
       stdout: Buffer.from("https://github.com/testOrg/testRepo.git"),
     });
 
-    const params = await JenkinsCI.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Jenkins-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await JenkinsCI.getServiceParams(inputs, output);
     expect(params.slug).toBe("testOrg/testRepo");
   });
 
@@ -124,7 +142,15 @@ describe("Jenkins CI Params", () => {
       slug: "testOrg/testRepo",
     };
 
-    const params = await JenkinsCI.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Jenkins-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await JenkinsCI.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -154,7 +180,15 @@ describe("Jenkins CI Params", () => {
       stdout: Buffer.from(""),
     });
 
-    const params = await JenkinsCI.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Jenkins-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await JenkinsCI.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 });

--- a/packages/bundler-plugin-core/src/utils/providers/__tests__/Local.test.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/__tests__/Local.test.ts
@@ -7,6 +7,7 @@ import {
   type ProviderUtilInputs,
 } from "../../../types.ts";
 import { SPAWN_PROCESS_BUFFER_SIZE } from "../../constants.ts";
+import { Output } from "../../Output.ts";
 import * as Local from "../Local.ts";
 
 describe("Local Params", () => {
@@ -60,7 +61,16 @@ describe("Local Params", () => {
       service: "",
       slug: "owner/repo",
     };
-    const params = await Local.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Local-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await Local.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -90,7 +100,15 @@ describe("Local Params", () => {
       slug: "owner/repo",
     };
 
-    const params = await Local.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Local-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await Local.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -99,8 +117,17 @@ describe("Local Params", () => {
       args: { ...createEmptyArgs() },
       envs: {},
     };
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Local-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
     const spawnSync = td.replace(childProcess, "spawnSync");
-    await expect(Local.getServiceParams(inputs)).rejects.toThrow();
+    await expect(Local.getServiceParams(inputs, output)).rejects.toThrow();
 
     td.when(
       spawnSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
@@ -109,7 +136,7 @@ describe("Local Params", () => {
     ).thenReturn({
       stdout: Buffer.from("main"),
     });
-    await expect(Local.getServiceParams(inputs)).rejects.toThrow();
+    await expect(Local.getServiceParams(inputs, output)).rejects.toThrow();
 
     td.when(
       spawnSync("git", ["rev-parse", "HEAD"], {
@@ -118,7 +145,7 @@ describe("Local Params", () => {
     ).thenReturn({
       stdout: Buffer.from("testSHA"),
     });
-    await expect(Local.getServiceParams(inputs)).rejects.toThrow();
+    await expect(Local.getServiceParams(inputs, output)).rejects.toThrow();
   });
 
   describe("getSlug()", () => {
@@ -154,7 +181,15 @@ describe("Local Params", () => {
         stdout: Buffer.from("testSHA"),
       });
 
-      const params = await Local.getServiceParams(inputs);
+      const output = new Output({
+        apiUrl: "http://localhost",
+        bundleName: "Local-test",
+        debug: false,
+        dryRun: true,
+        enableBundleAnalysis: true,
+        retryCount: 0,
+      });
+      const params = await Local.getServiceParams(inputs, output);
       expect(params.slug).toBe("testOrg/testRepo");
     });
 
@@ -184,7 +219,15 @@ describe("Local Params", () => {
         stdout: Buffer.from("testSHA"),
       });
 
-      await expect(Local.getServiceParams(inputs)).rejects.toThrow();
+      const output = new Output({
+        apiUrl: "http://localhost",
+        bundleName: "Local-test",
+        debug: false,
+        dryRun: true,
+        enableBundleAnalysis: true,
+        retryCount: 0,
+      });
+      await expect(Local.getServiceParams(inputs, output)).rejects.toThrow();
     });
 
     it("errors on a malformed slug", async () => {
@@ -214,7 +257,15 @@ describe("Local Params", () => {
         stdout: Buffer.from("testSHA"),
       });
 
-      const params = await Local.getServiceParams(inputs);
+      const output = new Output({
+        apiUrl: "http://localhost",
+        bundleName: "Local-test",
+        debug: false,
+        dryRun: true,
+        enableBundleAnalysis: true,
+        retryCount: 0,
+      });
+      const params = await Local.getServiceParams(inputs, output);
       expect(params.slug).toBe("testOrg/testRepo");
     });
   });

--- a/packages/bundler-plugin-core/src/utils/providers/__tests__/Netlify.test.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/__tests__/Netlify.test.ts
@@ -5,6 +5,7 @@ import {
   type ProviderServiceParams,
   type ProviderUtilInputs,
 } from "../../../types.ts";
+import { Output } from "../../Output.ts";
 import * as Netlify from "../Netlify.ts";
 
 describe("Netlify Params", () => {
@@ -58,7 +59,15 @@ describe("Netlify Params", () => {
       slug: "",
     };
 
-    const params = await Netlify.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Netlify-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await Netlify.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -90,7 +99,15 @@ describe("Netlify Params", () => {
       slug: "testOrg/testRepo",
     };
 
-    const params = await Netlify.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Netlify-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await Netlify.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -111,7 +128,15 @@ describe("Netlify Params", () => {
       slug: "",
     };
 
-    const params = await Netlify.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Netlify-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await Netlify.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 });

--- a/packages/bundler-plugin-core/src/utils/providers/__tests__/Render.test.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/__tests__/Render.test.ts
@@ -5,6 +5,7 @@ import {
   type ProviderServiceParams,
   type ProviderUtilInputs,
 } from "../../../types.ts";
+import { Output } from "../../Output.ts";
 import * as Render from "../Render.ts";
 
 describe("Render Params", () => {
@@ -58,7 +59,15 @@ describe("Render Params", () => {
       slug: "testOrg/testRepo",
     };
 
-    const params = await Render.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Render-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await Render.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -90,7 +99,15 @@ describe("Render Params", () => {
       slug: "testOrg/testRepo",
     };
 
-    const params = await Render.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Render-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await Render.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -111,7 +128,15 @@ describe("Render Params", () => {
       slug: "",
     };
 
-    const params = await Render.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Render-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await Render.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 });

--- a/packages/bundler-plugin-core/src/utils/providers/__tests__/TeamCity.test.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/__tests__/TeamCity.test.ts
@@ -7,6 +7,7 @@ import {
   type ProviderUtilInputs,
 } from "../../../types.ts";
 import { SPAWN_PROCESS_BUFFER_SIZE } from "../../constants.ts";
+import { Output } from "../../Output.ts";
 import * as TeamCity from "../TeamCity.ts";
 
 describe("TeamCity Params", () => {
@@ -64,7 +65,16 @@ describe("TeamCity Params", () => {
         maxBuffer: SPAWN_PROCESS_BUFFER_SIZE,
       }),
     ).thenReturn({ stdout: Buffer.from("") });
-    const params = await TeamCity.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "TeamCity-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await TeamCity.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -97,7 +107,16 @@ describe("TeamCity Params", () => {
     ).thenReturn({
       stdout: Buffer.from("https://github.com/testOrg/testRepo.git"),
     });
-    const params = await TeamCity.getServiceParams(inputs);
+
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "TeamCity-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await TeamCity.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -138,7 +157,15 @@ describe("TeamCity Params", () => {
       slug: "testOrg/testRepo",
     };
 
-    const params = await TeamCity.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "TeamCity-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await TeamCity.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -166,7 +193,15 @@ describe("TeamCity Params", () => {
       slug: "",
     };
 
-    const params = await TeamCity.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "TeamCity-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await TeamCity.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 });

--- a/packages/bundler-plugin-core/src/utils/providers/__tests__/TravisCI.test.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/__tests__/TravisCI.test.ts
@@ -5,6 +5,7 @@ import {
   type ProviderServiceParams,
   type ProviderUtilInputs,
 } from "../../../types.ts";
+import { Output } from "../../Output.ts";
 import * as TravisCI from "../TravisCI.ts";
 
 describe("TravisCI Params", () => {
@@ -75,7 +76,15 @@ describe("TravisCI Params", () => {
       slug: "testOrg/testRepo",
     };
 
-    const params = await TravisCI.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "TravisCI-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await TravisCI.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -108,7 +117,15 @@ describe("TravisCI Params", () => {
       slug: "testOrg/testRepo",
     };
 
-    const params = await TravisCI.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "TravisCI-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await TravisCI.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -140,7 +157,15 @@ describe("TravisCI Params", () => {
       slug: "testOrg/testRepo",
     };
 
-    const params = await TravisCI.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "TravisCI-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await TravisCI.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -173,7 +198,15 @@ describe("TravisCI Params", () => {
       slug: "testOrg/testRepo",
     };
 
-    const params = await TravisCI.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "TravisCI-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await TravisCI.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -194,7 +227,15 @@ describe("TravisCI Params", () => {
       slug: "",
     };
 
-    const params = await TravisCI.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "TravisCI-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await TravisCI.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 });

--- a/packages/bundler-plugin-core/src/utils/providers/__tests__/Vercel.test.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/__tests__/Vercel.test.ts
@@ -5,6 +5,7 @@ import {
   type ProviderServiceParams,
   type ProviderUtilInputs,
 } from "../../../types.ts";
+import { Output } from "../../Output.ts";
 import * as Vercel from "../Vercel.ts";
 
 describe("Vercel Params", () => {
@@ -59,7 +60,15 @@ describe("Vercel Params", () => {
       slug: "testOrg/testRepo",
     };
 
-    const params = await Vercel.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Vercel-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await Vercel.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -92,7 +101,15 @@ describe("Vercel Params", () => {
       slug: "testOrg/testRepo",
     };
 
-    const params = await Vercel.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Vercel-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await Vercel.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -113,7 +130,15 @@ describe("Vercel Params", () => {
       slug: "",
     };
 
-    const params = await Vercel.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Vercel-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await Vercel.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 });

--- a/packages/bundler-plugin-core/src/utils/providers/__tests__/Werker.test.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/__tests__/Werker.test.ts
@@ -5,6 +5,7 @@ import {
   type ProviderServiceParams,
   type ProviderUtilInputs,
 } from "../../../types.ts";
+import { Output } from "../../Output.ts";
 import * as Wercker from "../Wercker.ts";
 
 describe("Wercker CI Params", () => {
@@ -60,7 +61,15 @@ describe("Wercker CI Params", () => {
       slug: "testOrg/testRepo",
     };
 
-    const params = await Wercker.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Wercker-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await Wercker.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -98,7 +107,15 @@ describe("Wercker CI Params", () => {
       slug: "testOrg/testRepo",
     };
 
-    const params = await Wercker.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Wercker-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await Wercker.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -118,7 +135,15 @@ describe("Wercker CI Params", () => {
       slug: "",
     };
 
-    const params = await Wercker.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Wercker-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await Wercker.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 });

--- a/packages/bundler-plugin-core/src/utils/providers/__tests__/Woodpecker.test.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/__tests__/Woodpecker.test.ts
@@ -5,6 +5,7 @@ import {
   type ProviderServiceParams,
   type ProviderUtilInputs,
 } from "../../../types.ts";
+import { Output } from "../../Output.ts";
 import * as providerWoodpecker from "../Woodpecker.ts";
 
 describe("Woodpecker Params", () => {
@@ -61,7 +62,15 @@ describe("Woodpecker Params", () => {
       slug: "testOrg/testRepo",
     };
 
-    const params = await providerWoodpecker.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Woodpecker-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await providerWoodpecker.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -94,7 +103,15 @@ describe("Woodpecker Params", () => {
       slug: "testOrg/testRepo",
     };
 
-    const params = await providerWoodpecker.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Woodpecker-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await providerWoodpecker.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 
@@ -114,7 +131,15 @@ describe("Woodpecker Params", () => {
       slug: "",
     };
 
-    const params = await providerWoodpecker.getServiceParams(inputs);
+    const output = new Output({
+      apiUrl: "http://localhost",
+      bundleName: "Woodpecker-test",
+      debug: false,
+      dryRun: true,
+      enableBundleAnalysis: true,
+      retryCount: 0,
+    });
+    const params = await providerWoodpecker.getServiceParams(inputs, output);
     expect(params).toMatchObject(expected);
   });
 });

--- a/packages/bundler-plugin-core/src/utils/providers/__tests__/Woodpecker.test.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/__tests__/Woodpecker.test.ts
@@ -76,7 +76,16 @@ describe("Woodpecker Params", () => {
 
   it("gets correct params for overrides", async () => {
     const inputs: ProviderUtilInputs = {
-      args: { ...createEmptyArgs() },
+      args: {
+        ...createEmptyArgs(),
+        ...{
+          branch: "latest-feature",
+          build: "4",
+          pr: "123",
+          sha: "sha-123",
+          slug: "cool-slug",
+        },
+      },
       envs: {
         CI: "woodpecker",
         CI_COMMIT_BRANCH: "master",
@@ -92,15 +101,15 @@ describe("Woodpecker Params", () => {
     };
 
     const expected: ProviderServiceParams = {
-      branch: "new-feature",
-      build: "2",
+      branch: "latest-feature",
+      build: "4",
       buildURL:
         "https://ci.woodpecker-ci.org/woodpecker-ci/woodpecker/build/1629",
-      commit: "testingsha",
+      commit: "sha-123",
       job: "20",
-      pr: "1",
+      pr: "123",
       service: "woodpecker",
-      slug: "testOrg/testRepo",
+      slug: "cool-slug",
     };
 
     const output = new Output({

--- a/packages/bundler-plugin-core/src/utils/providers/__tests__/index.test.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/__tests__/index.test.ts
@@ -5,6 +5,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 
 import { createEmptyArgs } from "@test-utils/helpers.ts";
 import { type ProviderUtilInputs } from "../../../types.ts";
+import { Output } from "../../Output.ts";
 import { providerList } from "../index.ts";
 
 const server = setupServer(
@@ -61,7 +62,16 @@ describe("CI Providers", () => {
           },
         };
 
-        const serviceParams = await provider.getServiceParams(inputs);
+        const output = new Output({
+          apiUrl: "http://localhost",
+          bundleName: "service-test",
+          debug: false,
+          dryRun: true,
+          enableBundleAnalysis: true,
+          retryCount: 0,
+        });
+
+        const serviceParams = await provider.getServiceParams(inputs, output);
 
         expect(serviceParams).not.toBeNull();
         expect(serviceParams.commit).toEqual(inputs?.args?.sha);
@@ -80,7 +90,16 @@ describe("CI Providers", () => {
           },
         };
 
-        const serviceParams = await provider.getServiceParams(inputs);
+        const output = new Output({
+          apiUrl: "http://localhost",
+          bundleName: "service-test",
+          debug: false,
+          dryRun: true,
+          enableBundleAnalysis: true,
+          retryCount: 0,
+        });
+
+        const serviceParams = await provider.getServiceParams(inputs, output);
 
         expect(serviceParams).not.toBeNull();
         expect(serviceParams.slug).toEqual(inputs?.args?.slug);


### PR DESCRIPTION
# Description

This PR adds back in debug logs for to inform the user of what commit sha has been chosen, as well as some extra logs around which commit sha is being chosen in cases like GH merge commits, so we can debug some issues around the wrong commit being selected.

Closes codecov/engineering-team#1751

# Notable Changes

- Allow `debug` log util to be enabled/disabled depending on passed in debug setting
- Update CI providers to log out how the commit sha is chosen and which sha is being used
- Update tests
- Small tweaks  
