### PR TITLE
fix: Dynamically import webpack in webpack plugin

### DIFF
--- a/.changeset/thin-dryers-joke.md
+++ b/.changeset/thin-dryers-joke.md
@@ -1,0 +1,13 @@
+---
+"@codecov/webpack-plugin": patch
+"@codecov/bundler-plugin-core": patch
+"@codecov/nextjs-webpack-plugin": patch
+"@codecov/nuxt-plugin": patch
+"@codecov/remix-vite-plugin": patch
+"@codecov/rollup-plugin": patch
+"@codecov/solidstart-plugin": patch
+"@codecov/sveltekit-plugin": patch
+"@codecov/vite-plugin": patch
+---
+
+Switch webpack import from top level to dynamic in the webpack base plugin

--- a/packages/webpack-plugin/src/webpack-bundle-analysis/webpackBundleAnalysisPlugin.ts
+++ b/packages/webpack-plugin/src/webpack-bundle-analysis/webpackBundleAnalysisPlugin.ts
@@ -1,5 +1,6 @@
 import { type BundleAnalysisUploadPlugin } from "@codecov/bundler-plugin-core";
-import * as webpack from "webpack";
+import { createRequire } from "node:module";
+import type * as TWebpack from "webpack";
 
 import { processAssets, processChunks, processModules } from "./utils";
 
@@ -25,6 +26,10 @@ export const webpackBundleAnalysisPlugin: BundleAnalysisUploadPlugin = ({
     await output.write();
   },
   webpack(compiler) {
+    const webpack = createRequire(import.meta.url)(
+      "webpack",
+    ) as typeof TWebpack;
+
     compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
       compilation.hooks.processAssets.tapPromise(
         {


### PR DESCRIPTION
# Description

This PR updates the webpack plugin, to dynamically import webpack so that we shouldn't have any issues with conflicting webpack issues with NextJS
