### PR TITLE
Correct `GITHUB_ACTIONS` variable and add missing `GITHUB_JOB`

### DIFF
--- a/packages/bundler-plugin-core/src/utils/providers/GitHubActions.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/GitHubActions.ts
@@ -214,7 +214,8 @@ export async function getServiceParams(
 
 export function getEnvVarNames() {
   return [
-    "GITHUB_ACTION",
+    "GITHUB_ACTIONS",
+    "GITHUB_JOB",
     "GITHUB_HEAD_REF",
     "GITHUB_REF",
     "GITHUB_REPOSITORY",


### PR DESCRIPTION
It took me nearly 3 hours to debug this package. I can't believe in my eyes. My eyes are burning right now :(

# Description

# Code Example

# Notable Changes

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
