### PR TITLE
fix: Issue when hash length is set

### DIFF
--- a/.changeset/strong-readers-count.md
+++ b/.changeset/strong-readers-count.md
@@ -1,0 +1,14 @@
+---
+"@codecov/bundler-plugin-core": patch
+"@codecov/bundle-analyzer": patch
+"@codecov/nextjs-webpack-plugin": patch
+"@codecov/nuxt-plugin": patch
+"@codecov/remix-vite-plugin": patch
+"@codecov/rollup-plugin": patch
+"@codecov/solidstart-plugin": patch
+"@codecov/sveltekit-plugin": patch
+"@codecov/vite-plugin": patch
+"@codecov/webpack-plugin": patch
+---
+
+Fix issue with normalizing paths with a custom hash length is set

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,6 @@
 comment:
   layout: "condensed_header, condensed_files, components, condensed_footer"
 
-ai_pr_review:
-  enabled: true
-
 component_management:
   individual_components:
     - component_id: package_core

--- a/integration-tests/fixtures/generate-bundle-stats/rollup/__snapshots__/rollup-plugin.test.ts.snap
+++ b/integration-tests/fixtures/generate-bundle-stats/rollup/__snapshots__/rollup-plugin.test.ts.snap
@@ -776,7 +776,7 @@ exports[`Generating rollup stats 4 {"format":"amd","expected":"amd"} matches the
     {
       "gzipSize": 98808,
       "name": "main-H2_1FSsQ.js",
-      "normalized": "main-H2_1FSsQ.js",
+      "normalized": "main-*.js",
       "size": 577073,
     },
   ],

--- a/integration-tests/fixtures/generate-bundle-stats/vite/__snapshots__/vite-plugin.test.ts.snap
+++ b/integration-tests/fixtures/generate-bundle-stats/vite/__snapshots__/vite-plugin.test.ts.snap
@@ -1007,7 +1007,7 @@ exports[`Generating vite stats v5 {"format":"cjs","expected":"cjs"} matches the 
     {
       "gzipSize": 26812,
       "name": "assets/index-_9bu_Rar.js",
-      "normalized": "assets/index-_9bu_Rar.js",
+      "normalized": "assets/index-*.js",
       "size": 72342,
     },
   ],

--- a/integration-tests/fixtures/generate-bundle-stats/webpack/__snapshots__/webpack-plugin.test.ts.snap
+++ b/integration-tests/fixtures/generate-bundle-stats/webpack/__snapshots__/webpack-plugin.test.ts.snap
@@ -150,7 +150,7 @@ exports[`Generating webpack stats 5 {"format":"commonjs","expected":"cjs"} match
 }
 `;
 
-exports[`Generating webpack stats 5 source maps are enabled does not include any source maps 1`] = `
+exports[`Generating webpack stats 5 {"format":"module","expected":"esm"} matches the snapshot 1`] = `
 {
   "assets": [
     {
@@ -161,7 +161,7 @@ exports[`Generating webpack stats 5 source maps are enabled does not include any
     },
   ],
   "builtAt": Any<Number>,
-  "bundleName": StringNotContaining ".map",
+  "bundleName": StringContaining "test-webpack-v5-esm",
   "bundler": {
     "name": "webpack",
     "version": "5.90.0",
@@ -225,7 +225,7 @@ exports[`Generating webpack stats 5 source maps are enabled does not include any
 }
 `;
 
-exports[`Generating webpack stats 5 {"format":"module","expected":"esm"} matches the snapshot 1`] = `
+exports[`Generating webpack stats 5 source maps are enabled does not include any source maps 1`] = `
 {
   "assets": [
     {
@@ -236,7 +236,7 @@ exports[`Generating webpack stats 5 {"format":"module","expected":"esm"} matches
     },
   ],
   "builtAt": Any<Number>,
-  "bundleName": StringContaining "test-webpack-v5-esm",
+  "bundleName": StringNotContaining ".map",
   "bundler": {
     "name": "webpack",
     "version": "5.90.0",

--- a/packages/bundler-plugin-core/src/utils/__tests__/normalizePath.test.ts
+++ b/packages/bundler-plugin-core/src/utils/__tests__/normalizePath.test.ts
@@ -83,6 +83,38 @@ const tests: Test[] = [
     },
     expected: "test.*",
   },
+  {
+    name: "should replace '[hash:22]' with '*'",
+    input: {
+      path: "test.123.chunk.js",
+      format: "[name].[hash:22].chunk.js",
+    },
+    expected: "test.*.chunk.js",
+  },
+  {
+    name: "should replace '[contenthash:22]' with '*'",
+    input: {
+      path: "test.123.chunk.js",
+      format: "[name].[contenthash:22].chunk.js",
+    },
+    expected: "test.*.chunk.js",
+  },
+  {
+    name: "should replace '[fullhash:22]' with '*'",
+    input: {
+      path: "test.123.chunk.js",
+      format: "[name].[fullhash:22].chunk.js",
+    },
+    expected: "test.*.chunk.js",
+  },
+  {
+    name: "should replace '[chunkhash:22]' with '*'",
+    input: {
+      path: "test.123.chunk.js",
+      format: "[name].[chunkhash:22].chunk.js",
+    },
+    expected: "test.*.chunk.js",
+  },
 ];
 
 describe("normalizePath", () => {

--- a/packages/bundler-plugin-core/src/utils/__tests__/normalizePath.test.ts
+++ b/packages/bundler-plugin-core/src/utils/__tests__/normalizePath.test.ts
@@ -86,7 +86,7 @@ const tests: Test[] = [
   {
     name: "should replace '[hash:22]' with '*'",
     input: {
-      path: "test.123.chunk.js",
+      path: "test.CoScjXRp_rD9HKS--kYO73.chunk.js",
       format: "[name].[hash:22].chunk.js",
     },
     expected: "test.*.chunk.js",
@@ -94,7 +94,7 @@ const tests: Test[] = [
   {
     name: "should replace '[contenthash:22]' with '*'",
     input: {
-      path: "test.123.chunk.js",
+      path: "test.CoScjXRp_rD9HKS--kYO73.chunk.js",
       format: "[name].[contenthash:22].chunk.js",
     },
     expected: "test.*.chunk.js",
@@ -102,7 +102,7 @@ const tests: Test[] = [
   {
     name: "should replace '[fullhash:22]' with '*'",
     input: {
-      path: "test.123.chunk.js",
+      path: "test.CoScjXRp_rD9HKS--kYO73.chunk.js",
       format: "[name].[fullhash:22].chunk.js",
     },
     expected: "test.*.chunk.js",
@@ -110,7 +110,7 @@ const tests: Test[] = [
   {
     name: "should replace '[chunkhash:22]' with '*'",
     input: {
-      path: "test.123.chunk.js",
+      path: "test.CoScjXRp_rD9HKS--kYO73.chunk.js",
       format: "[name].[chunkhash:22].chunk.js",
     },
     expected: "test.*.chunk.js",

--- a/packages/bundler-plugin-core/src/utils/normalizePath.ts
+++ b/packages/bundler-plugin-core/src/utils/normalizePath.ts
@@ -47,8 +47,8 @@ export const normalizePath = (path: string, format: string): string => {
 
     // create a regex that will match the hash
     // potential values gathered from: https://en.wikipedia.org/wiki/Base64
-    // added in `\-` to account for the `-` character which seems to be used by Rollup through testing
-    const regexString = `(${leadingRegex}(?<hash>[0-9a-zA-Z\/+=-]+)${endingRegex})`;
+    // added in `\-` and `\_` to account for the `-` `_` as they are included in the potential hashes: https://rollupjs.org/configuration-options/#output-hashcharacters
+    const regexString = `(${leadingRegex}(?<hash>[0-9a-zA-Z/\+=_\/+=-]+)${endingRegex})`;
     const HASH_REPLACE_REGEX = new RegExp(regexString, "i");
 
     // replace the hash with a wildcard and the delimiters

--- a/packages/bundler-plugin-core/src/utils/normalizePath.ts
+++ b/packages/bundler-plugin-core/src/utils/normalizePath.ts
@@ -30,11 +30,11 @@ export const normalizePath = (path: string, format: string): string => {
 
     // grab the ending delimiter and create a regex group for it
     let endingDelimiter = "";
-    [...format.slice(match.hashIndex)].forEach((char, index) => {
-      if (char === "]") {
-        endingDelimiter = format.at(match.hashIndex + index + 1) ?? "";
-      }
-    });
+
+    endingDelimiter =
+      format.at(
+        match.hashIndex + format.slice(match.hashIndex).indexOf("]") + 1,
+      ) ?? "";
 
     // If the ending delimiter is `[extname]` there won't be a
     // `.<file-extension>` so we need to replace it with a `.` for the

--- a/packages/bundler-plugin-core/src/utils/normalizePath.ts
+++ b/packages/bundler-plugin-core/src/utils/normalizePath.ts
@@ -1,10 +1,5 @@
 const HASH_REGEX = /[a-f0-9]{8,}/i;
-const POTENTIAL_HASHES = [
-  "[hash]",
-  "[contenthash]",
-  "[fullhash]",
-  "[chunkhash]",
-];
+const POTENTIAL_HASHES = ["[contenthash", "[fullhash", "[chunkhash", "[hash"];
 
 const escapeRegex = (string: string): string =>
   string.replace(/[|\\{}()[\]^$+*?.]/g, "\\$&").replace(/-/g, "\\x2d");
@@ -34,8 +29,12 @@ export const normalizePath = (path: string, format: string): string => {
     )})`;
 
     // grab the ending delimiter and create a regex group for it
-    let endingDelimiter =
-      format.at(match.hashIndex + match.hashString.length) ?? "";
+    let endingDelimiter = "";
+    [...format.slice(match.hashIndex)].forEach((char, index) => {
+      if (char === "]") {
+        endingDelimiter = format.at(match.hashIndex + index + 1) ?? "";
+      }
+    });
 
     // If the ending delimiter is `[extname]` there won't be a
     // `.<file-extension>` so we need to replace it with a `.` for the

--- a/packages/bundler-plugin-core/src/utils/normalizePath.ts
+++ b/packages/bundler-plugin-core/src/utils/normalizePath.ts
@@ -28,13 +28,10 @@ export const normalizePath = (path: string, format: string): string => {
       leadingDelimiter,
     )})`;
 
+    const closingBracketIndex = format.slice(match.hashIndex).indexOf("]");
     // grab the ending delimiter and create a regex group for it
-    let endingDelimiter = "";
-
-    endingDelimiter =
-      format.at(
-        match.hashIndex + format.slice(match.hashIndex).indexOf("]") + 1,
-      ) ?? "";
+    let endingDelimiter =
+      format.at(match.hashIndex + closingBracketIndex + 1) ?? "";
 
     // If the ending delimiter is `[extname]` there won't be a
     // `.<file-extension>` so we need to replace it with a `.` for the


### PR DESCRIPTION
# Description

We're currently unable to handle normalizing strings when hashes have a custom length set `[hash:16]` for example. This PR resolves this issue by searching for the `]` character after finding the starting hash string match.

# Notable Changes

- Update `normalizePath` to handle custom hash lengths
- Update tests