### PR TITLE
build: Upload Nuxt and SvelteKit example stats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,8 +327,12 @@ jobs:
         env:
           NEXT_UPLOAD_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
           NEXT_API_URL: ${{ secrets.CODECOV_API_URL }}
+          NUXT_UPLOAD_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
+          NUXT_API_URL: ${{ secrets.CODECOV_API_URL }}
           ROLLUP_UPLOAD_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
           ROLLUP_API_URL: ${{ secrets.CODECOV_API_URL }}
+          SVELTEKIT_UPLOAD_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
+          SVELTEKIT_API_URL: ${{ secrets.CODECOV_API_URL }}
           VITE_UPLOAD_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
           VITE_API_URL: ${{ secrets.CODECOV_API_URL }}
           WEBPACK_UPLOAD_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
@@ -390,8 +394,12 @@ jobs:
         env:
           NEXT_UPLOAD_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN_STAGING }}
           NEXT_API_URL: ${{ secrets.CODECOV_STAGING_API_URL }}
+          NUXT_UPLOAD_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
+          NUXT_API_URL: ${{ secrets.CODECOV_API_URL }}
           ROLLUP_UPLOAD_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN_STAGING }}
           ROLLUP_API_URL: ${{ secrets.CODECOV_STAGING_API_URL }}
+          SVELTEKIT_UPLOAD_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN }}
+          SVELTEKIT_API_URL: ${{ secrets.CODECOV_API_URL }}
           VITE_UPLOAD_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN_STAGING }}
           VITE_API_URL: ${{ secrets.CODECOV_STAGING_API_URL }}
           WEBPACK_UPLOAD_TOKEN: ${{ secrets.CODECOV_ORG_TOKEN_STAGING }}

--- a/examples/nuxt/nuxt.config.ts
+++ b/examples/nuxt/nuxt.config.ts
@@ -5,7 +5,6 @@ export default defineNuxtConfig({
     [
       "@codecov/nuxt-plugin",
       {
-        dryRun: true,
         enableBundleAnalysis: true,
         bundleName: "@codecov/example-nuxt-app",
         uploadToken: process.env.VITE_UPLOAD_TOKEN,

--- a/examples/nuxt/nuxt.config.ts
+++ b/examples/nuxt/nuxt.config.ts
@@ -7,8 +7,8 @@ export default defineNuxtConfig({
       {
         enableBundleAnalysis: true,
         bundleName: "@codecov/example-nuxt-app",
-        uploadToken: process.env.VITE_UPLOAD_TOKEN,
-        apiUrl: process.env.VITE_API_URL,
+        uploadToken: process.env.NUXT_UPLOAD_TOKEN,
+        apiUrl: process.env.NUXT_API_URL,
       },
     ],
   ],

--- a/examples/sveltekit/vite.config.ts
+++ b/examples/sveltekit/vite.config.ts
@@ -6,7 +6,6 @@ export default defineConfig({
   plugins: [
     sveltekit(),
     codecovSvelteKitPlugin({
-      dryRun: true,
       enableBundleAnalysis: true,
       uploadToken: "test-token",
       bundleName: "@codecov/example-sveltekit-app",

--- a/examples/sveltekit/vite.config.ts
+++ b/examples/sveltekit/vite.config.ts
@@ -7,8 +7,9 @@ export default defineConfig({
     sveltekit(),
     codecovSvelteKitPlugin({
       enableBundleAnalysis: true,
-      uploadToken: "test-token",
       bundleName: "@codecov/example-sveltekit-app",
+      uploadToken: process.env.SVELTEKIT_UPLOAD_TOKEN,
+      apiUrl: process.env.SVELTEKIT_API_URL,
     }),
   ],
 });


### PR DESCRIPTION
# Description

Welp forgot to remove these `dryRun` settings in the Nuxt, and SvelteKit example apps, this PR just removes those and actually uploads the stats.
