### PR TITLE
feat: Collect gzip info in bundler plugins

### DIFF
--- a/.changeset/old-cameras-search.md
+++ b/.changeset/old-cameras-search.md
@@ -1,0 +1,11 @@
+---
+"@codecov/bundler-plugin-core": patch
+"@codecov/webpack-plugin": patch
+"@codecov/rollup-plugin": patch
+"@codecov/vite-plugin": patch
+"@codecov/nuxt-plugin": patch
+"@codecov/remix-vite-plugin": patch
+"@codecov/sveltekit-plugin": patch
+---
+
+Adjust asset type to contain gzipSize, add new function to collect gzip values

--- a/.changeset/stupid-points-vanish.md
+++ b/.changeset/stupid-points-vanish.md
@@ -8,4 +8,4 @@
 "@codecov/vite-plugin": patch
 ---
 
-Collect gzip information in plugins
+Set version from passed output arg, and collect gzip information in plugins

--- a/.changeset/stupid-points-vanish.md
+++ b/.changeset/stupid-points-vanish.md
@@ -1,0 +1,11 @@
+---
+"@codecov/bundler-plugin-core": patch
+"@codecov/remix-vite-plugin": patch
+"@codecov/sveltekit-plugin": patch
+"@codecov/webpack-plugin": patch
+"@codecov/rollup-plugin": patch
+"@codecov/nuxt-plugin": patch
+"@codecov/vite-plugin": patch
+---
+
+Collect gzip information in plugins

--- a/.changeset/wise-insects-accept.md
+++ b/.changeset/wise-insects-accept.md
@@ -1,0 +1,11 @@
+---
+"@codecov/bundler-plugin-core": patch
+"@codecov/remix-vite-plugin": patch
+"@codecov/sveltekit-plugin": patch
+"@codecov/webpack-plugin": patch
+"@codecov/rollup-plugin": patch
+"@codecov/nuxt-plugin": patch
+"@codecov/vite-plugin": patch
+---
+
+Update meta-framework plugins to collect version generated in output arg

--- a/integration-tests/fixtures/generate-bundle-stats/nuxt/__snapshots__/nuxt-plugin.test.ts.snap
+++ b/integration-tests/fixtures/generate-bundle-stats/nuxt/__snapshots__/nuxt-plugin.test.ts.snap
@@ -17,7 +17,7 @@ exports[`Generating nuxt stats 3 {"format":"amd","expected":"amd"} matches the s
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -38,7 +38,7 @@ exports[`Generating nuxt stats 3 {"format":"amd","expected":"amd"} matches the s
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -59,7 +59,7 @@ exports[`Generating nuxt stats 3 {"format":"cjs","expected":"cjs"} matches the s
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -80,7 +80,7 @@ exports[`Generating nuxt stats 3 {"format":"cjs","expected":"cjs"} matches the s
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -101,7 +101,7 @@ exports[`Generating nuxt stats 3 {"format":"es","expected":"esm"} matches the sn
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -122,7 +122,7 @@ exports[`Generating nuxt stats 3 {"format":"es","expected":"esm"} matches the sn
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -143,7 +143,7 @@ exports[`Generating nuxt stats 3 {"format":"esm","expected":"esm"} matches the s
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -164,7 +164,7 @@ exports[`Generating nuxt stats 3 {"format":"esm","expected":"esm"} matches the s
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -185,7 +185,7 @@ exports[`Generating nuxt stats 3 {"format":"module","expected":"esm"} matches th
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -206,7 +206,7 @@ exports[`Generating nuxt stats 3 {"format":"module","expected":"esm"} matches th
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -227,7 +227,7 @@ exports[`Generating nuxt stats 3 {"format":"iife","expected":"iife"} matches the
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -248,7 +248,7 @@ exports[`Generating nuxt stats 3 {"format":"iife","expected":"iife"} matches the
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -269,7 +269,7 @@ exports[`Generating nuxt stats 3 {"format":"umd","expected":"umd"} matches the s
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -290,7 +290,7 @@ exports[`Generating nuxt stats 3 {"format":"umd","expected":"umd"} matches the s
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -311,7 +311,7 @@ exports[`Generating nuxt stats 3 {"format":"system","expected":"system"} matches
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -332,7 +332,7 @@ exports[`Generating nuxt stats 3 {"format":"system","expected":"system"} matches
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -353,7 +353,7 @@ exports[`Generating nuxt stats 3 {"format":"systemjs","expected":"system"} match
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -374,6 +374,6 @@ exports[`Generating nuxt stats 3 {"format":"systemjs","expected":"system"} match
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;

--- a/integration-tests/fixtures/generate-bundle-stats/nuxt/nuxt-plugin.test.ts
+++ b/integration-tests/fixtures/generate-bundle-stats/nuxt/nuxt-plugin.test.ts
@@ -80,6 +80,7 @@ describe("Generating nuxt stats", () => {
                 name: expect.any(String),
                 normalized: expect.any(String),
                 size: expect.any(Number),
+                gzipSize: expect.anything(),
               },
             ]),
             chunks: expect.arrayContaining([
@@ -123,6 +124,7 @@ describe("Generating nuxt stats", () => {
                 name: expect.any(String),
                 normalized: expect.any(String),
                 size: expect.any(Number),
+                gzipSize: expect.anything(),
               },
             ]),
             chunks: expect.arrayContaining([

--- a/integration-tests/fixtures/generate-bundle-stats/remix/__snapshots__/remix-plugin.test.ts.snap
+++ b/integration-tests/fixtures/generate-bundle-stats/remix/__snapshots__/remix-plugin.test.ts.snap
@@ -1,5 +1,131 @@
 // Bun Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Generating remix stats 2 {"format":"amd","expected":"amd"} matches the snapshot 1`] = `
+{
+  "assets": ExpectArrayContaining {},
+  "builtAt": Any<Number>,
+  "bundleName": StringContaining "test-remix-v2-client-amd",
+  "bundler": {
+    "name": "rollup",
+    "version": "4.16.2",
+  },
+  "chunks": ExpectArrayContaining {},
+  "duration": Any<Number>,
+  "modules": ExpectArrayContaining {},
+  "outputPath": StringContaining "build",
+  "plugin": {
+    "name": StringMatching "@codecov/remix-vite-plugin",
+    "version": "0.0.1-beta.10",
+  },
+  "version": "2",
+}
+`;
+
+exports[`Generating remix stats 2 {"format":"amd","expected":"amd"} matches the snapshot 2`] = `
+{
+  "assets": ExpectArrayContaining {},
+  "builtAt": Any<Number>,
+  "bundleName": StringContaining "test-remix-v2-server-esm",
+  "bundler": {
+    "name": "rollup",
+    "version": "4.16.2",
+  },
+  "chunks": ExpectArrayContaining {},
+  "duration": Any<Number>,
+  "modules": ExpectArrayContaining {},
+  "outputPath": StringContaining "build",
+  "plugin": {
+    "name": StringMatching "@codecov/remix-vite-plugin",
+    "version": "0.0.1-beta.10",
+  },
+  "version": "2",
+}
+`;
+
+exports[`Generating remix stats 2 {"format":"cjs","expected":"cjs"} matches the snapshot 1`] = `
+{
+  "assets": ExpectArrayContaining {},
+  "builtAt": Any<Number>,
+  "bundleName": StringContaining "test-remix-v2-client-cjs",
+  "bundler": {
+    "name": "rollup",
+    "version": "4.16.2",
+  },
+  "chunks": ExpectArrayContaining {},
+  "duration": Any<Number>,
+  "modules": ExpectArrayContaining {},
+  "outputPath": StringContaining "build",
+  "plugin": {
+    "name": StringMatching "@codecov/remix-vite-plugin",
+    "version": "0.0.1-beta.10",
+  },
+  "version": "2",
+}
+`;
+
+exports[`Generating remix stats 2 {"format":"cjs","expected":"cjs"} matches the snapshot 2`] = `
+{
+  "assets": ExpectArrayContaining {},
+  "builtAt": Any<Number>,
+  "bundleName": StringContaining "test-remix-v2-server-esm",
+  "bundler": {
+    "name": "rollup",
+    "version": "4.16.2",
+  },
+  "chunks": ExpectArrayContaining {},
+  "duration": Any<Number>,
+  "modules": ExpectArrayContaining {},
+  "outputPath": StringContaining "build",
+  "plugin": {
+    "name": StringMatching "@codecov/remix-vite-plugin",
+    "version": "0.0.1-beta.10",
+  },
+  "version": "2",
+}
+`;
+
+exports[`Generating remix stats 2 {"format":"es","expected":"esm"} matches the snapshot 1`] = `
+{
+  "assets": ExpectArrayContaining {},
+  "builtAt": Any<Number>,
+  "bundleName": StringContaining "test-remix-v2-client-esm",
+  "bundler": {
+    "name": "rollup",
+    "version": "4.16.2",
+  },
+  "chunks": ExpectArrayContaining {},
+  "duration": Any<Number>,
+  "modules": ExpectArrayContaining {},
+  "outputPath": StringContaining "build",
+  "plugin": {
+    "name": StringMatching "@codecov/remix-vite-plugin",
+    "version": "0.0.1-beta.10",
+  },
+  "version": "2",
+}
+`;
+
+exports[`Generating remix stats 2 {"format":"es","expected":"esm"} matches the snapshot 2`] = `
+{
+  "assets": ExpectArrayContaining {},
+  "builtAt": Any<Number>,
+  "bundleName": StringContaining "test-remix-v2-server-esm",
+  "bundler": {
+    "name": "rollup",
+    "version": "4.16.2",
+  },
+  "chunks": ExpectArrayContaining {},
+  "duration": Any<Number>,
+  "modules": ExpectArrayContaining {},
+  "outputPath": StringContaining "build",
+  "plugin": {
+    "name": StringMatching "@codecov/remix-vite-plugin",
+    "version": "0.0.1-beta.10",
+  },
+  "version": "2",
+}
+`;
+
 exports[`Generating remix stats 2 {"format":"esm","expected":"esm"} matches the snapshot 1`] = `
 {
   "assets": ExpectArrayContaining {},
@@ -17,7 +143,7 @@ exports[`Generating remix stats 2 {"format":"esm","expected":"esm"} matches the 
     "name": StringMatching "@codecov/remix-vite-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -38,6 +164,48 @@ exports[`Generating remix stats 2 {"format":"esm","expected":"esm"} matches the 
     "name": StringMatching "@codecov/remix-vite-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
+}
+`;
+
+exports[`Generating remix stats 2 {"format":"module","expected":"esm"} matches the snapshot 1`] = `
+{
+  "assets": ExpectArrayContaining {},
+  "builtAt": Any<Number>,
+  "bundleName": StringContaining "test-remix-v2-client-esm",
+  "bundler": {
+    "name": "rollup",
+    "version": "4.16.2",
+  },
+  "chunks": ExpectArrayContaining {},
+  "duration": Any<Number>,
+  "modules": ExpectArrayContaining {},
+  "outputPath": StringContaining "build",
+  "plugin": {
+    "name": StringMatching "@codecov/remix-vite-plugin",
+    "version": "0.0.1-beta.10",
+  },
+  "version": "2",
+}
+`;
+
+exports[`Generating remix stats 2 {"format":"module","expected":"esm"} matches the snapshot 2`] = `
+{
+  "assets": ExpectArrayContaining {},
+  "builtAt": Any<Number>,
+  "bundleName": StringContaining "test-remix-v2-server-esm",
+  "bundler": {
+    "name": "rollup",
+    "version": "4.16.2",
+  },
+  "chunks": ExpectArrayContaining {},
+  "duration": Any<Number>,
+  "modules": ExpectArrayContaining {},
+  "outputPath": StringContaining "build",
+  "plugin": {
+    "name": StringMatching "@codecov/remix-vite-plugin",
+    "version": "0.0.1-beta.10",
+  },
+  "version": "2",
 }
 `;

--- a/integration-tests/fixtures/generate-bundle-stats/remix/remix-plugin.test.ts
+++ b/integration-tests/fixtures/generate-bundle-stats/remix/remix-plugin.test.ts
@@ -7,8 +7,13 @@ const remixApp = "test-apps/remix";
 
 const VERSIONS = [2];
 
-// Default Rollup formats: https://rollupjs.org/configuration-options/#output-format
-const FORMATS = [{ format: "esm", expected: "esm" }];
+const FORMATS = [
+  { format: "amd", expected: "amd" },
+  { format: "cjs", expected: "cjs" },
+  { format: "es", expected: "esm" },
+  { format: "esm", expected: "esm" },
+  { format: "module", expected: "esm" },
+];
 
 describe("Generating remix stats", () => {
   describe.each(VERSIONS)("%d", (version) => {
@@ -72,6 +77,7 @@ describe("Generating remix stats", () => {
                 name: expect.any(String),
                 normalized: expect.any(String),
                 size: expect.any(Number),
+                gzipSize: expect.anything(),
               },
             ]),
             chunks: expect.arrayContaining([
@@ -104,9 +110,7 @@ describe("Generating remix stats", () => {
             builtAt: expect.any(Number),
             duration: expect.any(Number),
             outputPath: expect.stringContaining(`build`),
-            bundleName: expect.stringContaining(
-              `test-remix-v${version}-server-${expected}`,
-            ),
+            bundleName: expect.stringContaining(serverBundleName),
             plugin: {
               name: expect.stringMatching("@codecov/remix-vite-plugin"),
             },
@@ -115,6 +119,7 @@ describe("Generating remix stats", () => {
                 name: expect.any(String),
                 normalized: expect.any(String),
                 size: expect.any(Number),
+                gzipSize: expect.anything(),
               },
             ]),
             chunks: expect.arrayContaining([

--- a/integration-tests/fixtures/generate-bundle-stats/remix/vite-base.config.ts
+++ b/integration-tests/fixtures/generate-bundle-stats/remix/vite-base.config.ts
@@ -4,6 +4,13 @@ import tsconfigPaths from "vite-tsconfig-paths";
 import { codecovRemixVitePlugin } from "@codecov/remix-vite-plugin";
 
 export default defineConfig({
+  build: {
+    rollupOptions: {
+      output: {
+        format: "esm",
+      },
+    },
+  },
   plugins: [
     remix({
       future: {

--- a/integration-tests/fixtures/generate-bundle-stats/rollup/__snapshots__/rollup-plugin.test.ts.snap
+++ b/integration-tests/fixtures/generate-bundle-stats/rollup/__snapshots__/rollup-plugin.test.ts.snap
@@ -4,6 +4,7 @@ exports[`Generating rollup stats 3 {"format":"amd","expected":"amd"} matches the
 {
   "assets": [
     {
+      "gzipSize": 98808,
       "name": "main-1cbfd464.js",
       "normalized": "main-*.js",
       "size": 577071,
@@ -72,7 +73,7 @@ exports[`Generating rollup stats 3 {"format":"amd","expected":"amd"} matches the
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -80,6 +81,7 @@ exports[`Generating rollup stats 3 {"format":"cjs","expected":"cjs"} matches the
 {
   "assets": [
     {
+      "gzipSize": 98252,
       "name": "main-420d8aeb.js",
       "normalized": "main-*.js",
       "size": 560886,
@@ -148,7 +150,7 @@ exports[`Generating rollup stats 3 {"format":"cjs","expected":"cjs"} matches the
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -156,6 +158,7 @@ exports[`Generating rollup stats 3 {"format":"es","expected":"esm"} matches the 
 {
   "assets": [
     {
+      "gzipSize": 98243,
       "name": "main-6ff1e9ca.js",
       "normalized": "main-*.js",
       "size": 560871,
@@ -224,7 +227,7 @@ exports[`Generating rollup stats 3 {"format":"es","expected":"esm"} matches the 
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -232,6 +235,7 @@ exports[`Generating rollup stats 3 {"format":"esm","expected":"esm"} matches the
 {
   "assets": [
     {
+      "gzipSize": 98243,
       "name": "main-6ff1e9ca.js",
       "normalized": "main-*.js",
       "size": 560871,
@@ -300,7 +304,7 @@ exports[`Generating rollup stats 3 {"format":"esm","expected":"esm"} matches the
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -308,6 +312,7 @@ exports[`Generating rollup stats 3 {"format":"module","expected":"esm"} matches 
 {
   "assets": [
     {
+      "gzipSize": 98243,
       "name": "main-6ff1e9ca.js",
       "normalized": "main-*.js",
       "size": 560871,
@@ -376,7 +381,7 @@ exports[`Generating rollup stats 3 {"format":"module","expected":"esm"} matches 
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -384,6 +389,7 @@ exports[`Generating rollup stats 3 {"format":"iife","expected":"iife"} matches t
 {
   "assets": [
     {
+      "gzipSize": 98804,
       "name": "main-cc182ba1.js",
       "normalized": "main-*.js",
       "size": 577066,
@@ -452,7 +458,7 @@ exports[`Generating rollup stats 3 {"format":"iife","expected":"iife"} matches t
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -460,6 +466,7 @@ exports[`Generating rollup stats 3 {"format":"umd","expected":"umd"} matches the
 {
   "assets": [
     {
+      "gzipSize": 98845,
       "name": "main-cdb2522f.js",
       "normalized": "main-*.js",
       "size": 577165,
@@ -528,7 +535,7 @@ exports[`Generating rollup stats 3 {"format":"umd","expected":"umd"} matches the
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -536,6 +543,7 @@ exports[`Generating rollup stats 3 {"format":"system","expected":"system"} match
 {
   "assets": [
     {
+      "gzipSize": 99908,
       "name": "main-b7135d24.js",
       "normalized": "main-*.js",
       "size": 609444,
@@ -604,7 +612,7 @@ exports[`Generating rollup stats 3 {"format":"system","expected":"system"} match
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -612,6 +620,7 @@ exports[`Generating rollup stats 3 {"format":"systemjs","expected":"system"} mat
 {
   "assets": [
     {
+      "gzipSize": 99908,
       "name": "main-b7135d24.js",
       "normalized": "main-*.js",
       "size": 609444,
@@ -680,7 +689,7 @@ exports[`Generating rollup stats 3 {"format":"systemjs","expected":"system"} mat
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -688,6 +697,7 @@ exports[`Generating rollup stats 3 source maps are enabled does not include any 
 {
   "assets": [
     {
+      "gzipSize": 98275,
       "name": "main-6ff1e9ca.js",
       "normalized": "main-*.js",
       "size": 560913,
@@ -756,7 +766,7 @@ exports[`Generating rollup stats 3 source maps are enabled does not include any 
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -764,6 +774,7 @@ exports[`Generating rollup stats 4 {"format":"amd","expected":"amd"} matches the
 {
   "assets": [
     {
+      "gzipSize": 98808,
       "name": "main-H2_1FSsQ.js",
       "normalized": "main-H2_1FSsQ.js",
       "size": 577071,
@@ -832,7 +843,7 @@ exports[`Generating rollup stats 4 {"format":"amd","expected":"amd"} matches the
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -840,6 +851,7 @@ exports[`Generating rollup stats 4 {"format":"cjs","expected":"cjs"} matches the
 {
   "assets": [
     {
+      "gzipSize": 98252,
       "name": "main-MVbZZknk.js",
       "normalized": "main-*.js",
       "size": 560886,
@@ -908,7 +920,7 @@ exports[`Generating rollup stats 4 {"format":"cjs","expected":"cjs"} matches the
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -916,6 +928,7 @@ exports[`Generating rollup stats 4 {"format":"es","expected":"esm"} matches the 
 {
   "assets": [
     {
+      "gzipSize": 98243,
       "name": "main-v-vWaFyT.js",
       "normalized": "main-*.js",
       "size": 560871,
@@ -984,7 +997,7 @@ exports[`Generating rollup stats 4 {"format":"es","expected":"esm"} matches the 
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -992,6 +1005,7 @@ exports[`Generating rollup stats 4 {"format":"esm","expected":"esm"} matches the
 {
   "assets": [
     {
+      "gzipSize": 98243,
       "name": "main-v-vWaFyT.js",
       "normalized": "main-*.js",
       "size": 560871,
@@ -1060,7 +1074,7 @@ exports[`Generating rollup stats 4 {"format":"esm","expected":"esm"} matches the
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -1068,6 +1082,7 @@ exports[`Generating rollup stats 4 {"format":"module","expected":"esm"} matches 
 {
   "assets": [
     {
+      "gzipSize": 98243,
       "name": "main-v-vWaFyT.js",
       "normalized": "main-*.js",
       "size": 560871,
@@ -1136,7 +1151,7 @@ exports[`Generating rollup stats 4 {"format":"module","expected":"esm"} matches 
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -1144,6 +1159,7 @@ exports[`Generating rollup stats 4 {"format":"iife","expected":"iife"} matches t
 {
   "assets": [
     {
+      "gzipSize": 98804,
       "name": "main-ChwnvxRF.js",
       "normalized": "main-*.js",
       "size": 577066,
@@ -1212,7 +1228,7 @@ exports[`Generating rollup stats 4 {"format":"iife","expected":"iife"} matches t
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -1220,6 +1236,7 @@ exports[`Generating rollup stats 4 {"format":"umd","expected":"umd"} matches the
 {
   "assets": [
     {
+      "gzipSize": 98845,
       "name": "main-ymXr0nql.js",
       "normalized": "main-*.js",
       "size": 577165,
@@ -1288,7 +1305,7 @@ exports[`Generating rollup stats 4 {"format":"umd","expected":"umd"} matches the
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -1296,6 +1313,7 @@ exports[`Generating rollup stats 4 {"format":"system","expected":"system"} match
 {
   "assets": [
     {
+      "gzipSize": 99908,
       "name": "main-VyFuBFOR.js",
       "normalized": "main-*.js",
       "size": 609444,
@@ -1364,7 +1382,7 @@ exports[`Generating rollup stats 4 {"format":"system","expected":"system"} match
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -1372,6 +1390,7 @@ exports[`Generating rollup stats 4 {"format":"systemjs","expected":"system"} mat
 {
   "assets": [
     {
+      "gzipSize": 99908,
       "name": "main-VyFuBFOR.js",
       "normalized": "main-*.js",
       "size": 609444,
@@ -1440,7 +1459,7 @@ exports[`Generating rollup stats 4 {"format":"systemjs","expected":"system"} mat
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -1448,6 +1467,7 @@ exports[`Generating rollup stats 4 source maps are enabled does not include any 
 {
   "assets": [
     {
+      "gzipSize": 98277,
       "name": "main-v-vWaFyT.js",
       "normalized": "main-*.js",
       "size": 560913,
@@ -1516,6 +1536,6 @@ exports[`Generating rollup stats 4 source maps are enabled does not include any 
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;

--- a/integration-tests/fixtures/generate-bundle-stats/sveltekit/__snapshots__/sveltekit-plugin.test.ts.snap
+++ b/integration-tests/fixtures/generate-bundle-stats/sveltekit/__snapshots__/sveltekit-plugin.test.ts.snap
@@ -1,5 +1,47 @@
 // Bun Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Generating sveltekit stats 2 {"format":"es","expected":"esm"} matches the snapshot 1`] = `
+{
+  "assets": ExpectArrayContaining {},
+  "builtAt": Any<Number>,
+  "bundleName": StringContaining "test-sveltekit-v2-client-esm",
+  "bundler": {
+    "name": "rollup",
+    "version": "4.16.2",
+  },
+  "chunks": ExpectArrayContaining {},
+  "duration": Any<Number>,
+  "modules": ExpectArrayContaining {},
+  "outputPath": StringContaining ".svelte-kit",
+  "plugin": {
+    "name": StringMatching "@codecov/sveltekit-plugin",
+    "version": "0.0.1-beta.10",
+  },
+  "version": "2",
+}
+`;
+
+exports[`Generating sveltekit stats 2 {"format":"es","expected":"esm"} matches the snapshot 2`] = `
+{
+  "assets": ExpectArrayContaining {},
+  "builtAt": Any<Number>,
+  "bundleName": StringContaining "test-sveltekit-v2-server-esm",
+  "bundler": {
+    "name": "rollup",
+    "version": "4.16.2",
+  },
+  "chunks": ExpectArrayContaining {},
+  "duration": Any<Number>,
+  "modules": ExpectArrayContaining {},
+  "outputPath": StringContaining ".svelte-kit",
+  "plugin": {
+    "name": StringMatching "@codecov/sveltekit-plugin",
+    "version": "0.0.1-beta.10",
+  },
+  "version": "2",
+}
+`;
+
 exports[`Generating sveltekit stats 2 {"format":"esm","expected":"esm"} matches the snapshot 1`] = `
 {
   "assets": ExpectArrayContaining {},
@@ -17,7 +59,7 @@ exports[`Generating sveltekit stats 2 {"format":"esm","expected":"esm"} matches 
     "name": StringMatching "@codecov/sveltekit-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -38,6 +80,48 @@ exports[`Generating sveltekit stats 2 {"format":"esm","expected":"esm"} matches 
     "name": StringMatching "@codecov/sveltekit-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
+}
+`;
+
+exports[`Generating sveltekit stats 2 {"format":"module","expected":"esm"} matches the snapshot 1`] = `
+{
+  "assets": ExpectArrayContaining {},
+  "builtAt": Any<Number>,
+  "bundleName": StringContaining "test-sveltekit-v2-client-esm",
+  "bundler": {
+    "name": "rollup",
+    "version": "4.16.2",
+  },
+  "chunks": ExpectArrayContaining {},
+  "duration": Any<Number>,
+  "modules": ExpectArrayContaining {},
+  "outputPath": StringContaining ".svelte-kit",
+  "plugin": {
+    "name": StringMatching "@codecov/sveltekit-plugin",
+    "version": "0.0.1-beta.10",
+  },
+  "version": "2",
+}
+`;
+
+exports[`Generating sveltekit stats 2 {"format":"module","expected":"esm"} matches the snapshot 2`] = `
+{
+  "assets": ExpectArrayContaining {},
+  "builtAt": Any<Number>,
+  "bundleName": StringContaining "test-sveltekit-v2-server-esm",
+  "bundler": {
+    "name": "rollup",
+    "version": "4.16.2",
+  },
+  "chunks": ExpectArrayContaining {},
+  "duration": Any<Number>,
+  "modules": ExpectArrayContaining {},
+  "outputPath": StringContaining ".svelte-kit",
+  "plugin": {
+    "name": StringMatching "@codecov/sveltekit-plugin",
+    "version": "0.0.1-beta.10",
+  },
+  "version": "2",
 }
 `;

--- a/integration-tests/fixtures/generate-bundle-stats/sveltekit/sveltekit-plugin.test.ts
+++ b/integration-tests/fixtures/generate-bundle-stats/sveltekit/sveltekit-plugin.test.ts
@@ -7,8 +7,11 @@ const sveltekitApp = "test-apps/sveltekit";
 
 const VERSIONS = [2];
 
-// Default Rollup formats: https://rollupjs.org/configuration-options/#output-format
-const FORMATS = [{ format: "esm", expected: "esm" }];
+const FORMATS = [
+  { format: "es", expected: "esm" },
+  { format: "esm", expected: "esm" },
+  { format: "module", expected: "esm" },
+];
 
 describe("Generating sveltekit stats", () => {
   describe.each(VERSIONS)("%d", (version) => {
@@ -61,9 +64,7 @@ describe("Generating sveltekit stats", () => {
             builtAt: expect.any(Number),
             duration: expect.any(Number),
             outputPath: expect.stringContaining(`.svelte-kit`),
-            bundleName: expect.stringContaining(
-              `test-sveltekit-v${version}-client-${expected}`,
-            ),
+            bundleName: expect.stringContaining(clientBundleName),
             plugin: {
               name: expect.stringMatching("@codecov/sveltekit-plugin"),
             },
@@ -72,6 +73,7 @@ describe("Generating sveltekit stats", () => {
                 name: expect.any(String),
                 normalized: expect.any(String),
                 size: expect.any(Number),
+                gzipSize: expect.anything(),
               },
             ]),
             chunks: expect.arrayContaining([
@@ -104,9 +106,7 @@ describe("Generating sveltekit stats", () => {
             builtAt: expect.any(Number),
             duration: expect.any(Number),
             outputPath: expect.stringContaining(`.svelte-kit`),
-            bundleName: expect.stringContaining(
-              `test-sveltekit-v${version}-server-${expected}`,
-            ),
+            bundleName: expect.stringContaining(serverBundleName),
             plugin: {
               name: expect.stringMatching("@codecov/sveltekit-plugin"),
             },
@@ -115,6 +115,7 @@ describe("Generating sveltekit stats", () => {
                 name: expect.any(String),
                 normalized: expect.any(String),
                 size: expect.any(Number),
+                gzipSize: expect.anything(),
               },
             ]),
             chunks: expect.arrayContaining([

--- a/integration-tests/fixtures/generate-bundle-stats/vite/__snapshots__/vite-plugin.test.ts.snap
+++ b/integration-tests/fixtures/generate-bundle-stats/vite/__snapshots__/vite-plugin.test.ts.snap
@@ -4,6 +4,7 @@ exports[`Generating vite stats v4 {"format":"amd","expected":"amd"} matches the 
 {
   "assets": [
     {
+      "gzipSize": 26821,
       "name": "assets/index-b7a309be.js",
       "normalized": "assets/index-*.js",
       "size": 72360,
@@ -86,7 +87,7 @@ exports[`Generating vite stats v4 {"format":"amd","expected":"amd"} matches the 
     "name": StringMatching "@codecov/vite-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -94,6 +95,7 @@ exports[`Generating vite stats v4 {"format":"cjs","expected":"cjs"} matches the 
 {
   "assets": [
     {
+      "gzipSize": 26812,
       "name": "assets/index-7de22500.js",
       "normalized": "assets/index-*.js",
       "size": 72342,
@@ -176,7 +178,7 @@ exports[`Generating vite stats v4 {"format":"cjs","expected":"cjs"} matches the 
     "name": StringMatching "@codecov/vite-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -184,6 +186,7 @@ exports[`Generating vite stats v4 {"format":"es","expected":"esm"} matches the s
 {
   "assets": [
     {
+      "gzipSize": 27169,
       "name": "assets/index-320c8eaf.js",
       "normalized": "assets/index-*.js",
       "size": 73071,
@@ -266,7 +269,7 @@ exports[`Generating vite stats v4 {"format":"es","expected":"esm"} matches the s
     "name": StringMatching "@codecov/vite-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -274,6 +277,7 @@ exports[`Generating vite stats v4 {"format":"esm","expected":"esm"} matches the 
 {
   "assets": [
     {
+      "gzipSize": 27169,
       "name": "assets/index-320c8eaf.js",
       "normalized": "assets/index-*.js",
       "size": 73071,
@@ -356,7 +360,7 @@ exports[`Generating vite stats v4 {"format":"esm","expected":"esm"} matches the 
     "name": StringMatching "@codecov/vite-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -364,6 +368,7 @@ exports[`Generating vite stats v4 {"format":"module","expected":"esm"} matches t
 {
   "assets": [
     {
+      "gzipSize": 27169,
       "name": "assets/index-320c8eaf.js",
       "normalized": "assets/index-*.js",
       "size": 73071,
@@ -446,7 +451,7 @@ exports[`Generating vite stats v4 {"format":"module","expected":"esm"} matches t
     "name": StringMatching "@codecov/vite-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -454,6 +459,7 @@ exports[`Generating vite stats v4 {"format":"iife","expected":"iife"} matches th
 {
   "assets": [
     {
+      "gzipSize": 26821,
       "name": "assets/index-646c8a11.js",
       "normalized": "assets/index-*.js",
       "size": 72356,
@@ -536,7 +542,7 @@ exports[`Generating vite stats v4 {"format":"iife","expected":"iife"} matches th
     "name": StringMatching "@codecov/vite-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -544,6 +550,7 @@ exports[`Generating vite stats v4 {"format":"umd","expected":"umd"} matches the 
 {
   "assets": [
     {
+      "gzipSize": 26850,
       "name": "assets/index-5458a54a.js",
       "normalized": "assets/index-*.js",
       "size": 72423,
@@ -626,7 +633,7 @@ exports[`Generating vite stats v4 {"format":"umd","expected":"umd"} matches the 
     "name": StringMatching "@codecov/vite-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -634,6 +641,7 @@ exports[`Generating vite stats v4 {"format":"system","expected":"system"} matche
 {
   "assets": [
     {
+      "gzipSize": 26850,
       "name": "assets/index-2fd1a797.js",
       "normalized": "assets/index-*.js",
       "size": 72405,
@@ -716,7 +724,7 @@ exports[`Generating vite stats v4 {"format":"system","expected":"system"} matche
     "name": StringMatching "@codecov/vite-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -724,6 +732,7 @@ exports[`Generating vite stats v4 {"format":"systemjs","expected":"system"} matc
 {
   "assets": [
     {
+      "gzipSize": 26850,
       "name": "assets/index-2fd1a797.js",
       "normalized": "assets/index-*.js",
       "size": 72405,
@@ -806,7 +815,7 @@ exports[`Generating vite stats v4 {"format":"systemjs","expected":"system"} matc
     "name": StringMatching "@codecov/vite-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -814,6 +823,7 @@ exports[`Generating vite stats v4 source maps are enabled does not include any s
 {
   "assets": [
     {
+      "gzipSize": 27198,
       "name": "assets/index-320c8eaf.js",
       "normalized": "assets/index-*.js",
       "size": 73114,
@@ -896,7 +906,7 @@ exports[`Generating vite stats v4 source maps are enabled does not include any s
     "name": StringMatching "@codecov/vite-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -904,6 +914,7 @@ exports[`Generating vite stats v5 {"format":"amd","expected":"amd"} matches the 
 {
   "assets": [
     {
+      "gzipSize": 26821,
       "name": "assets/index-D0r0olUW.js",
       "normalized": "assets/index-*.js",
       "size": 72360,
@@ -986,7 +997,7 @@ exports[`Generating vite stats v5 {"format":"amd","expected":"amd"} matches the 
     "name": StringMatching "@codecov/vite-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -994,6 +1005,7 @@ exports[`Generating vite stats v5 {"format":"cjs","expected":"cjs"} matches the 
 {
   "assets": [
     {
+      "gzipSize": 26812,
       "name": "assets/index-_9bu_Rar.js",
       "normalized": "assets/index-_9bu_Rar.js",
       "size": 72342,
@@ -1076,7 +1088,7 @@ exports[`Generating vite stats v5 {"format":"cjs","expected":"cjs"} matches the 
     "name": StringMatching "@codecov/vite-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -1084,6 +1096,7 @@ exports[`Generating vite stats v5 {"format":"es","expected":"esm"} matches the s
 {
   "assets": [
     {
+      "gzipSize": 27169,
       "name": "assets/index-Cq3U4pkx.js",
       "normalized": "assets/index-*.js",
       "size": 73071,
@@ -1166,7 +1179,7 @@ exports[`Generating vite stats v5 {"format":"es","expected":"esm"} matches the s
     "name": StringMatching "@codecov/vite-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -1174,6 +1187,7 @@ exports[`Generating vite stats v5 {"format":"esm","expected":"esm"} matches the 
 {
   "assets": [
     {
+      "gzipSize": 27169,
       "name": "assets/index-Cq3U4pkx.js",
       "normalized": "assets/index-*.js",
       "size": 73071,
@@ -1256,7 +1270,7 @@ exports[`Generating vite stats v5 {"format":"esm","expected":"esm"} matches the 
     "name": StringMatching "@codecov/vite-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -1264,6 +1278,7 @@ exports[`Generating vite stats v5 {"format":"module","expected":"esm"} matches t
 {
   "assets": [
     {
+      "gzipSize": 27169,
       "name": "assets/index-Cq3U4pkx.js",
       "normalized": "assets/index-*.js",
       "size": 73071,
@@ -1346,7 +1361,7 @@ exports[`Generating vite stats v5 {"format":"module","expected":"esm"} matches t
     "name": StringMatching "@codecov/vite-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -1354,6 +1369,7 @@ exports[`Generating vite stats v5 {"format":"iife","expected":"iife"} matches th
 {
   "assets": [
     {
+      "gzipSize": 26821,
       "name": "assets/index-B31DUBuo.js",
       "normalized": "assets/index-*.js",
       "size": 72356,
@@ -1436,7 +1452,7 @@ exports[`Generating vite stats v5 {"format":"iife","expected":"iife"} matches th
     "name": StringMatching "@codecov/vite-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -1444,6 +1460,7 @@ exports[`Generating vite stats v5 {"format":"umd","expected":"umd"} matches the 
 {
   "assets": [
     {
+      "gzipSize": 26850,
       "name": "assets/index-BFgpG9Ne.js",
       "normalized": "assets/index-*.js",
       "size": 72423,
@@ -1526,7 +1543,7 @@ exports[`Generating vite stats v5 {"format":"umd","expected":"umd"} matches the 
     "name": StringMatching "@codecov/vite-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -1534,6 +1551,7 @@ exports[`Generating vite stats v5 {"format":"system","expected":"system"} matche
 {
   "assets": [
     {
+      "gzipSize": 26850,
       "name": "assets/index-Cn9uVtOh.js",
       "normalized": "assets/index-*.js",
       "size": 72405,
@@ -1616,7 +1634,7 @@ exports[`Generating vite stats v5 {"format":"system","expected":"system"} matche
     "name": StringMatching "@codecov/vite-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -1624,6 +1642,7 @@ exports[`Generating vite stats v5 {"format":"systemjs","expected":"system"} matc
 {
   "assets": [
     {
+      "gzipSize": 26850,
       "name": "assets/index-Cn9uVtOh.js",
       "normalized": "assets/index-*.js",
       "size": 72405,
@@ -1706,7 +1725,7 @@ exports[`Generating vite stats v5 {"format":"systemjs","expected":"system"} matc
     "name": StringMatching "@codecov/vite-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -1714,6 +1733,7 @@ exports[`Generating vite stats v5 source maps are enabled does not include any s
 {
   "assets": [
     {
+      "gzipSize": 27198,
       "name": "assets/index-Cq3U4pkx.js",
       "normalized": "assets/index-*.js",
       "size": 73114,
@@ -1796,6 +1816,6 @@ exports[`Generating vite stats v5 source maps are enabled does not include any s
     "name": StringMatching "@codecov/vite-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;

--- a/integration-tests/fixtures/generate-bundle-stats/webpack/__snapshots__/webpack-plugin.test.ts.snap
+++ b/integration-tests/fixtures/generate-bundle-stats/webpack/__snapshots__/webpack-plugin.test.ts.snap
@@ -4,6 +4,7 @@ exports[`Generating webpack stats 5 {"format":"array-push","expected":"array-pus
 {
   "assets": [
     {
+      "gzipSize": 25254,
       "name": "main-6c1d26e76f6ba1fc75c8.js",
       "normalized": "main-*.js",
       "size": 70961,
@@ -70,7 +71,7 @@ exports[`Generating webpack stats 5 {"format":"array-push","expected":"array-pus
     "name": StringMatching "@codecov/webpack-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -78,6 +79,7 @@ exports[`Generating webpack stats 5 {"format":"commonjs","expected":"cjs"} match
 {
   "assets": [
     {
+      "gzipSize": 25254,
       "name": "main-6c1d26e76f6ba1fc75c8.js",
       "normalized": "main-*.js",
       "size": 70961,
@@ -144,7 +146,7 @@ exports[`Generating webpack stats 5 {"format":"commonjs","expected":"cjs"} match
     "name": StringMatching "@codecov/webpack-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -152,6 +154,7 @@ exports[`Generating webpack stats 5 {"format":"module","expected":"esm"} matches
 {
   "assets": [
     {
+      "gzipSize": 25254,
       "name": "main-6c1d26e76f6ba1fc75c8.js",
       "normalized": "main-*.js",
       "size": 70961,
@@ -218,7 +221,7 @@ exports[`Generating webpack stats 5 {"format":"module","expected":"esm"} matches
     "name": StringMatching "@codecov/webpack-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;
 
@@ -226,6 +229,7 @@ exports[`Generating webpack stats 5 source maps are enabled does not include any
 {
   "assets": [
     {
+      "gzipSize": 25254,
       "name": "main-6c1d26e76f6ba1fc75c8.js",
       "normalized": "main-*.js",
       "size": 70961,
@@ -292,6 +296,6 @@ exports[`Generating webpack stats 5 source maps are enabled does not include any
     "name": StringMatching "@codecov/webpack-plugin",
     "version": "0.0.1-beta.10",
   },
-  "version": "1",
+  "version": "2",
 }
 `;

--- a/packages/bundler-plugin-core/src/index.ts
+++ b/packages/bundler-plugin-core/src/index.ts
@@ -12,6 +12,7 @@ import { red } from "./utils/logging.ts";
 import { handleErrors, normalizeOptions } from "./utils/normalizeOptions.ts";
 import { normalizePath } from "./utils/normalizePath.ts";
 import { Output } from "./utils/Output.ts";
+import { getCompressedSize } from "./utils/getCompressedSize.ts";
 
 export type {
   Asset,
@@ -26,6 +27,7 @@ export type {
 export {
   checkNodeVersion,
   handleErrors,
+  getCompressedSize,
   normalizeOptions,
   normalizePath,
   Output,

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -9,6 +9,7 @@ export interface Dependency {
 export interface Asset {
   name: string;
   size: number;
+  gzipSize: number | null;
   normalized: string;
 }
 

--- a/packages/bundler-plugin-core/src/utils/Output.ts
+++ b/packages/bundler-plugin-core/src/utils/Output.ts
@@ -50,7 +50,7 @@ class Output {
   };
 
   constructor(userOptions: NormalizedOptions) {
-    this.version = "1";
+    this.version = "2";
     this.apiUrl = userOptions.apiUrl;
     this.dryRun = userOptions.dryRun;
     this.retryCount = userOptions.retryCount;

--- a/packages/bundler-plugin-core/src/utils/__tests__/getCompressedSize.spec.ts
+++ b/packages/bundler-plugin-core/src/utils/__tests__/getCompressedSize.spec.ts
@@ -1,0 +1,38 @@
+import { getCompressedSize } from "../getCompressedSize";
+import { describe, it, expect } from "vitest";
+
+describe("getCompressedSize", () => {
+  describe("file extension is not compressible", () => {
+    it("should return null", async () => {
+      const result = await getCompressedSize({
+        fileName: "file.png",
+        code: "<some cool png data>",
+      });
+
+      expect(result).toBe(null);
+    });
+  });
+
+  describe("file extension is compressible", () => {
+    describe("code is a string", () => {
+      it("should return the compressed size", async () => {
+        const result = await getCompressedSize({
+          fileName: "file.css",
+          code: "body { color: red; }",
+        });
+
+        expect(result).toBe(40);
+      });
+    });
+    describe("code is a Uint8Array", () => {
+      it("should return the compressed size", async () => {
+        const result = await getCompressedSize({
+          fileName: "file.css",
+          code: new TextEncoder().encode("body { color: red; }"),
+        });
+
+        expect(result).toBe(40);
+      });
+    });
+  });
+});

--- a/packages/bundler-plugin-core/src/utils/__tests__/normalizeOptions.test.ts
+++ b/packages/bundler-plugin-core/src/utils/__tests__/normalizeOptions.test.ts
@@ -226,8 +226,10 @@ describe("handleErrors", () => {
       });
 
       expect(consoleSpy).toHaveBeenCalled();
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "[codecov] `bundleName` is required for uploading bundle analysis information.",
+      expect(consoleSpy.mock.lastCall?.[0]).toStrictEqual(
+        expect.stringContaining(
+          "`bundleName` is required for uploading bundle analysis information.",
+        ),
       );
     });
 
@@ -252,8 +254,10 @@ describe("handleErrors", () => {
       });
 
       expect(consoleSpy).toHaveBeenCalled();
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "[codecov] `bundleName` is required for uploading bundle analysis information.",
+      expect(consoleSpy.mock.lastCall?.[0]).toStrictEqual(
+        expect.stringContaining(
+          "`bundleName` is required for uploading bundle analysis information.",
+        ),
       );
     });
 

--- a/packages/bundler-plugin-core/src/utils/getCompressedSize.ts
+++ b/packages/bundler-plugin-core/src/utils/getCompressedSize.ts
@@ -1,0 +1,28 @@
+import { promisify } from "node:util";
+import { gzip } from "node:zlib";
+
+const COMPRESSIBLE_ASSETS_RE = /\.(?:css|html|json|js|svg|txt|xml|xhtml)$/;
+
+interface GetCompressedSizeOptions {
+  fileName: string;
+  code: string | Uint8Array;
+}
+
+export const getCompressedSize = async ({
+  fileName,
+  code,
+}: GetCompressedSizeOptions) => {
+  const isCompressible = COMPRESSIBLE_ASSETS_RE.test(fileName);
+
+  if (!isCompressible) {
+    return null;
+  }
+
+  const compress = promisify(gzip);
+
+  const compressed = await compress(
+    typeof code === "string" ? code : Buffer.from(code),
+  );
+
+  return compressed.length;
+};

--- a/packages/nuxt-plugin/src/nuxt-bundle-analysis/__tests__/__snapshots__/nuxtBundleAnalysisPlugin.test.ts.snap
+++ b/packages/nuxt-plugin/src/nuxt-bundle-analysis/__tests__/__snapshots__/nuxtBundleAnalysisPlugin.test.ts.snap
@@ -4,7 +4,7 @@ exports[`nuxtBundleAnalysisPlugin > when called > returns a plugin object 1`] = 
 {
   "name": "@codecov/nuxt-plugin",
   "pluginVersion": "0.0.1-beta.10",
-  "version": "1",
+  "version": "2",
   "vite": {
     "generateBundle": [Function],
   },

--- a/packages/nuxt-plugin/src/nuxt-bundle-analysis/nuxtBundleAnalysisPlugin.ts
+++ b/packages/nuxt-plugin/src/nuxt-bundle-analysis/nuxtBundleAnalysisPlugin.ts
@@ -12,7 +12,7 @@ const PLUGIN_VERSION = __PACKAGE_VERSION__ as string;
 export const nuxtBundleAnalysisPlugin: BundleAnalysisUploadPlugin = ({
   output,
 }) => ({
-  version: "1",
+  version: output.version,
   name: PLUGIN_NAME,
   pluginVersion: PLUGIN_VERSION,
   vite: {

--- a/packages/remix-vite-plugin/src/remix-bundle-analysis/__tests__/__snapshots__/remixBundleAnalysisPlugin.test.ts.snap
+++ b/packages/remix-vite-plugin/src/remix-bundle-analysis/__tests__/__snapshots__/remixBundleAnalysisPlugin.test.ts.snap
@@ -4,7 +4,7 @@ exports[`remixBundleAnalysisPlugin > when called > returns a plugin object 1`] =
 {
   "name": "@codecov/remix-vite-plugin",
   "pluginVersion": "0.0.1-beta.10",
-  "version": "1",
+  "version": "2",
   "vite": {
     "generateBundle": [Function],
   },

--- a/packages/remix-vite-plugin/src/remix-bundle-analysis/remixBundleAnalysisPlugin.ts
+++ b/packages/remix-vite-plugin/src/remix-bundle-analysis/remixBundleAnalysisPlugin.ts
@@ -12,7 +12,7 @@ const PLUGIN_VERSION = __PACKAGE_VERSION__ as string;
 export const remixBundleAnalysisPlugin: BundleAnalysisUploadPlugin = ({
   output,
 }) => ({
-  version: "1",
+  version: output.version,
   name: PLUGIN_NAME,
   pluginVersion: PLUGIN_VERSION,
   vite: {

--- a/packages/rollup-plugin/src/rollup-bundle-analysis/__tests__/__snapshots__/rollupBundleAnalysisPlugin.test.ts.snap
+++ b/packages/rollup-plugin/src/rollup-bundle-analysis/__tests__/__snapshots__/rollupBundleAnalysisPlugin.test.ts.snap
@@ -9,7 +9,7 @@ exports[`rollupBundleAnalysisPlugin > when called > returns a plugin object 1`] 
   "rollup": {
     "generateBundle": [Function],
   },
-  "version": "1",
+  "version": "2",
   "writeBundle": [Function],
 }
 `;

--- a/packages/rollup-plugin/src/rollup-bundle-analysis/rollupBundleAnalysisPlugin.ts
+++ b/packages/rollup-plugin/src/rollup-bundle-analysis/rollupBundleAnalysisPlugin.ts
@@ -6,6 +6,7 @@ import {
   type BundleAnalysisUploadPlugin,
   red,
   normalizePath,
+  getCompressedSize,
 } from "@codecov/bundler-plugin-core";
 
 // @ts-expect-error this value is being replaced by rollup
@@ -16,7 +17,7 @@ const PLUGIN_VERSION = __PACKAGE_VERSION__ as string;
 export const rollupBundleAnalysisPlugin: BundleAnalysisUploadPlugin = ({
   output,
 }) => ({
-  version: "1",
+  version: output.version,
   name: PLUGIN_NAME,
   pluginVersion: PLUGIN_VERSION,
   buildStart: () => {
@@ -30,7 +31,7 @@ export const rollupBundleAnalysisPlugin: BundleAnalysisUploadPlugin = ({
     await output.write();
   },
   rollup: {
-    generateBundle(this, options, bundle) {
+    async generateBundle(this, options, bundle) {
       // TODO - remove this once we hard fail on not having a bundle name
       // don't need to do anything if the bundle name is not present or empty
       if (!output.bundleName || output.bundleName === "") {
@@ -78,9 +79,15 @@ export const rollupBundleAnalysisPlugin: BundleAnalysisUploadPlugin = ({
               continue;
             }
 
+            const compressedSize = await getCompressedSize({
+              fileName,
+              code: item.source,
+            });
+
             assets.push({
               name: fileName,
               size: size,
+              gzipSize: compressedSize,
               normalized: normalizePath(fileName, assetFormatString),
             });
           } else {
@@ -91,9 +98,15 @@ export const rollupBundleAnalysisPlugin: BundleAnalysisUploadPlugin = ({
               continue;
             }
 
+            const compressedSize = await getCompressedSize({
+              fileName,
+              code: item.source,
+            });
+
             assets.push({
               name: fileName,
               size: size,
+              gzipSize: compressedSize,
               normalized: normalizePath(fileName, assetFormatString),
             });
           }
@@ -110,9 +123,15 @@ export const rollupBundleAnalysisPlugin: BundleAnalysisUploadPlugin = ({
             continue;
           }
 
+          const compressedSize = await getCompressedSize({
+            fileName,
+            code: item.code,
+          });
+
           assets.push({
             name: fileName,
             size: size,
+            gzipSize: compressedSize,
             normalized: normalizePath(fileName, chunkFormatString),
           });
 

--- a/packages/sveltekit-plugin/src/sveltekit-bundle-analysis/__tests__/__snapshots__/sveltekitBundleAnalysisPlugin.test.ts.snap
+++ b/packages/sveltekit-plugin/src/sveltekit-bundle-analysis/__tests__/__snapshots__/sveltekitBundleAnalysisPlugin.test.ts.snap
@@ -4,7 +4,7 @@ exports[`sveltekitBundleAnalysisPlugin > when called > returns a plugin object 1
 {
   "name": "@codecov/sveltekit-plugin",
   "pluginVersion": "0.0.1-beta.10",
-  "version": "1",
+  "version": "2",
   "vite": {
     "generateBundle": [Function],
   },

--- a/packages/sveltekit-plugin/src/sveltekit-bundle-analysis/sveltekitBundleAnalysisPlugin.ts
+++ b/packages/sveltekit-plugin/src/sveltekit-bundle-analysis/sveltekitBundleAnalysisPlugin.ts
@@ -12,7 +12,7 @@ const PLUGIN_VERSION = __PACKAGE_VERSION__ as string;
 export const sveltekitBundleAnalysisPlugin: BundleAnalysisUploadPlugin = ({
   output,
 }) => ({
-  version: "1",
+  version: output.version,
   name: PLUGIN_NAME,
   pluginVersion: PLUGIN_VERSION,
   vite: {

--- a/packages/vite-plugin/src/vite-bundle-analysis/__tests__/__snapshots__/viteBundleAnalysisPlugin.test.ts.snap
+++ b/packages/vite-plugin/src/vite-bundle-analysis/__tests__/__snapshots__/viteBundleAnalysisPlugin.test.ts.snap
@@ -6,7 +6,7 @@ exports[`viteBundleAnalysisPlugin > when called > returns a plugin object 1`] = 
   "buildStart": [Function],
   "name": "@codecov/vite-plugin",
   "pluginVersion": "0.0.1-beta.10",
-  "version": "1",
+  "version": "2",
   "vite": {
     "generateBundle": [Function],
   },

--- a/packages/vite-plugin/src/vite-bundle-analysis/viteBundleAnalysisPlugin.ts
+++ b/packages/vite-plugin/src/vite-bundle-analysis/viteBundleAnalysisPlugin.ts
@@ -6,6 +6,7 @@ import {
   type Module,
   type BundleAnalysisUploadPlugin,
   red,
+  getCompressedSize,
 } from "@codecov/bundler-plugin-core";
 
 // @ts-expect-error this value is being replaced by rollup
@@ -16,7 +17,7 @@ const PLUGIN_VERSION = __PACKAGE_VERSION__ as string;
 export const viteBundleAnalysisPlugin: BundleAnalysisUploadPlugin = ({
   output,
 }) => ({
-  version: "1",
+  version: output.version,
   name: PLUGIN_NAME,
   pluginVersion: PLUGIN_VERSION,
   buildStart: () => {
@@ -30,7 +31,7 @@ export const viteBundleAnalysisPlugin: BundleAnalysisUploadPlugin = ({
     await output.write();
   },
   vite: {
-    generateBundle(this, options, bundle) {
+    async generateBundle(this, options, bundle) {
       // TODO - remove this once we hard fail on not having a bundle name
       // don't need to do anything if the bundle name is not present or empty
       if (!output.bundleName || output.bundleName === "") {
@@ -79,9 +80,15 @@ export const viteBundleAnalysisPlugin: BundleAnalysisUploadPlugin = ({
               continue;
             }
 
+            const compressedSize = await getCompressedSize({
+              fileName,
+              code: item.source,
+            });
+
             assets.push({
               name: fileName,
               size: size,
+              gzipSize: compressedSize,
               normalized: normalizePath(fileName, assetFormatString),
             });
           } else {
@@ -92,9 +99,15 @@ export const viteBundleAnalysisPlugin: BundleAnalysisUploadPlugin = ({
               continue;
             }
 
+            const compressedSize = await getCompressedSize({
+              fileName,
+              code: item.source,
+            });
+
             assets.push({
               name: fileName,
               size: size,
+              gzipSize: compressedSize,
               normalized: normalizePath(fileName, assetFormatString),
             });
           }
@@ -111,9 +124,15 @@ export const viteBundleAnalysisPlugin: BundleAnalysisUploadPlugin = ({
             continue;
           }
 
+          const compressedSize = await getCompressedSize({
+            fileName,
+            code: item.code,
+          });
+
           assets.push({
             name: fileName,
             size: size,
+            gzipSize: compressedSize,
             normalized: normalizePath(fileName, chunkFormatString),
           });
 

--- a/packages/webpack-plugin/src/webpack-bundle-analysis/__tests__/__snapshots__/webpackBundleAnalysisPlugin.test.ts.snap
+++ b/packages/webpack-plugin/src/webpack-bundle-analysis/__tests__/__snapshots__/webpackBundleAnalysisPlugin.test.ts.snap
@@ -6,7 +6,7 @@ exports[`webpackBundleAnalysisPlugin > when called > returns a plugin object 1`]
   "buildStart": [Function],
   "name": "@codecov/webpack-plugin",
   "pluginVersion": "0.0.1-beta.10",
-  "version": "1",
+  "version": "2",
   "webpack": [Function],
   "writeBundle": [Function],
 }


### PR DESCRIPTION
# Description

This PR adds in support for directly collect gzip values from a set of specific asset types.

Closes codecov/engineering-team#1820

# Notable Changes

- Add in function to calculate gzip values
- Update `Asset` type to include `gzipSize` field
- Update Rollup, Vite, and Webpack to collect gzip data
- Update stats schema version to `2`
- Update unit tests
- Update integration tests
