### PR TITLE
fix: Handle [extname] in normalizePath function

### DIFF
--- a/.changeset/thirty-cheetahs-teach.md
+++ b/.changeset/thirty-cheetahs-teach.md
@@ -1,0 +1,10 @@
+---
+"@codecov/bundler-plugin-core": patch
+"@codecov/nuxt-plugin": patch
+"@codecov/rollup-plugin": patch
+"@codecov/sveltekit-plugin": patch
+"@codecov/vite-plugin": patch
+"@codecov/webpack-plugin": patch
+---
+
+Update normalizePath function to handle [hash][extname] case.

--- a/packages/bundler-plugin-core/src/utils/__tests__/normalizePath.test.ts
+++ b/packages/bundler-plugin-core/src/utils/__tests__/normalizePath.test.ts
@@ -67,6 +67,14 @@ const tests: Test[] = [
     },
     expected: "test.*.chunk.js",
   },
+  {
+    name: "handle case where [extname] is used",
+    input: {
+      path: "test.12345678.js",
+      format: "[name].[hash][extname]",
+    },
+    expected: "test.*.js",
+  },
 ];
 
 describe("normalizePath", () => {

--- a/packages/bundler-plugin-core/src/utils/normalizePath.ts
+++ b/packages/bundler-plugin-core/src/utils/normalizePath.ts
@@ -34,8 +34,11 @@ export const normalizePath = (path: string, format: string): string => {
     )})`;
 
     // grab the ending delimiter and create a regex group for it
-    const endingDelimiter =
+    let endingDelimiter =
       format.at(match.hashIndex + match.hashString.length) ?? "";
+    if (endingDelimiter === "[") {
+      endingDelimiter = ".";
+    }
     const endingRegex = `(?<endingDelimiter>${escapeRegex(endingDelimiter)})`;
 
     // create a regex that will match the hash


### PR DESCRIPTION
# Description

Small fix to the `normalizePath` function where we didn't handle the case where the format string could be `[name].[hash][extname`.

# Notable Changes

- Update `normalizePath` function to handle this case
- Update tests