### PR TITLE
chore: Add in new debug logs, and expand on current logs

### DIFF
--- a/.changeset/moody-camels-accept.md
+++ b/.changeset/moody-camels-accept.md
@@ -1,0 +1,14 @@
+---
+"@codecov/bundler-plugin-core": minor
+"@codecov/bundle-analyzer": minor
+"@codecov/nextjs-webpack-plugin": minor
+"@codecov/nuxt-plugin": minor
+"@codecov/remix-vite-plugin": minor
+"@codecov/rollup-plugin": minor
+"@codecov/solidstart-plugin": minor
+"@codecov/sveltekit-plugin": minor
+"@codecov/vite-plugin": minor
+"@codecov/webpack-plugin": minor
+---
+
+Add in better debug logging when fetching pre-signed url or uploading stats fail. Update current logs to have more details present.

--- a/packages/bundler-plugin-core/src/utils/Output.ts
+++ b/packages/bundler-plugin-core/src/utils/Output.ts
@@ -11,6 +11,7 @@ import { type NormalizedOptions } from "./normalizeOptions.ts";
 import { detectProvider } from "./provider.ts";
 import { uploadStats } from "./uploadStats.ts";
 import { type ValidGitService } from "./normalizeOptions";
+import { debug } from "./logging.ts";
 
 class Output {
   // base user options
@@ -159,6 +160,10 @@ class Output {
       if (emitError) {
         throw error;
       }
+
+      debug(`Error getting pre-signed URL: "${error}"`, {
+        enabled: this.debug,
+      });
       return;
     }
 
@@ -173,6 +178,7 @@ class Output {
       if (emitError) {
         throw error;
       }
+      debug(`Error uploading stats: "${error}"`, { enabled: this.debug });
       return;
     }
 

--- a/packages/bundler-plugin-core/src/utils/__tests__/Output.test.ts
+++ b/packages/bundler-plugin-core/src/utils/__tests__/Output.test.ts
@@ -12,6 +12,7 @@ import {
 
 import { detectProvider } from "../provider";
 import { Output } from "../Output";
+import chalk from "chalk";
 
 vi.mock("../provider");
 
@@ -338,6 +339,31 @@ describe("Output", () => {
         await output.write();
       });
 
+      it("logs error when debug is enabled", async () => {
+        setup({ urlSendError: true });
+
+        const output = new Output({
+          apiUrl: "http://localhost",
+          bundleName: "output-test",
+          debug: true,
+          dryRun: false,
+          enableBundleAnalysis: true,
+          retryCount: 1,
+          uploadToken: "token",
+        });
+
+        output.start();
+        output.end();
+
+        await output.write();
+
+        expect(consoleSpy).toHaveBeenCalledWith(
+          `[codecov] ${chalk.italic.yellow(
+            'Error getting pre-signed URL: "Error: Failed to fetch pre-signed URL"',
+          )}`,
+        );
+      });
+
       it("optionally emits error", async () => {
         setup({ urlSendError: true });
 
@@ -428,6 +454,35 @@ describe("Output", () => {
         output.end();
 
         await output.write();
+      });
+
+      it("logs error when debug is enabled", async () => {
+        setup({
+          urlData: { url: "http://localhost/upload/stats/" },
+          urlStatus: 200,
+          statsSendError: true,
+        });
+
+        const output = new Output({
+          apiUrl: "http://localhost",
+          bundleName: "output-test",
+          debug: true,
+          dryRun: false,
+          enableBundleAnalysis: true,
+          retryCount: 1,
+          uploadToken: "token",
+        });
+
+        output.start();
+        output.end();
+
+        await output.write();
+
+        expect(consoleSpy).toHaveBeenCalledWith(
+          `[codecov] ${chalk.italic.yellow(
+            'Error uploading stats: "Error: Failed to upload stats"',
+          )}`,
+        );
       });
 
       it("optionally emits error", async () => {

--- a/packages/bundler-plugin-core/src/utils/__tests__/getPreSignedURL.test.ts
+++ b/packages/bundler-plugin-core/src/utils/__tests__/getPreSignedURL.test.ts
@@ -21,6 +21,7 @@ import { UploadLimitReachedError } from "../../errors/UploadLimitReachedError.ts
 import { UndefinedGitServiceError } from "../../errors/UndefinedGitServiceError.ts";
 import { BadOIDCServiceError } from "src/errors/BadOIDCServiceError.ts";
 import { FailedOIDCFetchError } from "src/errors/FailedOIDCFetchError.ts";
+import Chalk from "chalk";
 
 const mocks = vi.hoisted(() => ({
   getIDToken: vi.fn().mockReturnValue(""),
@@ -353,8 +354,10 @@ describe("getPreSignedURL", () => {
           error = e;
         }
 
-        expect(consoleSpy).toHaveBeenCalled();
         expect(error).toBeInstanceOf(FailedFetchError);
+        expect(consoleSpy).toHaveBeenCalledWith(
+          `[codecov] ${Chalk.red('Failed to get pre-signed URL, bad response: "400 - Bad Request"')}`,
+        );
       });
     });
 

--- a/packages/bundler-plugin-core/src/utils/__tests__/uploadStats.test.ts
+++ b/packages/bundler-plugin-core/src/utils/__tests__/uploadStats.test.ts
@@ -14,6 +14,7 @@ import { uploadStats } from "../uploadStats";
 import { FailedUploadError } from "../../errors/FailedUploadError";
 import { FailedFetchError } from "../../errors/FailedFetchError";
 import { UploadLimitReachedError } from "../../errors/UploadLimitReachedError";
+import Chalk from "chalk";
 
 const server = setupServer();
 
@@ -120,7 +121,7 @@ describe("uploadStats", () => {
 
     describe("response is not ok", () => {
       it("throws a FailedUploadError", async () => {
-        setup({ sendError: false, status: 400 });
+        const { consoleSpy } = setup({ sendError: false, status: 400 });
 
         let error;
         try {
@@ -135,6 +136,11 @@ describe("uploadStats", () => {
         }
 
         expect(error).toBeInstanceOf(FailedUploadError);
+        expect(consoleSpy).toHaveBeenCalledWith(
+          `[codecov] ${Chalk.red(
+            'Failed to upload stats, bad response: "400 - Bad Request"',
+          )}`,
+        );
       });
     });
   });

--- a/packages/bundler-plugin-core/src/utils/getPreSignedURL.ts
+++ b/packages/bundler-plugin-core/src/utils/getPreSignedURL.ts
@@ -116,7 +116,9 @@ export const getPreSignedURL = async ({
   }
 
   if (!response.ok) {
-    red("Failed to get pre-signed URL, bad response");
+    red(
+      `Failed to get pre-signed URL, bad response: "${response.status} - ${response.statusText}"`,
+    );
     throw new FailedFetchError("Failed to get pre-signed URL");
   }
 

--- a/packages/bundler-plugin-core/src/utils/uploadStats.ts
+++ b/packages/bundler-plugin-core/src/utils/uploadStats.ts
@@ -61,7 +61,7 @@ export async function uploadStats({
 
   if (!response.ok) {
     red(
-      `Failed to upload stats, bad response. Response ${response.status} - ${response.statusText}`,
+      `Failed to upload stats, bad response: "${response.status} - ${response.statusText}"`,
     );
     throw new FailedUploadError("Failed to upload stats");
   }


### PR DESCRIPTION
# Description

This PR introduces some small tweaks to enable better debug-ability of the plugins, by expanding on the error messages and introducing some new debug logs.

# Notable Changes

- Add debug logs with error for getting pre-signed url and uploading stats
- Update bad response logs with more details