### PR TITLE
chore: Align Change Sets for 1.0.0 release

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "beta",
   "initialVersions": {
     "@codecov/bundler-plugin-core": "0.0.0",

--- a/.changeset/shiny-ghosts-play.md
+++ b/.changeset/shiny-ghosts-play.md
@@ -10,22 +10,22 @@
 "@codecov/webpack-plugin": major
 ---
 
-Release 1.0.0 of the plugins. You can read more about the plugins in our [docs](https://docs.codecov.com/docs/javascript-bundle-analysis).
+Release 1.0.0 of the plugins. You can read more about the plugins and bundle analysis in our [docs](https://docs.codecov.com/docs/javascript-bundle-analysis).
 
 The plugins currently support the following frameworks and meta-frameworks:
 
-- Next.js
-- Nuxt.js
-- Remix (Vite)
-- Rollup
-- SolidStart
-- SvelteKit
-- Vite
-- Webpack
+- NextJS (Webpack) - [Docs](https://dash.readme.com/project/codecov/v2023/docs/nextjs-webpack-quick-start)
+- Nuxt - [Docs](https://dash.readme.com/project/codecov/v2023/docs/nuxt-quick-start)
+- Remix (Vite) - [Docs](https://dash.readme.com/project/codecov/v2023/docs/remix-vite-quick-start)
+- Rollup - [Docs](https://dash.readme.com/project/codecov/v2023/docs/rollup-quick-start)
+- SolidStart - [Docs](https://dash.readme.com/project/codecov/v2023/docs/sveltekit-quick-start)
+- SvelteKit - [Docs](https://dash.readme.com/project/codecov/v2023/docs/solidstart-quick-start)
+- Vite - [Docs](https://dash.readme.com/project/codecov/v2023/docs/vite-quick-start-vue-sveltekit-remix-solidjs-etc)
+- Webpack - [Docs](https://dash.readme.com/project/codecov/v2023/docs/webpack-quick-start-nextjs-craco)
 
 The plugins have the following functionality:
 
 - Automatically collect and upload bundle stats data to Codecov
-- Tokenless uploads of bundle stats for forked upstream pull requests
-- GH OIDC authentication for users or organizations who have configured it with GitHub
+- Tokenless uploads of bundle stats for forked upstream pull requests - [Docs](https://dash.readme.com/project/codecov/v2023/docs/tokenless-bundle-analysis)
+- GH OIDC authentication for users or organizations who have configured it with GitHub - [Docs](https://dash.readme.com/project/codecov/v2023/docs/github-oidc-bundle-analysis)
 - Support for Codecov Enterprise and self hosted users

--- a/.changeset/shiny-ghosts-play.md
+++ b/.changeset/shiny-ghosts-play.md
@@ -10,4 +10,22 @@
 "@codecov/webpack-plugin": major
 ---
 
-Release 1.0.0 of the plugins
+Release 1.0.0 of the plugins. You can read more about the plugins in our [docs](https://docs.codecov.com/docs/javascript-bundle-analysis).
+
+The plugins currently support the following frameworks and meta-frameworks:
+
+- Next.js
+- Nuxt.js
+- Remix (Vite)
+- Rollup
+- SolidStart
+- SvelteKit
+- Vite
+- Webpack
+
+The plugins have the following functionality:
+
+- Automatically collect and upload bundle stats data to Codecov
+- Tokenless uploads of bundle stats for forked upstream pull requests
+- GH OIDC authentication for users or organizations who have configured it with GitHub
+- Support for Codecov Enterprise and self hosted users

--- a/.changeset/shiny-ghosts-play.md
+++ b/.changeset/shiny-ghosts-play.md
@@ -1,0 +1,13 @@
+---
+"@codecov/bundler-plugin-core": major
+"@codecov/nextjs-webpack-plugin": major
+"@codecov/nuxt-plugin": major
+"@codecov/remix-vite-plugin": major
+"@codecov/rollup-plugin": major
+"@codecov/solidstart-plugin": major
+"@codecov/sveltekit-plugin": major
+"@codecov/vite-plugin": major
+"@codecov/webpack-plugin": major
+---
+
+Release 1.0.0 of the plugins


### PR DESCRIPTION
# Description

This PR sets everything up for the `1.0.0` release of the plugins, adding in a major release as well as exiting pre-mode. Here is an example after running `prepare-publish` ensuring that everything is working as expected with changeset: https://github.com/codecov/codecov-javascript-bundler-plugins/pull/165

- codecov/engineering-team#2440
- codecov/engineering-team#2441