### PR TITLE
feat: Hard fail on invalid bundle names

### DIFF
--- a/.changeset/two-spies-talk.md
+++ b/.changeset/two-spies-talk.md
@@ -1,0 +1,10 @@
+---
+"@codecov/bundler-plugin-core": patch
+"@codecov/sveltekit-plugin": patch
+"@codecov/webpack-plugin": patch
+"@codecov/rollup-plugin": patch
+"@codecov/nuxt-plugin": patch
+"@codecov/vite-plugin": patch
+---
+
+When a user submits a invalid bundle name, we will hard fail and exit the bundle process now.

--- a/integration-tests/fixtures/generate-bundle-stats/nuxt/nuxt-plugin.test.ts
+++ b/integration-tests/fixtures/generate-bundle-stats/nuxt/nuxt-plugin.test.ts
@@ -152,7 +152,8 @@ describe("Generating nuxt stats", () => {
       beforeEach(async () => {
         const config = new GenerateConfig({
           // nuxt uses vite under the hood
-          bundler: "nuxt",
+          plugin: "nuxt",
+          configFileName: "nuxt",
           format: "esm",
           detectFormat: "esm",
           version: `v3`,
@@ -173,7 +174,7 @@ describe("Generating nuxt stats", () => {
       });
 
       it(
-        "matches the snapshot",
+        "warns users and exits process with a code 1",
         async () => {
           const id = `nuxt-v${version}-${Date.now()}`;
           const API_URL = `http://localhost:8000/test-url/${id}/200/false`;

--- a/integration-tests/fixtures/generate-bundle-stats/nuxt/nuxt-plugin.test.ts
+++ b/integration-tests/fixtures/generate-bundle-stats/nuxt/nuxt-plugin.test.ts
@@ -147,5 +147,49 @@ describe("Generating nuxt stats", () => {
         { timeout: 25_000 },
       );
     });
+
+    describe("invalid bundle name is passed", () => {
+      beforeEach(async () => {
+        const config = new GenerateConfig({
+          // nuxt uses vite under the hood
+          bundler: "nuxt",
+          format: "esm",
+          detectFormat: "esm",
+          version: `v3`,
+          detectVersion: "v3",
+          file_format: "ts",
+          enableSourceMaps: false,
+          overrideOutputPath: `${nuxtApp}/nuxt.config.ts`,
+        });
+
+        await config.createConfig();
+        config.removeBundleName(`test-nuxt-v${version}`);
+        await config.writeConfig();
+      });
+
+      afterEach(async () => {
+        await $`rm -rf ${nuxtApp}/nuxt.config.ts`;
+        await $`rm -rf ${nuxtApp}/distV${version}`;
+      });
+
+      it(
+        "matches the snapshot",
+        async () => {
+          const id = `nuxt-v${version}-${Date.now()}`;
+          const API_URL = `http://localhost:8000/test-url/${id}/200/false`;
+
+          // prepare and build the app
+          const { exitCode } =
+            await $`cd test-apps/nuxt && API_URL=${API_URL} pnpm run build`.nothrow();
+
+          expect(exitCode).toBe(1);
+          // for some reason this isn't being outputted in the test env
+          // expect(stdout.toString()).toContain(
+          //   "[codecov] bundleName: `` does not match format: `/^[wd_:/@.{}[]$-]+$/`.",
+          // );
+        },
+        { timeout: 25_000 },
+      );
+    });
   });
 });

--- a/integration-tests/fixtures/generate-bundle-stats/rollup/rollup-plugin.test.ts
+++ b/integration-tests/fixtures/generate-bundle-stats/rollup/rollup-plugin.test.ts
@@ -129,7 +129,8 @@ describe("Generating rollup stats", () => {
     describe("passing invalid bundle name", () => {
       beforeEach(async () => {
         const config = new GenerateConfig({
-          bundler: "rollup",
+          plugin: "rollup",
+          configFileName: "rollup",
           format: "esm",
           detectFormat: "esm",
           version: `v${version}`,

--- a/integration-tests/fixtures/generate-bundle-stats/vite/vite-plugin.test.ts
+++ b/integration-tests/fixtures/generate-bundle-stats/vite/vite-plugin.test.ts
@@ -128,7 +128,8 @@ describe("Generating vite stats", () => {
     describe("invalid bundle name is passed", () => {
       beforeEach(async () => {
         const config = new GenerateConfig({
-          bundler: "vite",
+          plugin: "vite",
+          configFileName: "vite",
           format: "esm",
           detectFormat: "esm",
           version: `v${version}`,

--- a/integration-tests/fixtures/generate-bundle-stats/vite/vite-plugin.test.ts
+++ b/integration-tests/fixtures/generate-bundle-stats/vite/vite-plugin.test.ts
@@ -6,7 +6,7 @@ import { GenerateConfig } from "../../../scripts/gen-config";
 const vitePath = (version: number) =>
   `node_modules/viteV${version}/bin/vite.js`;
 const viteConfig = (version: number, format: string) =>
-  `fixtures/generate-bundle-stats/vite/vite-v${version}-${format}.config.ts`;
+  `fixtures/generate-bundle-stats/vite/vite-v${version}-${format}.config.*`;
 const viteApp = "test-apps/vite";
 
 const VERSIONS = [4, 5];
@@ -122,6 +122,45 @@ describe("Generating vite stats", () => {
             name: expect.stringMatching("@codecov/vite-plugin"),
           },
         });
+      });
+    });
+
+    describe("invalid bundle name is passed", () => {
+      beforeEach(async () => {
+        const config = new GenerateConfig({
+          bundler: "vite",
+          format: "esm",
+          detectFormat: "esm",
+          version: `v${version}`,
+          detectVersion: "v5",
+          file_format: "ts",
+          enableSourceMaps: true,
+        });
+
+        await config.createConfig();
+        config.removeBundleName(`test-vite-v${version}`);
+        await config.writeConfig();
+      });
+
+      afterEach(async () => {
+        await $`rm -rf ${viteConfig(version, "esm")}`;
+        await $`rm -rf ${viteApp}/distV${version}`;
+      });
+
+      it("warns users and exits process with a code 1", async () => {
+        const id = `vite-v${version}-sourcemaps-${Date.now()}`;
+        const vite = vitePath(version);
+        const configFile = viteConfig(version, "esm");
+        const API_URL = `http://localhost:8000/test-url/${id}/200/false`;
+
+        // build the app
+        const { exitCode, stdout } =
+          await $`API_URL=${API_URL} node ${vite} build -c ${configFile}`.nothrow();
+
+        expect(exitCode).toBe(1);
+        expect(stdout.toString()).toContain(
+          "[codecov] bundleName: `` does not match format: `/^[wd_:/@.{}[]$-]+$/`.",
+        );
       });
     });
   });

--- a/integration-tests/fixtures/generate-bundle-stats/webpack/webpack-plugin.test.ts
+++ b/integration-tests/fixtures/generate-bundle-stats/webpack/webpack-plugin.test.ts
@@ -6,7 +6,7 @@ import { GenerateConfig } from "../../../scripts/gen-config";
 const webpackPath = (version: number) =>
   `node_modules/webpackV${version}/bin/webpack.js`;
 const webpackConfig = (version: number, format: string) =>
-  `fixtures/generate-bundle-stats/webpack/webpack-v${version}-${format}.config.cjs`;
+  `fixtures/generate-bundle-stats/webpack/webpack-v${version}-${format}.config.*`;
 const webpackApp = "test-apps/webpack";
 
 const VERSIONS = [5];
@@ -114,6 +114,45 @@ describe("Generating webpack stats", () => {
             name: expect.stringMatching("@codecov/webpack-plugin"),
           },
         });
+      });
+    });
+
+    describe("invalid bundle name is passed", () => {
+      beforeEach(async () => {
+        const config = new GenerateConfig({
+          bundler: "webpack",
+          format: "module",
+          detectFormat: "commonjs",
+          version: `v${version}`,
+          detectVersion: "v5",
+          file_format: "cjs",
+          enableSourceMaps: false,
+        });
+
+        await config.createConfig();
+        config.removeBundleName(`test-webpack-v${version}`);
+        await config.writeConfig();
+      });
+
+      afterEach(async () => {
+        await $`rm -rf ${webpackConfig(version, "module")}`;
+        await $`rm -rf ${webpackApp}/distV${version}`;
+      });
+
+      it("warns users and exits process with a code 1", async () => {
+        const id = `webpack-v${version}-sourcemaps-${Date.now()}`;
+        const webpack = webpackPath(version);
+        const configFile = webpackConfig(version, "module");
+        const API_URL = `http://localhost:8000/test-url/${id}/200/false`;
+
+        // build the app
+        const { exitCode, stdout } =
+          await $`API_URL=${API_URL} node ${webpack} --config ${configFile}`.nothrow();
+
+        expect(exitCode).toBe(1);
+        expect(stdout.toString()).toContain(
+          "[codecov] bundleName: `` does not match format: `/^[wd_:/@.{}[]$-]+$/`.",
+        );
       });
     });
   });

--- a/integration-tests/fixtures/generate-bundle-stats/webpack/webpack-plugin.test.ts
+++ b/integration-tests/fixtures/generate-bundle-stats/webpack/webpack-plugin.test.ts
@@ -120,7 +120,8 @@ describe("Generating webpack stats", () => {
     describe("invalid bundle name is passed", () => {
       beforeEach(async () => {
         const config = new GenerateConfig({
-          bundler: "webpack",
+          plugin: "webpack",
+          configFileName: "webpack",
           format: "module",
           detectFormat: "commonjs",
           version: `v${version}`,

--- a/integration-tests/scripts/gen-config.ts
+++ b/integration-tests/scripts/gen-config.ts
@@ -114,6 +114,15 @@ export class GenerateConfig {
     return this.newConfigContents;
   }
 
+  removeBundleName(bundleName: string) {
+    if (typeof this.newConfigContents === "string") {
+      this.newConfigContents = this.newConfigContents.replaceAll(
+        bundleName,
+        "",
+      );
+    }
+  }
+
   async writeConfig() {
     if (typeof this.newConfigContents === "string") {
       await Bun.write(this.outFilePath, this.newConfigContents);

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -1,26 +1,33 @@
 import {
   type Asset,
+  type BundleAnalysisUploadPlugin,
   type Chunk,
   type Module,
   type Options,
   type ProviderUtilInputs,
   type UploadOverrides,
-  type BundleAnalysisUploadPlugin,
 } from "./types.ts";
 import { checkNodeVersion } from "./utils/checkNodeVersion.ts";
 import { red } from "./utils/logging.ts";
-import { normalizeOptions } from "./utils/normalizeOptions.ts";
+import { handleErrors, normalizeOptions } from "./utils/normalizeOptions.ts";
 import { normalizePath } from "./utils/normalizePath.ts";
 import { Output } from "./utils/Output.ts";
 
 export type {
   Asset,
+  BundleAnalysisUploadPlugin,
   Chunk,
   Module,
   Options,
   ProviderUtilInputs,
   UploadOverrides,
-  BundleAnalysisUploadPlugin,
 };
 
-export { checkNodeVersion, normalizeOptions, normalizePath, red, Output };
+export {
+  checkNodeVersion,
+  handleErrors,
+  normalizeOptions,
+  normalizePath,
+  Output,
+  red,
+};

--- a/packages/bundler-plugin-core/src/utils/__tests__/normalizeOptions.test.ts
+++ b/packages/bundler-plugin-core/src/utils/__tests__/normalizeOptions.test.ts
@@ -207,17 +207,12 @@ describe("normalizeOptions", () => {
 
 describe("handleErrors", () => {
   let consoleSpy: MockInstance;
-  let processExitSpy: MockInstance<[code?: number], never>;
 
   beforeEach(() => {
     consoleSpy = vi.spyOn(console, "log");
-    processExitSpy = vi
-      .spyOn(process, "exit")
-      .mockImplementation(() => undefined as never);
   });
 
   afterEach(() => {
-    processExitSpy.mockReset();
     consoleSpy.mockReset();
   });
 
@@ -236,14 +231,38 @@ describe("handleErrors", () => {
       );
     });
 
-    it("exits the process with status code 1", () => {
+    it("returns shouldExit as true", () => {
+      const { shouldExit } = handleErrors({
+        success: false,
+        errors: [
+          "`bundleName` is required for uploading bundle analysis information.",
+        ],
+      });
+      expect(shouldExit).toBeTruthy();
+    });
+  });
+
+  describe("there is no bundleName error", () => {
+    it("logs out the error message", () => {
       handleErrors({
         success: false,
         errors: [
           "`bundleName` is required for uploading bundle analysis information.",
         ],
       });
-      expect(processExitSpy).toHaveBeenCalledWith(1);
+
+      expect(consoleSpy).toHaveBeenCalled();
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "[codecov] `bundleName` is required for uploading bundle analysis information.",
+      );
+    });
+
+    it("returns shouldExit as false", () => {
+      const { shouldExit } = handleErrors({
+        success: false,
+        errors: ["random error"],
+      });
+      expect(shouldExit).toBeFalsy();
     });
   });
 });

--- a/packages/bundler-plugin-core/src/utils/normalizeOptions.ts
+++ b/packages/bundler-plugin-core/src/utils/normalizeOptions.ts
@@ -142,23 +142,21 @@ export const normalizeOptions = (
 };
 
 /**
- * This function logs the errors to the console, and will exit if there are any `bundleName` errors.
+ * This function logs the errors to the console, and will return `shouldExit` if there are errors
+ * that we should exit the build process for.
  *
  * @param {NormalizedOptionsFailure} options - The normalized options that failed validation.
  */
 export const handleErrors = (options: NormalizedOptionsFailure) => {
-  let hasBundleNameError = false;
+  let shouldExit = false;
   // we probably don't want to exit early so we can provide all the errors to the user
   for (const error of options.errors) {
     // if the error is related to the bundleName, we should set a flag
     if (error.includes("bundleName")) {
-      hasBundleNameError = true;
+      shouldExit = true;
     }
     red(error);
   }
 
-  // since bundle names are required, we should exit if the bundleName fails validation
-  if (hasBundleNameError) {
-    process.exit(1);
-  }
+  return { shouldExit };
 };

--- a/packages/nuxt-plugin/src/index.ts
+++ b/packages/nuxt-plugin/src/index.ts
@@ -3,9 +3,9 @@ import { type UnpluginOptions, createVitePlugin } from "unplugin";
 import {
   type Options,
   normalizeOptions,
-  red,
   checkNodeVersion,
   Output,
+  handleErrors,
 } from "@codecov/bundler-plugin-core";
 import { _internal_viteBundleAnalysisPlugin } from "@codecov/vite-plugin";
 import { addVitePlugin, defineNuxtModule } from "@nuxt/kit";
@@ -24,9 +24,7 @@ const codecovNuxtPluginFactory = createVitePlugin<Options, true>(
 
     const normalizedOptions = normalizeOptions(userOptions);
     if (!normalizedOptions.success) {
-      for (const error of normalizedOptions.errors) {
-        red(error);
-      }
+      handleErrors(normalizedOptions);
       return [];
     }
 

--- a/packages/nuxt-plugin/src/index.ts
+++ b/packages/nuxt-plugin/src/index.ts
@@ -24,7 +24,11 @@ const codecovNuxtPluginFactory = createVitePlugin<Options, true>(
 
     const normalizedOptions = normalizeOptions(userOptions);
     if (!normalizedOptions.success) {
-      handleErrors(normalizedOptions);
+      const { shouldExit } = handleErrors(normalizedOptions);
+
+      if (shouldExit) {
+        process.exit(1);
+      }
       return [];
     }
 

--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -6,10 +6,10 @@ import {
 } from "unplugin";
 import {
   normalizeOptions,
-  red,
   type Options,
   checkNodeVersion,
   Output,
+  handleErrors,
 } from "@codecov/bundler-plugin-core";
 
 import { rollupBundleAnalysisPlugin } from "./rollup-bundle-analysis/rollupBundleAnalysisPlugin";
@@ -22,9 +22,7 @@ const codecovRollupPluginFactory = createRollupPlugin<Options, true>(
 
     const normalizedOptions = normalizeOptions(userOptions);
     if (!normalizedOptions.success) {
-      for (const error of normalizedOptions.errors) {
-        red(error);
-      }
+      handleErrors(normalizedOptions);
       return [];
     }
 

--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -22,7 +22,11 @@ const codecovRollupPluginFactory = createRollupPlugin<Options, true>(
 
     const normalizedOptions = normalizeOptions(userOptions);
     if (!normalizedOptions.success) {
-      handleErrors(normalizedOptions);
+      const { shouldExit } = handleErrors(normalizedOptions);
+
+      if (shouldExit) {
+        process.exit(1);
+      }
       return [];
     }
 

--- a/packages/sveltekit-plugin/src/index.ts
+++ b/packages/sveltekit-plugin/src/index.ts
@@ -23,7 +23,11 @@ const codecovSvelteKitPluginFactory = createVitePlugin<Options, true>(
 
     const normalizedOptions = normalizeOptions(userOptions);
     if (!normalizedOptions.success) {
-      handleErrors(normalizedOptions);
+      const { shouldExit } = handleErrors(normalizedOptions);
+
+      if (shouldExit) {
+        process.exit(1);
+      }
       return [];
     }
 

--- a/packages/sveltekit-plugin/src/index.ts
+++ b/packages/sveltekit-plugin/src/index.ts
@@ -7,9 +7,9 @@ import {
 import {
   type Options,
   normalizeOptions,
-  red,
   checkNodeVersion,
   Output,
+  handleErrors,
 } from "@codecov/bundler-plugin-core";
 import { _internal_viteBundleAnalysisPlugin } from "@codecov/vite-plugin";
 
@@ -23,9 +23,7 @@ const codecovSvelteKitPluginFactory = createVitePlugin<Options, true>(
 
     const normalizedOptions = normalizeOptions(userOptions);
     if (!normalizedOptions.success) {
-      for (const error of normalizedOptions.errors) {
-        red(error);
-      }
+      handleErrors(normalizedOptions);
       return [];
     }
 

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -7,9 +7,9 @@ import {
 import {
   type Options,
   normalizeOptions,
-  red,
   checkNodeVersion,
   Output,
+  handleErrors,
 } from "@codecov/bundler-plugin-core";
 
 import { viteBundleAnalysisPlugin } from "./vite-bundle-analysis/viteBundleAnalysisPlugin";
@@ -22,16 +22,14 @@ const codecovVitePluginFactory = createVitePlugin<Options, true>(
 
     const normalizedOptions = normalizeOptions(userOptions);
     if (!normalizedOptions.success) {
-      for (const error of normalizedOptions.errors) {
-        red(error);
-      }
+      handleErrors(normalizedOptions);
       return [];
     }
 
     const plugins: UnpluginOptions[] = [];
-    const output = new Output(normalizedOptions.options);
     const options = normalizedOptions.options;
     if (options.enableBundleAnalysis) {
+      const output = new Output(normalizedOptions.options);
       plugins.push(viteBundleAnalysisPlugin({ output }));
     }
 

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -22,7 +22,11 @@ const codecovVitePluginFactory = createVitePlugin<Options, true>(
 
     const normalizedOptions = normalizeOptions(userOptions);
     if (!normalizedOptions.success) {
-      handleErrors(normalizedOptions);
+      const { shouldExit } = handleErrors(normalizedOptions);
+
+      if (shouldExit) {
+        process.exit(1);
+      }
       return [];
     }
 

--- a/packages/webpack-plugin/src/index.ts
+++ b/packages/webpack-plugin/src/index.ts
@@ -6,10 +6,10 @@ import {
 } from "unplugin";
 import {
   normalizeOptions,
-  red,
   type Options,
   checkNodeVersion,
   Output,
+  handleErrors,
 } from "@codecov/bundler-plugin-core";
 
 import { webpackBundleAnalysisPlugin } from "./webpack-bundle-analysis/webpackBundleAnalysisPlugin";
@@ -22,9 +22,7 @@ const codecovWebpackPluginFactory = createWebpackPlugin<Options, true>(
 
     const normalizedOptions = normalizeOptions(userOptions);
     if (!normalizedOptions.success) {
-      for (const error of normalizedOptions.errors) {
-        red(error);
-      }
+      handleErrors(normalizedOptions);
       return [];
     }
 

--- a/packages/webpack-plugin/src/index.ts
+++ b/packages/webpack-plugin/src/index.ts
@@ -22,7 +22,11 @@ const codecovWebpackPluginFactory = createWebpackPlugin<Options, true>(
 
     const normalizedOptions = normalizeOptions(userOptions);
     if (!normalizedOptions.success) {
-      handleErrors(normalizedOptions);
+      const { shouldExit } = handleErrors(normalizedOptions);
+
+      if (shouldExit) {
+        process.exit(1);
+      }
       return [];
     }
 


### PR DESCRIPTION
# Description

This PR updates the plugins to hard fail when a user passes an invalid bundle name, exiting the process. This is a small change, but should really help people when setting up the bundler plugins if they're not getting any data in Codecov but still seeing checkmarks across their CI.

Closes #124

# Notable Changes

- Add in new `handleErrors` function the plugin core
- Use new function in the various plugins
- Add in integration tests