### PR TITLE
chore: Resolve vite vulns

### DIFF
--- a/.changeset/giant-peas-matter.md
+++ b/.changeset/giant-peas-matter.md
@@ -1,0 +1,14 @@
+---
+"@codecov/nextjs-webpack-plugin": minor
+"@codecov/remix-vite-plugin": minor
+"@codecov/solidstart-plugin": minor
+"@codecov/sveltekit-plugin": minor
+"@codecov/bundle-analyzer": minor
+"@codecov/webpack-plugin": minor
+"@codecov/nuxt-plugin": minor
+"@codecov/vite-plugin": minor
+"@codecov/bundler-plugin-core": minor
+"@codecov/rollup-plugin": minor
+---
+
+Bump vite versions

--- a/examples/oidc/package.json
+++ b/examples/oidc/package.json
@@ -25,7 +25,7 @@
     "eslint-plugin-react-refresh": "^0.4.5",
     "rollup": "^4.9.6",
     "typescript": "^5.3.3",
-    "vite": "^5.2.10"
+    "vite": "^5.2.14"
   },
   "volta": {
     "extends": "../../package.json"

--- a/examples/remix/package.json
+++ b/examples/remix/package.json
@@ -35,7 +35,7 @@
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.4",
     "typescript": "^5.1.6",
-    "vite": "^5.1.0",
+    "vite": "^5.1.8",
     "vite-tsconfig-paths": "^4.2.1"
   },
   "engines": {

--- a/examples/sveltekit/package.json
+++ b/examples/sveltekit/package.json
@@ -19,7 +19,7 @@
     "svelte-check": "^3.6.0",
     "tslib": "^2.4.1",
     "typescript": "^5.0.0",
-    "vite": "^5.0.3"
+    "vite": "^5.1.8"
   },
   "type": "module"
 }

--- a/examples/tokenless/package.json
+++ b/examples/tokenless/package.json
@@ -25,7 +25,7 @@
     "eslint-plugin-react-refresh": "^0.4.5",
     "rollup": "^4.9.6",
     "typescript": "^5.3.3",
-    "vite": "^5.2.10"
+    "vite": "^5.2.14"
   },
   "volta": {
     "extends": "../../package.json"

--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -25,7 +25,7 @@
     "eslint-plugin-react-refresh": "^0.4.5",
     "rollup": "^4.9.6",
     "typescript": "^5.3.3",
-    "vite": "^5.2.10"
+    "vite": "^5.2.14"
   },
   "volta": {
     "extends": "../../package.json"

--- a/integration-tests/fixtures/generate-bundle-stats/nuxt/__snapshots__/nuxt-plugin.test.ts.snap
+++ b/integration-tests/fixtures/generate-bundle-stats/nuxt/__snapshots__/nuxt-plugin.test.ts.snap
@@ -7,7 +7,7 @@ exports[`Generating nuxt stats 3 {"format":"amd","expected":"amd"} matches the s
   "bundleName": StringContaining "test-nuxt-v3-client-amd",
   "bundler": {
     "name": "rollup",
-    "version": "4.26.0",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -28,7 +28,7 @@ exports[`Generating nuxt stats 3 {"format":"amd","expected":"amd"} matches the s
   "bundleName": StringContaining "test-nuxt-v3-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.26.0",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -49,7 +49,7 @@ exports[`Generating nuxt stats 3 {"format":"cjs","expected":"cjs"} matches the s
   "bundleName": StringContaining "test-nuxt-v3-client-cjs",
   "bundler": {
     "name": "rollup",
-    "version": "4.26.0",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -70,7 +70,7 @@ exports[`Generating nuxt stats 3 {"format":"cjs","expected":"cjs"} matches the s
   "bundleName": StringContaining "test-nuxt-v3-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.26.0",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -91,7 +91,7 @@ exports[`Generating nuxt stats 3 {"format":"es","expected":"esm"} matches the sn
   "bundleName": StringContaining "test-nuxt-v3-client-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.26.0",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -112,7 +112,7 @@ exports[`Generating nuxt stats 3 {"format":"es","expected":"esm"} matches the sn
   "bundleName": StringContaining "test-nuxt-v3-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.26.0",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -133,7 +133,7 @@ exports[`Generating nuxt stats 3 {"format":"esm","expected":"esm"} matches the s
   "bundleName": StringContaining "test-nuxt-v3-client-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.26.0",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -154,7 +154,7 @@ exports[`Generating nuxt stats 3 {"format":"esm","expected":"esm"} matches the s
   "bundleName": StringContaining "test-nuxt-v3-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.26.0",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -175,7 +175,7 @@ exports[`Generating nuxt stats 3 {"format":"module","expected":"esm"} matches th
   "bundleName": StringContaining "test-nuxt-v3-client-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.26.0",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -196,7 +196,7 @@ exports[`Generating nuxt stats 3 {"format":"module","expected":"esm"} matches th
   "bundleName": StringContaining "test-nuxt-v3-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.26.0",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -217,7 +217,7 @@ exports[`Generating nuxt stats 3 {"format":"iife","expected":"iife"} matches the
   "bundleName": StringContaining "test-nuxt-v3-client-iife",
   "bundler": {
     "name": "rollup",
-    "version": "4.26.0",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -238,7 +238,7 @@ exports[`Generating nuxt stats 3 {"format":"iife","expected":"iife"} matches the
   "bundleName": StringContaining "test-nuxt-v3-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.26.0",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -259,7 +259,7 @@ exports[`Generating nuxt stats 3 {"format":"umd","expected":"umd"} matches the s
   "bundleName": StringContaining "test-nuxt-v3-client-umd",
   "bundler": {
     "name": "rollup",
-    "version": "4.26.0",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -280,7 +280,7 @@ exports[`Generating nuxt stats 3 {"format":"umd","expected":"umd"} matches the s
   "bundleName": StringContaining "test-nuxt-v3-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.26.0",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -301,7 +301,7 @@ exports[`Generating nuxt stats 3 {"format":"system","expected":"system"} matches
   "bundleName": StringContaining "test-nuxt-v3-client-system",
   "bundler": {
     "name": "rollup",
-    "version": "4.26.0",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -322,7 +322,7 @@ exports[`Generating nuxt stats 3 {"format":"system","expected":"system"} matches
   "bundleName": StringContaining "test-nuxt-v3-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.26.0",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -343,7 +343,7 @@ exports[`Generating nuxt stats 3 {"format":"systemjs","expected":"system"} match
   "bundleName": StringContaining "test-nuxt-v3-client-system",
   "bundler": {
     "name": "rollup",
-    "version": "4.26.0",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -364,7 +364,7 @@ exports[`Generating nuxt stats 3 {"format":"systemjs","expected":"system"} match
   "bundleName": StringContaining "test-nuxt-v3-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.26.0",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,

--- a/integration-tests/fixtures/generate-bundle-stats/nuxt/__snapshots__/nuxt-plugin.test.ts.snap
+++ b/integration-tests/fixtures/generate-bundle-stats/nuxt/__snapshots__/nuxt-plugin.test.ts.snap
@@ -7,7 +7,7 @@ exports[`Generating nuxt stats 3 {"format":"amd","expected":"amd"} matches the s
   "bundleName": StringContaining "test-nuxt-v3-client-amd",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.26.0",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -28,7 +28,7 @@ exports[`Generating nuxt stats 3 {"format":"amd","expected":"amd"} matches the s
   "bundleName": StringContaining "test-nuxt-v3-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.26.0",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -49,7 +49,7 @@ exports[`Generating nuxt stats 3 {"format":"cjs","expected":"cjs"} matches the s
   "bundleName": StringContaining "test-nuxt-v3-client-cjs",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.26.0",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -70,7 +70,7 @@ exports[`Generating nuxt stats 3 {"format":"cjs","expected":"cjs"} matches the s
   "bundleName": StringContaining "test-nuxt-v3-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.26.0",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -91,7 +91,7 @@ exports[`Generating nuxt stats 3 {"format":"es","expected":"esm"} matches the sn
   "bundleName": StringContaining "test-nuxt-v3-client-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.26.0",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -112,7 +112,7 @@ exports[`Generating nuxt stats 3 {"format":"es","expected":"esm"} matches the sn
   "bundleName": StringContaining "test-nuxt-v3-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.26.0",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -133,7 +133,7 @@ exports[`Generating nuxt stats 3 {"format":"esm","expected":"esm"} matches the s
   "bundleName": StringContaining "test-nuxt-v3-client-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.26.0",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -154,7 +154,7 @@ exports[`Generating nuxt stats 3 {"format":"esm","expected":"esm"} matches the s
   "bundleName": StringContaining "test-nuxt-v3-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.26.0",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -175,7 +175,7 @@ exports[`Generating nuxt stats 3 {"format":"module","expected":"esm"} matches th
   "bundleName": StringContaining "test-nuxt-v3-client-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.26.0",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -196,7 +196,7 @@ exports[`Generating nuxt stats 3 {"format":"module","expected":"esm"} matches th
   "bundleName": StringContaining "test-nuxt-v3-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.26.0",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -217,7 +217,7 @@ exports[`Generating nuxt stats 3 {"format":"iife","expected":"iife"} matches the
   "bundleName": StringContaining "test-nuxt-v3-client-iife",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.26.0",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -238,7 +238,7 @@ exports[`Generating nuxt stats 3 {"format":"iife","expected":"iife"} matches the
   "bundleName": StringContaining "test-nuxt-v3-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.26.0",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -259,7 +259,7 @@ exports[`Generating nuxt stats 3 {"format":"umd","expected":"umd"} matches the s
   "bundleName": StringContaining "test-nuxt-v3-client-umd",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.26.0",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -280,7 +280,7 @@ exports[`Generating nuxt stats 3 {"format":"umd","expected":"umd"} matches the s
   "bundleName": StringContaining "test-nuxt-v3-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.26.0",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -301,7 +301,7 @@ exports[`Generating nuxt stats 3 {"format":"system","expected":"system"} matches
   "bundleName": StringContaining "test-nuxt-v3-client-system",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.26.0",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -322,7 +322,7 @@ exports[`Generating nuxt stats 3 {"format":"system","expected":"system"} matches
   "bundleName": StringContaining "test-nuxt-v3-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.26.0",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -343,7 +343,7 @@ exports[`Generating nuxt stats 3 {"format":"systemjs","expected":"system"} match
   "bundleName": StringContaining "test-nuxt-v3-client-system",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.26.0",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -364,7 +364,7 @@ exports[`Generating nuxt stats 3 {"format":"systemjs","expected":"system"} match
   "bundleName": StringContaining "test-nuxt-v3-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.26.0",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,

--- a/integration-tests/fixtures/generate-bundle-stats/remix/__snapshots__/remix-plugin.test.ts.snap
+++ b/integration-tests/fixtures/generate-bundle-stats/remix/__snapshots__/remix-plugin.test.ts.snap
@@ -7,7 +7,7 @@ exports[`Generating remix stats 2 {"format":"amd","expected":"amd"} matches the 
   "bundleName": StringContaining "test-remix-v2-client-amd",
   "bundler": {
     "name": "rollup",
-    "version": "4.16.2",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -28,7 +28,7 @@ exports[`Generating remix stats 2 {"format":"amd","expected":"amd"} matches the 
   "bundleName": StringContaining "test-remix-v2-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.16.2",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -49,7 +49,7 @@ exports[`Generating remix stats 2 {"format":"cjs","expected":"cjs"} matches the 
   "bundleName": StringContaining "test-remix-v2-client-cjs",
   "bundler": {
     "name": "rollup",
-    "version": "4.16.2",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -70,7 +70,7 @@ exports[`Generating remix stats 2 {"format":"cjs","expected":"cjs"} matches the 
   "bundleName": StringContaining "test-remix-v2-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.16.2",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -91,7 +91,7 @@ exports[`Generating remix stats 2 {"format":"es","expected":"esm"} matches the s
   "bundleName": StringContaining "test-remix-v2-client-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.16.2",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -112,7 +112,7 @@ exports[`Generating remix stats 2 {"format":"es","expected":"esm"} matches the s
   "bundleName": StringContaining "test-remix-v2-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.16.2",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -133,7 +133,7 @@ exports[`Generating remix stats 2 {"format":"esm","expected":"esm"} matches the 
   "bundleName": StringContaining "test-remix-v2-client-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.16.2",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -154,7 +154,7 @@ exports[`Generating remix stats 2 {"format":"esm","expected":"esm"} matches the 
   "bundleName": StringContaining "test-remix-v2-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.16.2",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -175,7 +175,7 @@ exports[`Generating remix stats 2 {"format":"module","expected":"esm"} matches t
   "bundleName": StringContaining "test-remix-v2-client-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.16.2",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -196,7 +196,7 @@ exports[`Generating remix stats 2 {"format":"module","expected":"esm"} matches t
   "bundleName": StringContaining "test-remix-v2-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.16.2",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,

--- a/integration-tests/fixtures/generate-bundle-stats/remix/vite-base.config.ts
+++ b/integration-tests/fixtures/generate-bundle-stats/remix/vite-base.config.ts
@@ -20,7 +20,9 @@ export default defineConfig({
         v3_throwAbortReason: true,
       },
     }),
+    //@ts-expect-error handle conflicting vite version types
     tsconfigPaths(),
+    //@ts-expect-error handle conflicting vite version types
     codecovRemixVitePlugin({
       enableBundleAnalysis: true,
       bundleName: "test-remix-v2",

--- a/integration-tests/fixtures/generate-bundle-stats/sveltekit/__snapshots__/sveltekit-plugin.test.ts.snap
+++ b/integration-tests/fixtures/generate-bundle-stats/sveltekit/__snapshots__/sveltekit-plugin.test.ts.snap
@@ -7,7 +7,7 @@ exports[`Generating sveltekit stats 2 {"format":"es","expected":"esm"} matches t
   "bundleName": StringContaining "test-sveltekit-v2-client-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.16.2",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -28,7 +28,7 @@ exports[`Generating sveltekit stats 2 {"format":"es","expected":"esm"} matches t
   "bundleName": StringContaining "test-sveltekit-v2-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.16.2",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -49,7 +49,7 @@ exports[`Generating sveltekit stats 2 {"format":"esm","expected":"esm"} matches 
   "bundleName": StringContaining "test-sveltekit-v2-client-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.16.2",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -70,7 +70,7 @@ exports[`Generating sveltekit stats 2 {"format":"esm","expected":"esm"} matches 
   "bundleName": StringContaining "test-sveltekit-v2-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.16.2",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -91,7 +91,7 @@ exports[`Generating sveltekit stats 2 {"format":"module","expected":"esm"} match
   "bundleName": StringContaining "test-sveltekit-v2-client-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.16.2",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -112,7 +112,7 @@ exports[`Generating sveltekit stats 2 {"format":"module","expected":"esm"} match
   "bundleName": StringContaining "test-sveltekit-v2-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.16.2",
+    "version": "4.21.2",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,

--- a/integration-tests/fixtures/generate-bundle-stats/sveltekit/vite-base.config.ts
+++ b/integration-tests/fixtures/generate-bundle-stats/sveltekit/vite-base.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
   plugins: [
     //@ts-expect-error handle conflicting vite version types
     sveltekit(),
+    //@ts-expect-error handle conflicting vite version types
     codecovSvelteKitPlugin({
       enableBundleAnalysis: true,
       bundleName: "test-sveltekit-v2",

--- a/integration-tests/fixtures/generate-bundle-stats/vite/__snapshots__/vite-plugin.test.ts.snap
+++ b/integration-tests/fixtures/generate-bundle-stats/vite/__snapshots__/vite-plugin.test.ts.snap
@@ -924,7 +924,7 @@ exports[`Generating vite stats v5 {"format":"amd","expected":"amd"} matches the 
   "bundleName": StringContaining "test-vite-v5-amd",
   "bundler": {
     "name": "rollup",
-    "version": "4.16.2",
+    "version": "4.21.2",
   },
   "chunks": [
     {
@@ -1015,7 +1015,7 @@ exports[`Generating vite stats v5 {"format":"cjs","expected":"cjs"} matches the 
   "bundleName": StringContaining "test-vite-v5-cjs",
   "bundler": {
     "name": "rollup",
-    "version": "4.16.2",
+    "version": "4.21.2",
   },
   "chunks": [
     {
@@ -1106,7 +1106,7 @@ exports[`Generating vite stats v5 {"format":"es","expected":"esm"} matches the s
   "bundleName": StringContaining "test-vite-v5-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.16.2",
+    "version": "4.21.2",
   },
   "chunks": [
     {
@@ -1197,7 +1197,7 @@ exports[`Generating vite stats v5 {"format":"esm","expected":"esm"} matches the 
   "bundleName": StringContaining "test-vite-v5-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.16.2",
+    "version": "4.21.2",
   },
   "chunks": [
     {
@@ -1288,7 +1288,7 @@ exports[`Generating vite stats v5 {"format":"module","expected":"esm"} matches t
   "bundleName": StringContaining "test-vite-v5-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.16.2",
+    "version": "4.21.2",
   },
   "chunks": [
     {
@@ -1379,7 +1379,7 @@ exports[`Generating vite stats v5 {"format":"iife","expected":"iife"} matches th
   "bundleName": StringContaining "test-vite-v5-iife",
   "bundler": {
     "name": "rollup",
-    "version": "4.16.2",
+    "version": "4.21.2",
   },
   "chunks": [
     {
@@ -1470,7 +1470,7 @@ exports[`Generating vite stats v5 {"format":"umd","expected":"umd"} matches the 
   "bundleName": StringContaining "test-vite-v5-umd",
   "bundler": {
     "name": "rollup",
-    "version": "4.16.2",
+    "version": "4.21.2",
   },
   "chunks": [
     {
@@ -1561,7 +1561,7 @@ exports[`Generating vite stats v5 {"format":"system","expected":"system"} matche
   "bundleName": StringContaining "test-vite-v5-system",
   "bundler": {
     "name": "rollup",
-    "version": "4.16.2",
+    "version": "4.21.2",
   },
   "chunks": [
     {
@@ -1652,7 +1652,7 @@ exports[`Generating vite stats v5 {"format":"systemjs","expected":"system"} matc
   "bundleName": StringContaining "test-vite-v5-system",
   "bundler": {
     "name": "rollup",
-    "version": "4.16.2",
+    "version": "4.21.2",
   },
   "chunks": [
     {
@@ -1743,7 +1743,7 @@ exports[`Generating vite stats v5 source maps are enabled does not include any s
   "bundleName": StringNotContaining ".map",
   "bundler": {
     "name": "rollup",
-    "version": "4.16.2",
+    "version": "4.21.2",
   },
   "chunks": [
     {

--- a/integration-tests/fixtures/generate-bundle-stats/vite/vite-base.config.ts
+++ b/integration-tests/fixtures/generate-bundle-stats/vite/vite-base.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
     },
   },
   plugins: [
+    //@ts-expect-error handle conflicting vite version types
     codecovVitePlugin({
       enableBundleAnalysis: true,
       bundleName: "test-vite-v5",

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -55,7 +55,7 @@
     "rollupV4": "npm:rollup@4.9.6",
     "ts-node": "^10.9.2",
     "viteV4": "npm:vite@4.5.3",
-    "viteV5": "npm:vite@5.2.10",
+    "viteV5": "npm:vite@5.2.14",
     "vue-routerV4": "npm:vue-router@4.3.0",
     "vueV3": "npm:vue@3.4.21",
     "webpackV5": "npm:webpack@5.90.0"

--- a/integration-tests/test-apps/bundle-analyzer/dotenv-vercel/package.json
+++ b/integration-tests/test-apps/bundle-analyzer/dotenv-vercel/package.json
@@ -13,6 +13,6 @@
     "@codecov/bundle-analyzer": "workspace:^",
     "dotenv": "^16.4.5",
     "typescript": "^5.0.2",
-    "vite": "npm:vite@4.5.3"
+    "vite": "^5.2.14"
   }
 }

--- a/integration-tests/test-apps/remix/package.json
+++ b/integration-tests/test-apps/remix/package.json
@@ -35,7 +35,7 @@
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.4",
     "typescript": "^5.1.6",
-    "vite": "^5.1.0",
+    "vite": "^5.1.8",
     "vite-tsconfig-paths": "^4.2.1"
   },
   "engines": {

--- a/integration-tests/test-apps/sveltekit/package.json
+++ b/integration-tests/test-apps/sveltekit/package.json
@@ -14,7 +14,7 @@
     "@sveltejs/kit": "^2.5.25",
     "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "svelte": "^4.2.7",
-    "vite": "^5.0.3"
+    "vite": "^5.1.8"
   },
   "type": "module"
 }

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "prettier": "^3.2.4",
     "typedoc": "^0.25.12",
     "typescript": "^5.3.3",
-    "vite": "^5.2.14",
-    "vite-tsconfig-paths": "^4.3.2",
+    "vite": "^5.4.11",
+    "vite-tsconfig-paths": "^5.1.2",
     "vitest": "^1.5.0"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "prettier": "^3.2.4",
     "typedoc": "^0.25.12",
     "typescript": "^5.3.3",
-    "vite": "^5.3.6",
+    "vite": "^5.2.14",
     "vite-tsconfig-paths": "^4.3.2",
     "vitest": "^1.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "prettier": "^3.2.4",
     "typedoc": "^0.25.12",
     "typescript": "^5.3.3",
-    "vite": "^5.2.10",
+    "vite": "^5.3.6",
     "vite-tsconfig-paths": "^4.3.2",
     "vitest": "^1.5.0"
   },

--- a/packages/bundle-analyzer/package.json
+++ b/packages/bundle-analyzer/package.json
@@ -69,7 +69,7 @@
     "ts-node": "^10.9.2",
     "typedoc": "^0.25.12",
     "unbuild": "^2.0.0",
-    "vite": "^5.2.10",
+    "vite": "^5.2.14",
     "vite-tsconfig-paths": "^4.3.2",
     "vitest": "^1.5.0"
   },

--- a/packages/nextjs-webpack-plugin/vitest.config.ts
+++ b/packages/nextjs-webpack-plugin/vitest.config.ts
@@ -7,7 +7,6 @@ const packageJson = await import("./package.json");
 export default defineProject({
   ...config,
   plugins: [
-    // @ts-expect-error - using rollup plugin
     {
       ...replace({
         preventAssignment: true,

--- a/packages/nuxt-plugin/package.json
+++ b/packages/nuxt-plugin/package.json
@@ -60,7 +60,7 @@
     "typedoc": "^0.25.12",
     "typescript": "^5.3.3",
     "unbuild": "^2.0.0",
-    "vite": "^5.2.10",
+    "vite": "^5.2.14",
     "vite-tsconfig-paths": "^4.3.2",
     "vitest": "^1.5.0"
   },

--- a/packages/nuxt-plugin/vitest.config.ts
+++ b/packages/nuxt-plugin/vitest.config.ts
@@ -7,7 +7,6 @@ const packageJson = await import("./package.json");
 export default defineProject({
   ...config,
   plugins: [
-    // @ts-expect-error - using rollup plugin
     {
       ...replace({
         preventAssignment: true,

--- a/packages/remix-vite-plugin/package.json
+++ b/packages/remix-vite-plugin/package.json
@@ -59,7 +59,7 @@
     "typedoc": "^0.25.12",
     "typescript": "^5.3.3",
     "unbuild": "^2.0.0",
-    "vite": "^5.2.10",
+    "vite": "^5.2.14",
     "vite-tsconfig-paths": "^4.3.2",
     "vitest": "^1.5.0"
   },

--- a/packages/remix-vite-plugin/vitest.config.ts
+++ b/packages/remix-vite-plugin/vitest.config.ts
@@ -7,7 +7,6 @@ const packageJson = await import("./package.json");
 export default defineProject({
   ...config,
   plugins: [
-    // @ts-expect-error - using rollup plugin
     {
       ...replace({
         preventAssignment: true,

--- a/packages/solidstart-plugin/package.json
+++ b/packages/solidstart-plugin/package.json
@@ -59,7 +59,7 @@
     "typedoc": "^0.25.12",
     "typescript": "^5.3.3",
     "unbuild": "^2.0.0",
-    "vite": "^5.2.10",
+    "vite": "^5.2.14",
     "vite-tsconfig-paths": "^4.3.2",
     "vitest": "^1.5.0"
   },

--- a/packages/solidstart-plugin/vitest.config.ts
+++ b/packages/solidstart-plugin/vitest.config.ts
@@ -7,7 +7,6 @@ const packageJson = await import("./package.json");
 export default defineProject({
   ...config,
   plugins: [
-    // @ts-expect-error - using rollup plugin
     {
       ...replace({
         preventAssignment: true,

--- a/packages/sveltekit-plugin/package.json
+++ b/packages/sveltekit-plugin/package.json
@@ -59,7 +59,7 @@
     "typedoc": "^0.25.12",
     "typescript": "^5.3.3",
     "unbuild": "^2.0.0",
-    "vite": "^5.2.10",
+    "vite": "^5.2.14",
     "vite-tsconfig-paths": "^4.3.2",
     "vitest": "^1.5.0"
   },

--- a/packages/sveltekit-plugin/vitest.config.ts
+++ b/packages/sveltekit-plugin/vitest.config.ts
@@ -7,7 +7,6 @@ const packageJson = await import("./package.json");
 export default defineProject({
   ...config,
   plugins: [
-    // @ts-expect-error - using rollup plugin
     {
       ...replace({
         preventAssignment: true,

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -58,7 +58,7 @@
     "typedoc": "^0.25.12",
     "typescript": "^5.3.3",
     "unbuild": "^2.0.0",
-    "vite": "^5.2.10",
+    "vite": "^5.2.14",
     "vite-tsconfig-paths": "^4.3.2",
     "vitest": "^1.5.0"
   },

--- a/packages/vite-plugin/vitest.config.ts
+++ b/packages/vite-plugin/vitest.config.ts
@@ -7,7 +7,6 @@ const packageJson = await import("./package.json");
 export default defineProject({
   ...config,
   plugins: [
-    // @ts-expect-error - using rollup plugin
     {
       ...replace({
         preventAssignment: true,

--- a/packages/webpack-plugin/vitest.config.ts
+++ b/packages/webpack-plugin/vitest.config.ts
@@ -7,7 +7,6 @@ const packageJson = await import("./package.json");
 export default defineProject({
   ...config,
   plugins: [
-    // @ts-expect-error - using rollup plugin
     {
       ...replace({
         preventAssignment: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,11 +57,11 @@ importers:
         specifier: ^5.3.3
         version: 5.3.3
       vite:
-        specifier: ^5.2.14
+        specifier: ^5.4.11
         version: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
       vite-tsconfig-paths:
-        specifier: ^4.3.2
-        version: 4.3.2(typescript@5.3.3)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
+        specifier: ^5.1.2
+        version: 5.1.2(typescript@5.3.3)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       vitest:
         specifier: ^1.5.0
         version: 1.5.0(@types/node@20.11.15)(terser@5.27.0)
@@ -215,7 +215,7 @@ importers:
         version: 6.20.0(eslint@8.56.0)(typescript@5.4.5)
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.2.1(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+        version: 4.2.1(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
@@ -233,7 +233,7 @@ importers:
         version: 5.4.5
       vite:
         specifier: ^5.2.14
-        version: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+        version: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
 
   examples/remix:
     dependencies:
@@ -261,7 +261,7 @@ importers:
         version: link:../../packages/remix-vite-plugin
       '@remix-run/dev':
         specifier: ^2.9.2
-        version: 2.9.2(@remix-run/react@2.9.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5))(@remix-run/serve@2.9.2(typescript@5.4.5))(@types/node@20.12.12)(terser@5.27.0)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))(typescript@5.4.5)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+        version: 2.9.2(@remix-run/react@2.9.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5))(@remix-run/serve@2.9.2(typescript@5.4.5))(@types/node@20.12.12)(terser@5.27.0)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))(typescript@5.4.5)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
       '@types/react':
         specifier: ^18.2.20
         version: 18.3.3
@@ -306,10 +306,10 @@ importers:
         version: 5.4.5
       vite:
         specifier: ^5.1.8
-        version: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+        version: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
       vite-tsconfig-paths:
         specifier: ^4.2.1
-        version: 4.3.2(typescript@5.4.5)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+        version: 4.3.2(typescript@5.4.5)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
 
   examples/rollup:
     dependencies:
@@ -373,19 +373,19 @@ importers:
         version: 1.0.0
       '@sveltejs/adapter-auto':
         specifier: ^3.0.0
-        version: 3.2.0(@sveltejs/kit@2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)))
+        version: 3.2.0(@sveltejs/kit@2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0)))
       '@sveltejs/kit':
         specifier: ^2.5.25
-        version: 2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+        version: 2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.0.0
-        version: 3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+        version: 3.1.0(svelte@4.2.15)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
       svelte:
         specifier: ^4.2.7
         version: 4.2.15
       svelte-check:
         specifier: ^3.6.0
-        version: 3.7.0(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.3.3)))(postcss@8.4.49)(svelte@4.2.15)
+        version: 3.7.0(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.44)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.3.3)))(postcss@8.4.44)(svelte@4.2.15)
       tslib:
         specifier: ^2.4.1
         version: 2.6.2
@@ -394,7 +394,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.1.8
-        version: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+        version: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
 
   examples/tokenless:
     dependencies:
@@ -422,7 +422,7 @@ importers:
         version: 6.20.0(eslint@8.56.0)(typescript@5.4.5)
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.2.1(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+        version: 4.2.1(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
@@ -440,7 +440,7 @@ importers:
         version: 5.4.5
       vite:
         specifier: ^5.2.14
-        version: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+        version: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
 
   examples/vite:
     dependencies:
@@ -468,7 +468,7 @@ importers:
         version: 6.20.0(eslint@8.56.0)(typescript@5.3.3)
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.2.1(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+        version: 4.2.1(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
@@ -486,7 +486,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.2.14
-        version: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+        version: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
 
   examples/webpack:
     dependencies:
@@ -592,8 +592,8 @@ importers:
         specifier: npm:vite@4.5.3
         version: vite@4.5.3(@types/node@20.11.15)(terser@5.27.0)
       viteV5:
-        specifier: npm:vite@5.2.10
-        version: vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)
+        specifier: npm:vite@5.2.14
+        version: vite@5.2.14(@types/node@20.11.15)(terser@5.27.0)
       vue-routerV4:
         specifier: npm:vue-router@4.3.0
         version: vue-router@4.3.0(vue@3.5.0(typescript@5.4.5))
@@ -617,7 +617,7 @@ importers:
         version: 5.4.5
       vite:
         specifier: ^5.2.14
-        version: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+        version: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
 
   integration-tests/test-apps/nextjs:
     dependencies:
@@ -651,7 +651,7 @@ importers:
     dependencies:
       nuxt:
         specifier: ^3.12.4
-        version: 3.12.4(@parcel/watcher@2.4.1)(@types/node@20.12.12)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.26.0)(terser@5.27.0)(typescript@5.4.5)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
+        version: 3.12.4(@parcel/watcher@2.4.1)(@types/node@20.12.12)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.4.5)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       vue:
         specifier: ^3.4.21
         version: 3.4.24(typescript@5.4.5)
@@ -689,7 +689,7 @@ importers:
         version: link:../../../packages/remix-vite-plugin
       '@remix-run/dev':
         specifier: ^2.9.2
-        version: 2.9.2(@remix-run/react@2.9.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5))(@remix-run/serve@2.9.2(typescript@5.4.5))(@types/node@20.12.12)(terser@5.27.0)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))(typescript@5.4.5)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+        version: 2.9.2(@remix-run/react@2.9.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5))(@remix-run/serve@2.9.2(typescript@5.4.5))(@types/node@20.12.12)(terser@5.27.0)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))(typescript@5.4.5)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
       '@types/react':
         specifier: ^18.2.20
         version: 18.3.3
@@ -734,10 +734,10 @@ importers:
         version: 5.4.5
       vite:
         specifier: ^5.1.8
-        version: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+        version: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
       vite-tsconfig-paths:
         specifier: ^4.2.1
-        version: 4.3.2(typescript@5.4.5)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+        version: 4.3.2(typescript@5.4.5)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
 
   integration-tests/test-apps/solidstart:
     dependencies:
@@ -749,7 +749,7 @@ importers:
         version: 0.14.1(solid-js@1.8.19)
       '@solidjs/start':
         specifier: ^1.0.6
-        version: 1.0.6(rollup@4.26.0)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
+        version: 1.0.6(rollup@4.21.2)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
       solid-js:
         specifier: ^1.8.18
         version: 1.8.19
@@ -773,19 +773,19 @@ importers:
         version: 1.0.0
       '@sveltejs/adapter-auto':
         specifier: ^3.0.0
-        version: 3.2.0(@sveltejs/kit@2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)))
+        version: 3.2.0(@sveltejs/kit@2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0)))
       '@sveltejs/kit':
         specifier: ^2.5.25
-        version: 2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+        version: 2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.0.0
-        version: 3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+        version: 3.1.0(svelte@4.2.15)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
       svelte:
         specifier: ^4.2.7
         version: 4.2.15
       vite:
         specifier: ^5.1.8
-        version: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+        version: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
 
   packages/bundle-analyzer:
     dependencies:
@@ -831,10 +831,10 @@ importers:
         version: 2.0.0(typescript@5.4.5)
       vite:
         specifier: ^5.2.14
-        version: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+        version: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.4.5)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+        version: 4.3.2(typescript@5.4.5)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
       vitest:
         specifier: ^1.5.0
         version: 1.5.0(@types/node@20.12.12)(terser@5.27.0)
@@ -874,7 +874,7 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.11.15)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.26.0)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.21.2)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.3.3)
@@ -920,7 +920,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.26.0)
+        version: 5.0.5(rollup@4.21.2)
       '@types/node':
         specifier: ^20.10.0
         version: 20.12.12
@@ -932,7 +932,7 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.12.12)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.26.0)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.21.2)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.4.5)
@@ -968,17 +968,17 @@ importers:
         version: link:../vite-plugin
       '@nuxt/kit':
         specifier: ^3.11.2
-        version: 3.11.2(rollup@4.26.0)
+        version: 3.11.2(rollup@4.21.2)
       nuxt:
         specifier: 3.x
-        version: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.26.0)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+        version: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       unplugin:
         specifier: ^1.10.1
         version: 1.10.1
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.26.0)
+        version: 5.0.5(rollup@4.21.2)
       '@types/node':
         specifier: ^20.11.15
         version: 20.11.15
@@ -987,7 +987,7 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.11.15)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.26.0)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.21.2)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.3.3)
@@ -1005,10 +1005,10 @@ importers:
         version: 2.0.0(typescript@5.3.3)
       vite:
         specifier: ^5.2.14
-        version: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+        version: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.3.3)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+        version: 4.3.2(typescript@5.3.3)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       vitest:
         specifier: ^1.5.0
         version: 1.5.0(@types/node@20.11.15)(terser@5.27.0)
@@ -1030,7 +1030,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.26.0)
+        version: 5.0.5(rollup@4.21.2)
       '@types/node':
         specifier: ^20.11.15
         version: 20.12.12
@@ -1039,7 +1039,7 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.12.12)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.26.0)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.21.2)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.4.5)
@@ -1057,10 +1057,10 @@ importers:
         version: 2.0.0(typescript@5.4.5)
       vite:
         specifier: ^5.2.14
-        version: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+        version: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.4.5)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+        version: 4.3.2(typescript@5.4.5)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
       vitest:
         specifier: ^1.5.0
         version: 1.5.0(@types/node@20.12.12)(terser@5.27.0)
@@ -1121,14 +1121,14 @@ importers:
         version: link:../vite-plugin
       '@solidjs/start':
         specifier: 1.x
-        version: 1.0.6(rollup@4.26.0)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+        version: 1.0.6(rollup@4.21.2)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
       unplugin:
         specifier: ^1.10.1
         version: 1.10.1
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.26.0)
+        version: 5.0.5(rollup@4.21.2)
       '@types/node':
         specifier: ^20.11.15
         version: 20.12.12
@@ -1137,7 +1137,7 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.12.12)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.26.0)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.21.2)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.4.5)
@@ -1155,10 +1155,10 @@ importers:
         version: 2.0.0(typescript@5.4.5)
       vite:
         specifier: ^5.2.14
-        version: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+        version: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.4.5)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+        version: 4.3.2(typescript@5.4.5)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
       vitest:
         specifier: ^1.5.0
         version: 1.5.0(@types/node@20.12.12)(terser@5.27.0)
@@ -1173,7 +1173,7 @@ importers:
         version: link:../vite-plugin
       '@sveltejs/kit':
         specifier: 2.x
-        version: 2.5.7(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+        version: 2.5.7(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       svelte:
         specifier: 4.x
         version: 4.2.15
@@ -1183,7 +1183,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.26.0)
+        version: 5.0.5(rollup@4.21.2)
       '@types/node':
         specifier: ^20.11.15
         version: 20.11.15
@@ -1192,7 +1192,7 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.11.15)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.26.0)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.21.2)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.3.3)
@@ -1210,10 +1210,10 @@ importers:
         version: 2.0.0(typescript@5.3.3)
       vite:
         specifier: ^5.2.14
-        version: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+        version: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.3.3)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+        version: 4.3.2(typescript@5.3.3)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       vitest:
         specifier: ^1.5.0
         version: 1.5.0(@types/node@20.11.15)(terser@5.27.0)
@@ -1229,7 +1229,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.26.0)
+        version: 5.0.5(rollup@4.21.2)
       '@types/node':
         specifier: ^20.11.15
         version: 20.11.15
@@ -1238,7 +1238,7 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.11.15)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.26.0)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.21.2)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.3.3)
@@ -1256,10 +1256,10 @@ importers:
         version: 2.0.0(typescript@5.3.3)
       vite:
         specifier: ^5.2.14
-        version: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+        version: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.3.3)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+        version: 4.3.2(typescript@5.3.3)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       vitest:
         specifier: ^1.5.0
         version: 1.5.0(@types/node@20.11.15)(terser@5.27.0)
@@ -1275,7 +1275,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.26.0)
+        version: 5.0.5(rollup@4.21.2)
       '@types/node':
         specifier: ^20.10.0
         version: 20.10.0
@@ -1287,7 +1287,7 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.10.0)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.26.0)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.21.2)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.3.3)
@@ -1336,8 +1336,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@antfu/install-pkg@0.4.1':
-    resolution: {integrity: sha512-T7yB5QNG29afhWVkVq7XeIMBa5U/vs9mX69YqayXypPRmYzUmzwnYltplHmPtZ4HPCn+sQKeXW8I47wCbuBOjw==}
+  '@antfu/install-pkg@0.1.1':
+    resolution: {integrity: sha512-LyB/8+bSfa0DFGC06zpCEfs89/XoWZwws5ygEa5D+Xsm3OfI+aXQ86VgVG7Acyef+rSZ5HE7J8rrxzrQeM3PjQ==}
 
   '@antfu/utils@0.7.10':
     resolution: {integrity: sha512-+562v9k4aI80m1+VuMHehNJWLOFjBnXn3tdOitzD0il5b7smkSBal4+a3oKiQTbrwMmN/TBUMDvbdoWDehgOww==}
@@ -1351,10 +1351,6 @@ packages:
 
   '@babel/code-frame@7.24.7':
     resolution: {integrity: sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/code-frame@7.26.2':
-    resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/compat-data@7.23.5':
@@ -1393,20 +1389,12 @@ packages:
     resolution: {integrity: sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.26.2':
-    resolution: {integrity: sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-annotate-as-pure@7.22.5':
     resolution: {integrity: sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-annotate-as-pure@7.24.7':
     resolution: {integrity: sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-annotate-as-pure@7.25.9':
-    resolution: {integrity: sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-builder-binary-assignment-operator-visitor@7.24.7':
@@ -1439,12 +1427,6 @@ packages:
 
   '@babel/helper-create-class-features-plugin@7.25.4':
     resolution: {integrity: sha512-ro/bFs3/84MDgDmMwbcHgDa8/E6J3QKNTk4xJJnVeFtGE+tL0K26E3pNxhYz2b67fJpt7Aphw5XcploKXuCvCQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/helper-create-class-features-plugin@7.25.9':
-    resolution: {integrity: sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -1492,10 +1474,6 @@ packages:
     resolution: {integrity: sha512-LABppdt+Lp/RlBxqrh4qgf1oEH/WxdzQNDJIu5gC/W1GyvPVrOBiItmmM8wan2fm4oYqFuFfkXmlGpLQhPY8CA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-member-expression-to-functions@7.25.9':
-    resolution: {integrity: sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-module-imports@7.18.6':
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
     engines: {node: '>=6.9.0'}
@@ -1506,10 +1484,6 @@ packages:
 
   '@babel/helper-module-imports@7.24.7':
     resolution: {integrity: sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-imports@7.25.9':
-    resolution: {integrity: sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-transforms@7.23.3':
@@ -1530,22 +1504,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-module-transforms@7.26.0':
-    resolution: {integrity: sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
   '@babel/helper-optimise-call-expression@7.22.5':
     resolution: {integrity: sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-optimise-call-expression@7.24.7':
     resolution: {integrity: sha512-jKiTsW2xmWwxT1ixIdfXUZp+P5yURx2suzLZr5Hi64rURpDYdMW0pv+Uf17EYk2Rd428Lx4tLsnjGJzYKDM/6A==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-optimise-call-expression@7.25.9':
-    resolution: {integrity: sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-plugin-utils@7.22.5':
@@ -1558,10 +1522,6 @@ packages:
 
   '@babel/helper-plugin-utils@7.24.8':
     resolution: {integrity: sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-plugin-utils@7.25.9':
-    resolution: {integrity: sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-remap-async-to-generator@7.24.7':
@@ -1588,12 +1548,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-replace-supers@7.25.9':
-    resolution: {integrity: sha512-IiDqTOTBQy0sWyeXyGSC5TBJpGFXBkRynjBeXsvbhQFKj2viwJC76Epz35YLU1fpe/Am6Vppb7W7zM4fPQzLsQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
   '@babel/helper-simple-access@7.22.5':
     resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
     engines: {node: '>=6.9.0'}
@@ -1602,20 +1556,12 @@ packages:
     resolution: {integrity: sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-simple-access@7.25.9':
-    resolution: {integrity: sha512-c6WHXuiaRsJTyHYLJV75t9IqsmTbItYfdj99PnzYGQZkYKvan5/2jKJ7gu31J3/BJ/A18grImSPModuyG/Eo0Q==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-skip-transparent-expression-wrappers@7.22.5':
     resolution: {integrity: sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-skip-transparent-expression-wrappers@7.24.7':
     resolution: {integrity: sha512-IO+DLT3LQUElMbpzlatRASEyQtfhSE0+m465v++3jyyXeBTBUjtVZg28/gHeV5mrTJqvEKhKroBGAvhW+qPHiQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-skip-transparent-expression-wrappers@7.25.9':
-    resolution: {integrity: sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-split-export-declaration@7.22.6':
@@ -1634,10 +1580,6 @@ packages:
     resolution: {integrity: sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.25.9':
-    resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-validator-identifier@7.22.20':
     resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
     engines: {node: '>=6.9.0'}
@@ -1646,20 +1588,12 @@ packages:
     resolution: {integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-identifier@7.25.9':
-    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-validator-option@7.23.5':
     resolution: {integrity: sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.24.8':
     resolution: {integrity: sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-option@7.25.9':
-    resolution: {integrity: sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-wrap-function@7.24.7':
@@ -1698,11 +1632,6 @@ packages:
 
   '@babel/parser@7.25.6':
     resolution: {integrity: sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@7.26.2':
-    resolution: {integrity: sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1808,12 +1737,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-syntax-jsx@7.25.9':
-    resolution: {integrity: sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4':
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
     peerDependencies:
@@ -1864,12 +1787,6 @@ packages:
 
   '@babel/plugin-syntax-typescript@7.25.4':
     resolution: {integrity: sha512-uMOCoHVU52BsSWxPOMVv5qKRdeSlPuImUCB2dlPuBSU+W2/ROE7/Zg8F2Kepbk+8yBa68LlRKxO+xgEVWorsDg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-typescript@7.25.9':
-    resolution: {integrity: sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2024,12 +1941,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-modules-commonjs@7.25.9':
-    resolution: {integrity: sha512-dwh2Ol1jWwL2MgkCzUSOvfmKElqQcuswAZypBSUsScMXvgdT8Ekq5YA6TtqpTVWH+4903NmboMuH1o9i8Rxlyg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-modules-systemjs@7.24.7':
     resolution: {integrity: sha512-GYQE0tW7YoaN13qFh3O1NCY4MPkUiAH3fiF7UcV/I3ajmDKEdG3l+UOcbAm4zUE3gnvUU+Eni7XrVKo9eO9auw==}
     engines: {node: '>=6.9.0'}
@@ -2180,12 +2091,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-typescript@7.25.9':
-    resolution: {integrity: sha512-7PbZQZP50tzv2KGGnhh82GSyMB01yKY9scIjf1a+GfZCtInOWqUH5+1EBU4t9fyR5Oykkkc9vFTs4OHrhHXljQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-unicode-escapes@7.24.7':
     resolution: {integrity: sha512-U3ap1gm5+4edc2Q/P+9VrBNhGkfnf+8ZqppY71Bo/pzZmXhhLdqgaUl6cuB07O1+AQJtCLfaOmswiNbSQ9ivhw==}
     engines: {node: '>=6.9.0'}
@@ -2227,12 +2132,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/preset-typescript@7.26.0':
-    resolution: {integrity: sha512-NMk1IGZ5I/oHhoXEElcm+xUnL/szL6xflkFZmoEU9xj1qSJXpiS7rsspYo92B4DRCDvZn2erT5LdsCeXAKNCkg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/regjsgen@0.8.0':
     resolution: {integrity: sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==}
 
@@ -2256,10 +2155,6 @@ packages:
     resolution: {integrity: sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/template@7.25.9':
-    resolution: {integrity: sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/traverse@7.23.9':
     resolution: {integrity: sha512-I/4UJ9vs90OkBtY6iiiTORVMyIhJ4kAVmsKo9KFc8UOxMeUfi2hvtIBsET5u9GizXE6/GFSuKCTNfgCswuEjRg==}
     engines: {node: '>=6.9.0'}
@@ -2276,10 +2171,6 @@ packages:
     resolution: {integrity: sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.25.9':
-    resolution: {integrity: sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/types@7.24.0':
     resolution: {integrity: sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==}
     engines: {node: '>=6.9.0'}
@@ -2290,10 +2181,6 @@ packages:
 
   '@babel/types@7.25.6':
     resolution: {integrity: sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.26.0':
-    resolution: {integrity: sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@0.2.3':
@@ -3364,14 +3251,14 @@ packages:
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
 
-  '@floating-ui/core@1.6.8':
-    resolution: {integrity: sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==}
+  '@floating-ui/core@1.6.0':
+    resolution: {integrity: sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==}
 
   '@floating-ui/dom@1.1.1':
     resolution: {integrity: sha512-TpIO93+DIujg3g7SykEAGZMDtbJRrmnYRCNYSjJlvIbGhBjRSNTLVbNeDQBrzy9qDgUbiWdc7KA0uZHZ2tJmiw==}
 
-  '@floating-ui/utils@0.2.8':
-    resolution: {integrity: sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==}
+  '@floating-ui/utils@0.2.1':
+    resolution: {integrity: sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==}
 
   '@fontsource/fira-mono@4.5.10':
     resolution: {integrity: sha512-bxUnRP8xptGRo8YXeY073DSpfK74XpSb0ZyRNpHV9WvLnJ7TwPOjZll8hTMin7zLC6iOp59pDZ8EQDj1gzgAQQ==}
@@ -3398,8 +3285,8 @@ packages:
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
-  '@iconify/utils@2.1.33':
-    resolution: {integrity: sha512-jP9h6v/g0BIZx0p7XGJJVtkVnydtbgTgt9mVNcGDYwaa7UhdHdI9dvoq+gKj9sijMSJKxUPEG2JyjsgXjxL7Kw==}
+  '@iconify/utils@2.1.23':
+    resolution: {integrity: sha512-YGNbHKM5tyDvdWZ92y2mIkrfvm5Fvhe6WJSkWu7vvOFhMtYDP0casZpoRz0XEHZCrYsR4stdGT3cZ52yp5qZdQ==}
 
   '@img/sharp-darwin-arm64@0.33.5':
     resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
@@ -4301,27 +4188,8 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/pluginutils@5.1.3':
-    resolution: {integrity: sha512-Pnsb6f32CD2W3uCaLZIzDmeFyQ2b8UWMFI7xtwUezpcGBDVDW6y9XgAWIlARiGAo6eNF5FK5aQTr0LFyNyqq5A==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-
-  '@rollup/rollup-android-arm-eabi@4.16.2':
-    resolution: {integrity: sha512-VGodkwtEuZ+ENPz/CpDSl091koMv8ao5jHVMbG1vNK+sbx/48/wVzP84M5xSfDAC69mAKKoEkSo+ym9bXYRK9w==}
-    cpu: [arm]
-    os: [android]
-
   '@rollup/rollup-android-arm-eabi@4.21.2':
     resolution: {integrity: sha512-fSuPrt0ZO8uXeS+xP3b+yYTCBUd05MoSp2N/MFOgjhhUhMmchXlpTQrTpI8T+YAwAQuK7MafsCOxW7VrPMrJcg==}
-    cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm-eabi@4.26.0':
-    resolution: {integrity: sha512-gJNwtPDGEaOEgejbaseY6xMFu+CPltsc8/T+diUTTbOQLqD+bnrJq9ulH6WD69TqwqWmrfRAtUv30cCFZlbGTQ==}
     cpu: [arm]
     os: [android]
 
@@ -4330,18 +4198,8 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.16.2':
-    resolution: {integrity: sha512-5/W1xyIdc7jw6c/f1KEtg1vYDBWnWCsLiipK41NiaWGLG93eH2edgE6EgQJ3AGiPERhiOLUqlDSfjRK08C9xFg==}
-    cpu: [arm64]
-    os: [android]
-
   '@rollup/rollup-android-arm64@4.21.2':
     resolution: {integrity: sha512-xGU5ZQmPlsjQS6tzTTGwMsnKUtu0WVbl0hYpTPauvbRAnmIvpInhJtgjj3mcuJpEiuUw4v1s4BimkdfDWlh7gA==}
-    cpu: [arm64]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.26.0':
-    resolution: {integrity: sha512-YJa5Gy8mEZgz5JquFruhJODMq3lTHWLm1fOy+HIANquLzfIOzE9RA5ie3JjCdVb9r46qfAQY/l947V0zfGJ0OQ==}
     cpu: [arm64]
     os: [android]
 
@@ -4350,18 +4208,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.16.2':
-    resolution: {integrity: sha512-vOAKMqZSTbPfyPVu1jBiy+YniIQd3MG7LUnqV0dA6Q5tyhdqYtxacTHP1+S/ksKl6qCtMG1qQ0grcIgk/19JEA==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rollup/rollup-darwin-arm64@4.21.2':
     resolution: {integrity: sha512-99AhQ3/ZMxU7jw34Sq8brzXqWH/bMnf7ZVhvLk9QU2cOepbQSVTns6qoErJmSiAvU3InRqC2RRZ5ovh1KN0d0Q==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-arm64@4.26.0':
-    resolution: {integrity: sha512-ErTASs8YKbqTBoPLp/kA1B1Um5YSom8QAc4rKhg7b9tyyVqDBlQxy7Bf2wW7yIlPGPg2UODDQcbkTlruPzDosw==}
     cpu: [arm64]
     os: [darwin]
 
@@ -4370,18 +4218,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.16.2':
-    resolution: {integrity: sha512-aIJVRUS3Dnj6MqocBMrcXlatKm64O3ITeQAdAxVSE9swyhNyV1dwnRgw7IGKIkDQofatd8UqMSyUxuFEa42EcA==}
-    cpu: [x64]
-    os: [darwin]
-
   '@rollup/rollup-darwin-x64@4.21.2':
     resolution: {integrity: sha512-ZbRaUvw2iN/y37x6dY50D8m2BnDbBjlnMPotDi/qITMJ4sIxNY33HArjikDyakhSv0+ybdUxhWxE6kTI4oX26w==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.26.0':
-    resolution: {integrity: sha512-wbgkYDHcdWW+NqP2mnf2NOuEbOLzDblalrOWcPyY6+BRbVhliavon15UploG7PpBRQ2bZJnbmh8o3yLoBvDIHA==}
     cpu: [x64]
     os: [darwin]
 
@@ -4390,28 +4228,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.26.0':
-    resolution: {integrity: sha512-Y9vpjfp9CDkAG4q/uwuhZk96LP11fBz/bYdyg9oaHYhtGZp7NrbkQrj/66DYMMP2Yo/QPAsVHkV891KyO52fhg==}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.26.0':
-    resolution: {integrity: sha512-A/jvfCZ55EYPsqeaAt/yDAG4q5tt1ZboWMHEvKAH9Zl92DWvMIbnZe/f/eOXze65aJaaKbL+YeM0Hz4kLQvdwg==}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@rollup/rollup-linux-arm-gnueabihf@4.16.2':
-    resolution: {integrity: sha512-/bjfUiXwy3P5vYr6/ezv//Yle2Y0ak3a+Av/BKoi76nFryjWCkki8AuVoPR7ZU/ckcvAWFo77OnFK14B9B5JsA==}
-    cpu: [arm]
-    os: [linux]
-
   '@rollup/rollup-linux-arm-gnueabihf@4.21.2':
     resolution: {integrity: sha512-ztRJJMiE8nnU1YFcdbd9BcH6bGWG1z+jP+IPW2oDUAPxPjo9dverIOyXz76m6IPA6udEL12reYeLojzW2cYL7w==}
-    cpu: [arm]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm-gnueabihf@4.26.0':
-    resolution: {integrity: sha512-paHF1bMXKDuizaMODm2bBTjRiHxESWiIyIdMugKeLnjuS1TCS54MF5+Y5Dx8Ui/1RBPVRE09i5OUlaLnv8OGnA==}
     cpu: [arm]
     os: [linux]
 
@@ -4420,33 +4238,13 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.16.2':
-    resolution: {integrity: sha512-S24b+tJHwpq2TNRz9T+r71FjMvyBBApY8EkYxz8Cwi/rhH6h+lu/iDUxyc9PuHf9UvyeBFYkWWcrDahai/NCGw==}
-    cpu: [arm]
-    os: [linux]
-
   '@rollup/rollup-linux-arm-musleabihf@4.21.2':
     resolution: {integrity: sha512-flOcGHDZajGKYpLV0JNc0VFH361M7rnV1ee+NTeC/BQQ1/0pllYcFmxpagltANYt8FYf9+kL6RSk80Ziwyhr7w==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.26.0':
-    resolution: {integrity: sha512-cwxiHZU1GAs+TMxvgPfUDtVZjdBdTsQwVnNlzRXC5QzIJ6nhfB4I1ahKoe9yPmoaA/Vhf7m9dB1chGPpDRdGXg==}
-    cpu: [arm]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm64-gnu@4.16.2':
-    resolution: {integrity: sha512-UN7VAXLyeyGbCQWiOtQN7BqmjTDw1ON2Oos4lfk0YR7yNhFEJWZiwGtvj9Ay4lsT/ueT04sh80Sg2MlWVVZ+Ug==}
-    cpu: [arm64]
-    os: [linux]
-
   '@rollup/rollup-linux-arm64-gnu@4.21.2':
     resolution: {integrity: sha512-69CF19Kp3TdMopyteO/LJbWufOzqqXzkrv4L2sP8kfMaAQ6iwky7NoXTp7bD6/irKgknDKM0P9E/1l5XxVQAhw==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm64-gnu@4.26.0':
-    resolution: {integrity: sha512-4daeEUQutGRCW/9zEo8JtdAgtJ1q2g5oHaoQaZbMSKaIWKDQwQ3Yx0/3jJNmpzrsScIPtx/V+1AfibLisb3AMQ==}
     cpu: [arm64]
     os: [linux]
 
@@ -4455,18 +4253,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.16.2':
-    resolution: {integrity: sha512-ZBKvz3+rIhQjusKMccuJiPsStCrPOtejCHxTe+yWp3tNnuPWtyCh9QLGPKz6bFNFbwbw28E2T6zDgzJZ05F1JQ==}
-    cpu: [arm64]
-    os: [linux]
-
   '@rollup/rollup-linux-arm64-musl@4.21.2':
     resolution: {integrity: sha512-48pD/fJkTiHAZTnZwR0VzHrao70/4MlzJrq0ZsILjLW/Ab/1XlVUStYyGt7tdyIiVSlGZbnliqmult/QGA2O2w==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm64-musl@4.26.0':
-    resolution: {integrity: sha512-eGkX7zzkNxvvS05ROzJ/cO/AKqNvR/7t1jA3VZDi2vRniLKwAWxUr85fH3NsvtxU5vnUUKFHKh8flIBdlo2b3Q==}
     cpu: [arm64]
     os: [linux]
 
@@ -4475,33 +4263,13 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.16.2':
-    resolution: {integrity: sha512-LjMMFiVBRL3wOe095vHAekL4b7nQqf4KZEpdMWd3/W+nIy5o9q/8tlVKiqMbfieDypNXLsxM9fexOxd9Qcklyg==}
-    cpu: [ppc64]
-    os: [linux]
-
   '@rollup/rollup-linux-powerpc64le-gnu@4.21.2':
     resolution: {integrity: sha512-cZdyuInj0ofc7mAQpKcPR2a2iu4YM4FQfuUzCVA2u4HI95lCwzjoPtdWjdpDKyHxI0UO82bLDoOaLfpZ/wviyQ==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.26.0':
-    resolution: {integrity: sha512-Odp/lgHbW/mAqw/pU21goo5ruWsytP7/HCC/liOt0zcGG0llYWKrd10k9Fj0pdj3prQ63N5yQLCLiE7HTX+MYw==}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@rollup/rollup-linux-riscv64-gnu@4.16.2':
-    resolution: {integrity: sha512-ohkPt0lKoCU0s4B6twro2aft+QROPdUiWwOjPNTzwTsBK5w+2+iT9kySdtOdq0gzWJAdiqsV4NFtXOwGZmIsHA==}
-    cpu: [riscv64]
-    os: [linux]
-
   '@rollup/rollup-linux-riscv64-gnu@4.21.2':
     resolution: {integrity: sha512-RL56JMT6NwQ0lXIQmMIWr1SW28z4E4pOhRRNqwWZeXpRlykRIlEpSWdsgNWJbYBEWD84eocjSGDu/XxbYeCmwg==}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@rollup/rollup-linux-riscv64-gnu@4.26.0':
-    resolution: {integrity: sha512-MBR2ZhCTzUgVD0OJdTzNeF4+zsVogIR1U/FsyuFerwcqjZGvg2nYe24SAHp8O5sN8ZkRVbHwlYeHqcSQ8tcYew==}
     cpu: [riscv64]
     os: [linux]
 
@@ -4510,33 +4278,13 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.16.2':
-    resolution: {integrity: sha512-jm2lvLc+/gqXfndlpDw05jKvsl/HKYxUEAt1h5UXcMFVpO4vGpoWmJVUfKDtTqSaHcCNw1his1XjkgR9aort3w==}
-    cpu: [s390x]
-    os: [linux]
-
   '@rollup/rollup-linux-s390x-gnu@4.21.2':
     resolution: {integrity: sha512-PMxkrWS9z38bCr3rWvDFVGD6sFeZJw4iQlhrup7ReGmfn7Oukrr/zweLhYX6v2/8J6Cep9IEA/SmjXjCmSbrMQ==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.26.0':
-    resolution: {integrity: sha512-YYcg8MkbN17fMbRMZuxwmxWqsmQufh3ZJFxFGoHjrE7bv0X+T6l3glcdzd7IKLiwhT+PZOJCblpnNlz1/C3kGQ==}
-    cpu: [s390x]
-    os: [linux]
-
-  '@rollup/rollup-linux-x64-gnu@4.16.2':
-    resolution: {integrity: sha512-oc5/SlITI/Vj/qL4UM+lXN7MERpiy1HEOnrE+SegXwzf7WP9bzmZd6+MDljCEZTdSY84CpvUv9Rq7bCaftn1+g==}
-    cpu: [x64]
-    os: [linux]
-
   '@rollup/rollup-linux-x64-gnu@4.21.2':
     resolution: {integrity: sha512-B90tYAUoLhU22olrafY3JQCFLnT3NglazdwkHyxNDYF/zAxJt5fJUB/yBoWFoIQ7SQj+KLe3iL4BhOMa9fzgpw==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rollup/rollup-linux-x64-gnu@4.26.0':
-    resolution: {integrity: sha512-ZuwpfjCwjPkAOxpjAEjabg6LRSfL7cAJb6gSQGZYjGhadlzKKywDkCUnJ+KEfrNY1jH5EEoSIKLCb572jSiglA==}
     cpu: [x64]
     os: [linux]
 
@@ -4545,18 +4293,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.16.2':
-    resolution: {integrity: sha512-/2VWEBG6mKbS2itm7hzPwhIPaxfZh/KLWrYg20pCRLHhNFtF+epLgcBtwy3m07bl/k86Q3PFRAf2cX+VbZbwzQ==}
-    cpu: [x64]
-    os: [linux]
-
   '@rollup/rollup-linux-x64-musl@4.21.2':
     resolution: {integrity: sha512-7twFizNXudESmC9oneLGIUmoHiiLppz/Xs5uJQ4ShvE6234K0VB1/aJYU3f/4g7PhssLGKBVCC37uRkkOi8wjg==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rollup/rollup-linux-x64-musl@4.26.0':
-    resolution: {integrity: sha512-+HJD2lFS86qkeF8kNu0kALtifMpPCZU80HvwztIKnYwym3KnA1os6nsX4BGSTLtS2QVAGG1P3guRgsYyMA0Yhg==}
     cpu: [x64]
     os: [linux]
 
@@ -4565,18 +4303,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-win32-arm64-msvc@4.16.2':
-    resolution: {integrity: sha512-Wg7ANh7+hSilF0lG3e/0Oy8GtfTIfEk1327Bw8juZOMOoKmJLs3R+a4JDa/4cHJp2Gs7QfCDTepXXcyFD0ubBg==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rollup/rollup-win32-arm64-msvc@4.21.2':
     resolution: {integrity: sha512-9rRero0E7qTeYf6+rFh3AErTNU1VCQg2mn7CQcI44vNUWM9Ze7MSRS/9RFuSsox+vstRt97+x3sOhEey024FRQ==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rollup/rollup-win32-arm64-msvc@4.26.0':
-    resolution: {integrity: sha512-WUQzVFWPSw2uJzX4j6YEbMAiLbs0BUysgysh8s817doAYhR5ybqTI1wtKARQKo6cGop3pHnrUJPFCsXdoFaimQ==}
     cpu: [arm64]
     os: [win32]
 
@@ -4585,18 +4313,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.16.2':
-    resolution: {integrity: sha512-J/jCDKVMWp0Y2ELnTjpQFYUCUWv1Jr+LdFrJVZtdqGyjDo0PHPa7pCamjHvJel6zBFM3doFFqAr7cmXYWBAbfw==}
-    cpu: [ia32]
-    os: [win32]
-
   '@rollup/rollup-win32-ia32-msvc@4.21.2':
     resolution: {integrity: sha512-5rA4vjlqgrpbFVVHX3qkrCo/fZTj1q0Xxpg+Z7yIo3J2AilW7t2+n6Q8Jrx+4MrYpAnjttTYF8rr7bP46BPzRw==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rollup/rollup-win32-ia32-msvc@4.26.0':
-    resolution: {integrity: sha512-D4CxkazFKBfN1akAIY6ieyOqzoOoBV1OICxgUblWxff/pSjCA2khXlASUx7mK6W1oP4McqhgcCsu6QaLj3WMWg==}
     cpu: [ia32]
     os: [win32]
 
@@ -4605,18 +4323,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.16.2':
-    resolution: {integrity: sha512-3nIf+SJMs2ZzrCh+SKNqgLVV9hS/UY0UjT1YU8XQYFGLiUfmHYJ/5trOU1XSvmHjV5gTF/K3DjrWxtyzKKcAHA==}
-    cpu: [x64]
-    os: [win32]
-
   '@rollup/rollup-win32-x64-msvc@4.21.2':
     resolution: {integrity: sha512-6UUxd0+SKomjdzuAcp+HAmxw1FlGBnl1v2yEPSabtx4lBfdXHDVsW7+lQkgz9cNFJGY3AWR7+V8P5BqkD9L9nA==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.26.0':
-    resolution: {integrity: sha512-2x8MO1rm4PGEP0xWbubJW5RtbNLk3puzAMaLQd3B3JHVw4KcHlmXcO+Wewx9zCoo7EUFiMlu/aZbCJ7VjMzAag==}
     cpu: [x64]
     os: [win32]
 
@@ -4796,9 +4504,6 @@ packages:
 
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
-
-  '@types/estree@1.0.6':
-    resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
   '@types/hast@2.3.10':
     resolution: {integrity: sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==}
@@ -5508,7 +5213,6 @@ packages:
 
   acorn-import-assertions@1.9.0:
     resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
-    deprecated: package has been renamed to acorn-import-attributes
     peerDependencies:
       acorn: ^8
 
@@ -5547,11 +5251,6 @@ packages:
 
   acorn@8.12.1:
     resolution: {integrity: sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
-  acorn@8.14.0:
-    resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -6230,9 +5929,6 @@ packages:
   confbox@0.1.7:
     resolution: {integrity: sha512-uJcB/FKZtBMCJpK8MQji6bJHgu1tixKPxRLeGkNzBoOZzpnZUJm0jm2/sBDWcuBx1dYgxV4JU+g5hmNxCyAmdA==}
 
-  confbox@0.1.8:
-    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
-
   connect@3.7.0:
     resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
     engines: {node: '>= 0.10.0'}
@@ -6466,15 +6162,6 @@ packages:
 
   debug@4.3.6:
     resolution: {integrity: sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
-  debug@4.3.7:
-    resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -6954,7 +6641,6 @@ packages:
   eslint@8.56.0:
     resolution: {integrity: sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   esm-env@1.0.0:
@@ -8246,9 +7932,6 @@ packages:
   magic-string@0.30.11:
     resolution: {integrity: sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==}
 
-  magic-string@0.30.12:
-    resolution: {integrity: sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==}
-
   magic-string@0.30.5:
     resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
     engines: {node: '>=12'}
@@ -8610,9 +8293,6 @@ packages:
   mlly@1.7.1:
     resolution: {integrity: sha512-rrVRZRELyQzrIUAVMHxP97kv+G786pHmOKzuFII8zDYahFBS7qnHh2AlYSl1GAHhaMPCz6/oHjVMcfFYgFYHgA==}
 
-  mlly@1.7.3:
-    resolution: {integrity: sha512-xUsx5n/mN0uQf4V548PKQ+YShA4/IW0KI1dZhrNrPCLG+xizETbHTkOa1f8/xut9JRPp8kQuMnz0oqwkTiLo/A==}
-
   modern-ahocorasick@1.0.1:
     resolution: {integrity: sha512-yoe+JbhTClckZ67b2itRtistFKf8yPYelHLc7e5xAwtNAXxM6wJTUx2C7QeVSJFDzKT7bCIFyBVybPMKvmB9AA==}
 
@@ -8970,9 +8650,6 @@ packages:
   ofetch@1.3.4:
     resolution: {integrity: sha512-KLIET85ik3vhEfS+3fDlc/BAZiAp+43QEC/yCo5zkNoY2YaKvNkOaFr/6wCFgFH1kuYQM5pMNi0Tg8koiIemtw==}
 
-  ofetch@1.4.1:
-    resolution: {integrity: sha512-QZj2DfGplQAr2oj9KzceK9Hwz6Whxazmn85yYeVuS3u9XTMOGMRx0kO95MQ+vLsj/S/NwBDMMLU5hpxvI6Tklw==}
-
   ohash@1.1.3:
     resolution: {integrity: sha512-zuHHiGTYTA1sYJ/wZN+t5HKZaH23i4yI1HMwbuXm24Nid7Dv0KcuRlKoNKS9UNfAVSBlnGLcuQrnOKWOZoEGaw==}
 
@@ -9075,9 +8752,6 @@ packages:
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
-
-  package-manager-detector@0.2.2:
-    resolution: {integrity: sha512-VgXbyrSNsml4eHWIvxxG/nTL4wgybMTXCV2Un/+yEc3aDKKU6nQBZjbeP3Pl3qm9Qg92X/1ng4ffvCeD/zwHgg==}
 
   pacote@18.0.0:
     resolution: {integrity: sha512-ma7uVt/q3Sb3XbLwUjOeClz+7feHjMOFegHn5whw++x+GzikZkAq/2auklSbRuy6EI2iJh1/ZqCpVaUcxRaeqQ==}
@@ -9195,9 +8869,6 @@ packages:
   picocolors@1.0.1:
     resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
 
-  picocolors@1.1.1:
-    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
-
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
@@ -9241,9 +8912,6 @@ packages:
 
   pkg-types@1.2.0:
     resolution: {integrity: sha512-+ifYuSSqOQ8CqP4MbZA5hDpb97n3E8SVWdJe+Wms9kj745lmd3b7EZJiqvmLwAlmRfjrI7Hi5z3kdBJ93lFNPA==}
-
-  pkg-types@1.2.1:
-    resolution: {integrity: sha512-sQoqa8alT3nHjGuTjuKgOnvjo4cljkufdtLMnO2LBP/wRwuDlo1tkaEdMxCRhyGRPacv/ztlZgDPm2b7FAmEvw==}
 
   postcss-calc@10.0.2:
     resolution: {integrity: sha512-DT/Wwm6fCKgpYVI7ZEWuPJ4az8hiEHtCUeYjZXqU7Ou4QqYh1Df2yCQ7Ca6N7xqKPFkxN3fhf+u9KSoOCJNAjg==}
@@ -9655,10 +9323,6 @@ packages:
 
   postcss@8.4.44:
     resolution: {integrity: sha512-Aweb9unOEpQ3ezu4Q00DPvvM2ZTUitJdNKeP/+uQgr1IBIqu574IaZoURId7BKtWMREwzKa9OgzPzezWGPWFQw==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.4.49:
-    resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
     engines: {node: ^10 || ^12 || >=14}
 
   preferred-pm@3.1.2:
@@ -10077,18 +9741,8 @@ packages:
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rollup@4.16.2:
-    resolution: {integrity: sha512-sxDP0+pya/Yi5ZtptF4p3avI+uWCIf/OdrfdH2Gbv1kWddLKk0U7WE3PmQokhi5JrektxsK3sK8s4hzAmjqahw==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
-
   rollup@4.21.2:
     resolution: {integrity: sha512-e3TapAgYf9xjdLvKQCkQTnbTKd4a6jwlpQSJJFokHGaX2IVjoEqkIIhiQfqsi0cdwlOD+tQGuOd5AJkc5RngBw==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
-
-  rollup@4.26.0:
-    resolution: {integrity: sha512-ilcl12hnWonG8f+NxU6BlgysVA0gvY2l8N0R84S1HcINbW20bvwuCngJkkInV6LXhwRpucsW5k1ovDwEdBVrNg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -10406,10 +10060,6 @@ packages:
 
   source-map-js@1.2.0:
     resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
-    engines: {node: '>=0.10.0'}
-
-  source-map-js@1.2.1:
-    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
   source-map-support@0.5.21:
@@ -10831,9 +10481,6 @@ packages:
 
   tinybench@2.7.0:
     resolution: {integrity: sha512-Qgayeb106x2o4hNzNjsZEfFziw8IbKqtbXBjVh7VIZfBxfD5M4gWtpyx5+YTae2gJ6Y6Dz/KLepiv16RFeQWNA==}
-
-  tinyexec@0.3.1:
-    resolution: {integrity: sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==}
 
   tinyglobby@0.2.5:
     resolution: {integrity: sha512-Dlqgt6h0QkoHttG53/WGADNh9QhcjCAIZMTERAVhdpmIBEejSuLI9ZmGKWzB7tweBjlk30+s/ofi4SLmBeTYhw==}
@@ -11458,6 +11105,14 @@ packages:
       vite:
         optional: true
 
+  vite-tsconfig-paths@5.1.2:
+    resolution: {integrity: sha512-gEIbKfJzSEv0yR3XS2QEocKetONoWkbROj6hGx0FHM18qKUojhvcokQsxQx5nMkelZq2n37zbSGCJn+FSODSjA==}
+    peerDependencies:
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
   vite@4.5.3:
     resolution: {integrity: sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -11486,8 +11141,8 @@ packages:
       terser:
         optional: true
 
-  vite@5.2.10:
-    resolution: {integrity: sha512-PAzgUZbP7msvQvqdSD+ErD5qGnSFiGOoWmV5yAKUEI0kdhjbH6nMWVyZQC/hSc4aXwc0oJ9aEdIiF9Oje0JFCw==}
+  vite@5.2.14:
+    resolution: {integrity: sha512-TFQLuwWLPms+NBNlh0D9LZQ+HXW471COABxw/9TEUBrjuHMo9BrYBPrN/SYAwIuVL+rLerycxiLT41t4f5MZpA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -11516,37 +11171,6 @@ packages:
 
   vite@5.4.11:
     resolution: {integrity: sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-
-  vite@5.4.3:
-    resolution: {integrity: sha512-IH+nl64eq9lJjFqU+/yrRnrHPVTlgy42/+IzbOdaFDVlyLgI/wDlf+FCobXLX1cT0X5+7LMyH1mIy2xJdLfo8Q==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -12005,10 +11629,10 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@antfu/install-pkg@0.4.1':
+  '@antfu/install-pkg@0.1.1':
     dependencies:
-      package-manager-detector: 0.2.2
-      tinyexec: 0.3.1
+      execa: 5.1.1
+      find-up: 5.0.0
 
   '@antfu/utils@0.7.10': {}
 
@@ -12022,13 +11646,7 @@ snapshots:
   '@babel/code-frame@7.24.7':
     dependencies:
       '@babel/highlight': 7.24.7
-      picocolors: 1.1.1
-
-  '@babel/code-frame@7.26.2':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.25.9
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
+      picocolors: 1.0.1
 
   '@babel/compat-data@7.23.5': {}
 
@@ -12089,7 +11707,7 @@ snapshots:
       '@babel/traverse': 7.25.6
       '@babel/types': 7.25.6
       convert-source-map: 2.0.0
-      debug: 4.3.4
+      debug: 4.3.6
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -12117,14 +11735,6 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
 
-  '@babel/generator@7.26.2':
-    dependencies:
-      '@babel/parser': 7.26.2
-      '@babel/types': 7.26.0
-      '@jridgewell/gen-mapping': 0.3.5
-      '@jridgewell/trace-mapping': 0.3.25
-      jsesc: 3.0.2
-
   '@babel/helper-annotate-as-pure@7.22.5':
     dependencies:
       '@babel/types': 7.24.9
@@ -12132,10 +11742,6 @@ snapshots:
   '@babel/helper-annotate-as-pure@7.24.7':
     dependencies:
       '@babel/types': 7.24.9
-
-  '@babel/helper-annotate-as-pure@7.25.9':
-    dependencies:
-      '@babel/types': 7.26.0
 
   '@babel/helper-builder-binary-assignment-operator-visitor@7.24.7':
     dependencies:
@@ -12181,6 +11787,19 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.22.6
       semver: 6.3.1
 
+  '@babel/helper-create-class-features-plugin@7.24.4(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-function-name': 7.23.0
+      '@babel/helper-member-expression-to-functions': 7.23.0
+      '@babel/helper-optimise-call-expression': 7.22.5
+      '@babel/helper-replace-supers': 7.24.1(@babel/core@7.25.2)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      semver: 6.3.1
+
   '@babel/helper-create-class-features-plugin@7.24.8(@babel/core@7.24.4)':
     dependencies:
       '@babel/core': 7.24.4
@@ -12209,19 +11828,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-create-class-features-plugin@7.25.9(@babel/core@7.25.2)':
-    dependencies:
-      '@babel/core': 7.25.2
-      '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-member-expression-to-functions': 7.25.9
-      '@babel/helper-optimise-call-expression': 7.25.9
-      '@babel/helper-replace-supers': 7.25.9(@babel/core@7.25.2)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
-      '@babel/traverse': 7.25.9
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-create-regexp-features-plugin@7.24.7(@babel/core@7.24.4)':
     dependencies:
       '@babel/core': 7.24.4
@@ -12234,7 +11840,7 @@ snapshots:
       '@babel/core': 7.24.4
       '@babel/helper-compilation-targets': 7.24.8
       '@babel/helper-plugin-utils': 7.24.8
-      debug: 4.3.4
+      debug: 4.3.6
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -12275,13 +11881,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-member-expression-to-functions@7.25.9':
-    dependencies:
-      '@babel/traverse': 7.25.9
-      '@babel/types': 7.26.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-module-imports@7.18.6':
     dependencies:
       '@babel/types': 7.24.9
@@ -12297,13 +11896,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-imports@7.25.9':
-    dependencies:
-      '@babel/traverse': 7.25.9
-      '@babel/types': 7.26.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-module-transforms@7.23.3(@babel/core@7.23.9)':
     dependencies:
       '@babel/core': 7.23.9
@@ -12316,6 +11908,15 @@ snapshots:
   '@babel/helper-module-transforms@7.23.3(@babel/core@7.24.4)':
     dependencies:
       '@babel/core': 7.24.4
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-module-imports': 7.22.15
+      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/helper-validator-identifier': 7.22.20
+
+  '@babel/helper-module-transforms@7.23.3(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-simple-access': 7.22.5
@@ -12343,15 +11944,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.26.0(@babel/core@7.25.2)':
-    dependencies:
-      '@babel/core': 7.25.2
-      '@babel/helper-module-imports': 7.25.9
-      '@babel/helper-validator-identifier': 7.25.9
-      '@babel/traverse': 7.25.9
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-optimise-call-expression@7.22.5':
     dependencies:
       '@babel/types': 7.24.9
@@ -12360,17 +11952,11 @@ snapshots:
     dependencies:
       '@babel/types': 7.24.9
 
-  '@babel/helper-optimise-call-expression@7.25.9':
-    dependencies:
-      '@babel/types': 7.26.0
-
   '@babel/helper-plugin-utils@7.22.5': {}
 
   '@babel/helper-plugin-utils@7.24.0': {}
 
   '@babel/helper-plugin-utils@7.24.8': {}
-
-  '@babel/helper-plugin-utils@7.25.9': {}
 
   '@babel/helper-remap-async-to-generator@7.24.7(@babel/core@7.24.4)':
     dependencies:
@@ -12384,6 +11970,13 @@ snapshots:
   '@babel/helper-replace-supers@7.24.1(@babel/core@7.24.4)':
     dependencies:
       '@babel/core': 7.24.4
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-member-expression-to-functions': 7.23.0
+      '@babel/helper-optimise-call-expression': 7.22.5
+
+  '@babel/helper-replace-supers@7.24.1(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-member-expression-to-functions': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
@@ -12406,15 +11999,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-replace-supers@7.25.9(@babel/core@7.25.2)':
-    dependencies:
-      '@babel/core': 7.25.2
-      '@babel/helper-member-expression-to-functions': 7.25.9
-      '@babel/helper-optimise-call-expression': 7.25.9
-      '@babel/traverse': 7.25.9
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-simple-access@7.22.5':
     dependencies:
       '@babel/types': 7.24.9
@@ -12426,13 +12010,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-simple-access@7.25.9':
-    dependencies:
-      '@babel/traverse': 7.25.9
-      '@babel/types': 7.26.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-skip-transparent-expression-wrappers@7.22.5':
     dependencies:
       '@babel/types': 7.24.9
@@ -12441,13 +12018,6 @@ snapshots:
     dependencies:
       '@babel/traverse': 7.24.8
       '@babel/types': 7.24.9
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-skip-transparent-expression-wrappers@7.25.9':
-    dependencies:
-      '@babel/traverse': 7.25.9
-      '@babel/types': 7.26.0
     transitivePeerDependencies:
       - supports-color
 
@@ -12463,19 +12033,13 @@ snapshots:
 
   '@babel/helper-string-parser@7.24.8': {}
 
-  '@babel/helper-string-parser@7.25.9': {}
-
   '@babel/helper-validator-identifier@7.22.20': {}
 
   '@babel/helper-validator-identifier@7.24.7': {}
 
-  '@babel/helper-validator-identifier@7.25.9': {}
-
   '@babel/helper-validator-option@7.23.5': {}
 
   '@babel/helper-validator-option@7.24.8': {}
-
-  '@babel/helper-validator-option@7.25.9': {}
 
   '@babel/helper-wrap-function@7.24.7':
     dependencies:
@@ -12512,14 +12076,14 @@ snapshots:
       '@babel/helper-validator-identifier': 7.22.20
       chalk: 2.4.2
       js-tokens: 4.0.0
-      picocolors: 1.1.1
+      picocolors: 1.0.1
 
   '@babel/highlight@7.24.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.24.7
       chalk: 2.4.2
       js-tokens: 4.0.0
-      picocolors: 1.1.1
+      picocolors: 1.0.1
 
   '@babel/parser@7.24.4':
     dependencies:
@@ -12532,10 +12096,6 @@ snapshots:
   '@babel/parser@7.25.6':
     dependencies:
       '@babel/types': 7.25.6
-
-  '@babel/parser@7.26.2':
-    dependencies:
-      '@babel/types': 7.26.0
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.24.7(@babel/core@7.24.4)':
     dependencies:
@@ -12639,11 +12199,6 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-jsx@7.25.9(@babel/core@7.25.2)':
-    dependencies:
-      '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.25.9
-
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.24.4)':
     dependencies:
       '@babel/core': 7.24.4
@@ -12689,15 +12244,15 @@ snapshots:
       '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-typescript@7.25.4(@babel/core@7.25.2)':
+  '@babel/plugin-syntax-typescript@7.24.1(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-typescript@7.25.9(@babel/core@7.25.2)':
+  '@babel/plugin-syntax-typescript@7.25.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.24.4)':
     dependencies:
@@ -12864,21 +12419,19 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/helper-simple-access': 7.22.5
 
+  '@babel/plugin-transform-modules-commonjs@7.24.1(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.25.2)
+      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-simple-access': 7.22.5
+
   '@babel/plugin-transform-modules-commonjs@7.24.8(@babel/core@7.24.4)':
     dependencies:
       '@babel/core': 7.24.4
       '@babel/helper-module-transforms': 7.24.9(@babel/core@7.24.4)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-simple-access': 7.24.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-modules-commonjs@7.25.9(@babel/core@7.25.2)':
-    dependencies:
-      '@babel/core': 7.25.2
-      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.25.2)
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/helper-simple-access': 7.25.9
     transitivePeerDependencies:
       - supports-color
 
@@ -13039,6 +12592,14 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/plugin-syntax-typescript': 7.24.1(@babel/core@7.24.4)
 
+  '@babel/plugin-transform-typescript@7.24.4(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-create-class-features-plugin': 7.24.4(@babel/core@7.25.2)
+      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/plugin-syntax-typescript': 7.24.1(@babel/core@7.25.2)
+
   '@babel/plugin-transform-typescript@7.25.2(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -13047,17 +12608,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
       '@babel/plugin-syntax-typescript': 7.25.4(@babel/core@7.25.2)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-typescript@7.25.9(@babel/core@7.25.2)':
-    dependencies:
-      '@babel/core': 7.25.2
-      '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.25.2)
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
-      '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.25.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -13187,16 +12737,14 @@ snapshots:
       '@babel/plugin-transform-modules-commonjs': 7.24.1(@babel/core@7.24.4)
       '@babel/plugin-transform-typescript': 7.24.4(@babel/core@7.24.4)
 
-  '@babel/preset-typescript@7.26.0(@babel/core@7.25.2)':
+  '@babel/preset-typescript@7.24.1(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/helper-validator-option': 7.25.9
-      '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.25.2)
-      '@babel/plugin-transform-modules-commonjs': 7.25.9(@babel/core@7.25.2)
-      '@babel/plugin-transform-typescript': 7.25.9(@babel/core@7.25.2)
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-plugin-utils': 7.24.0
+      '@babel/helper-validator-option': 7.23.5
+      '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.25.2)
+      '@babel/plugin-transform-modules-commonjs': 7.24.1(@babel/core@7.25.2)
+      '@babel/plugin-transform-typescript': 7.24.4(@babel/core@7.25.2)
 
   '@babel/regjsgen@0.8.0': {}
 
@@ -13224,12 +12772,6 @@ snapshots:
       '@babel/parser': 7.25.6
       '@babel/types': 7.25.6
 
-  '@babel/template@7.25.9':
-    dependencies:
-      '@babel/code-frame': 7.26.2
-      '@babel/parser': 7.26.2
-      '@babel/types': 7.26.0
-
   '@babel/traverse@7.23.9':
     dependencies:
       '@babel/code-frame': 7.24.2
@@ -13240,7 +12782,7 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.24.4
       '@babel/types': 7.24.0
-      debug: 4.3.4
+      debug: 4.3.6
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -13270,7 +12812,7 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.24.7
       '@babel/parser': 7.24.8
       '@babel/types': 7.24.9
-      debug: 4.3.4
+      debug: 4.3.6
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -13282,19 +12824,7 @@ snapshots:
       '@babel/parser': 7.25.6
       '@babel/template': 7.25.0
       '@babel/types': 7.25.6
-      debug: 4.3.4
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/traverse@7.25.9':
-    dependencies:
-      '@babel/code-frame': 7.26.2
-      '@babel/generator': 7.26.2
-      '@babel/parser': 7.26.2
-      '@babel/template': 7.25.9
-      '@babel/types': 7.26.0
-      debug: 4.3.7
+      debug: 4.3.6
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -13316,11 +12846,6 @@ snapshots:
       '@babel/helper-string-parser': 7.24.8
       '@babel/helper-validator-identifier': 7.24.7
       to-fast-properties: 2.0.0
-
-  '@babel/types@7.26.0':
-    dependencies:
-      '@babel/helper-string-parser': 7.25.9
-      '@babel/helper-validator-identifier': 7.25.9
 
   '@bcoe/v8-coverage@0.2.3': {}
 
@@ -13500,10 +13025,10 @@ snapshots:
       '@codecov/bundler-plugin-core': 0.0.1-beta.6
       rollup: 3.29.4
 
-  '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.26.0)':
+  '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.21.2)':
     dependencies:
       '@codecov/bundler-plugin-core': 0.0.1-beta.6
-      rollup: 4.26.0
+      rollup: 4.21.2
 
   '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.9.6)':
     dependencies:
@@ -14029,15 +13554,15 @@ snapshots:
 
   '@fastify/busboy@2.1.1': {}
 
-  '@floating-ui/core@1.6.8':
+  '@floating-ui/core@1.6.0':
     dependencies:
-      '@floating-ui/utils': 0.2.8
+      '@floating-ui/utils': 0.2.1
 
   '@floating-ui/dom@1.1.1':
     dependencies:
-      '@floating-ui/core': 1.6.8
+      '@floating-ui/core': 1.6.0
 
-  '@floating-ui/utils@0.2.8': {}
+  '@floating-ui/utils@0.2.1': {}
 
   '@fontsource/fira-mono@4.5.10': {}
 
@@ -14061,15 +13586,15 @@ snapshots:
 
   '@iconify/types@2.0.0': {}
 
-  '@iconify/utils@2.1.33':
+  '@iconify/utils@2.1.23':
     dependencies:
-      '@antfu/install-pkg': 0.4.1
+      '@antfu/install-pkg': 0.1.1
       '@antfu/utils': 0.7.10
       '@iconify/types': 2.0.0
-      debug: 4.3.7
+      debug: 4.3.6
       kolorist: 1.8.0
       local-pkg: 0.5.0
-      mlly: 1.7.3
+      mlly: 1.7.1
     transitivePeerDependencies:
       - supports-color
 
@@ -14198,7 +13723,7 @@ snapshots:
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.6
     transitivePeerDependencies:
       - supports-color
 
@@ -14488,13 +14013,13 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@1.2.0(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.26.0)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))':
+  '@nuxt/devtools-kit@1.2.0(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))':
     dependencies:
-      '@nuxt/kit': 3.11.2(rollup@4.26.0)
-      '@nuxt/schema': 3.11.2(rollup@4.26.0)
+      '@nuxt/kit': 3.11.2(rollup@4.21.2)
+      '@nuxt/schema': 3.11.2(rollup@4.21.2)
       execa: 7.2.0
-      nuxt: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.26.0)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+      nuxt: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -14510,23 +14035,23 @@ snapshots:
       - rollup
       - supports-color
 
+  '@nuxt/devtools-kit@1.4.1(magicast@0.3.4)(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))':
+    dependencies:
+      '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.21.2)
+      '@nuxt/schema': 3.13.0(rollup@4.21.2)
+      execa: 7.2.0
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
+    transitivePeerDependencies:
+      - magicast
+      - rollup
+      - supports-color
+
   '@nuxt/devtools-kit@1.4.1(magicast@0.3.4)(rollup@4.21.2)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))':
     dependencies:
       '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.21.2)
       '@nuxt/schema': 3.13.0(rollup@4.21.2)
       execa: 7.2.0
       vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
-    transitivePeerDependencies:
-      - magicast
-      - rollup
-      - supports-color
-
-  '@nuxt/devtools-kit@1.4.1(magicast@0.3.4)(rollup@4.26.0)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))':
-    dependencies:
-      '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.26.0)
-      '@nuxt/schema': 3.13.0(rollup@4.26.0)
-      execa: 7.2.0
-      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
     transitivePeerDependencies:
       - magicast
       - rollup
@@ -14558,14 +14083,14 @@ snapshots:
       rc9: 2.1.2
       semver: 7.6.3
 
-  '@nuxt/devtools@1.2.0(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3)))(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.26.0)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.26.0)(unocss@0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))':
+  '@nuxt/devtools@1.2.0(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.21.2)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))':
     dependencies:
       '@antfu/utils': 0.7.7
-      '@nuxt/devtools-kit': 1.2.0(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.26.0)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      '@nuxt/devtools-kit': 1.2.0(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       '@nuxt/devtools-wizard': 1.2.0
-      '@nuxt/kit': 3.11.2(rollup@4.26.0)
-      '@vue/devtools-applet': 7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
-      '@vue/devtools-core': 7.0.27(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
+      '@nuxt/kit': 3.11.2(rollup@4.21.2)
+      '@vue/devtools-applet': 7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
+      '@vue/devtools-core': 7.0.27(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
       '@vue/devtools-kit': 7.0.27(vue@3.4.24(typescript@5.3.3))
       birpc: 0.2.17
       consola: 3.2.3
@@ -14582,7 +14107,7 @@ snapshots:
       launch-editor: 2.6.1
       local-pkg: 0.5.0
       magicast: 0.3.4
-      nuxt: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.26.0)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      nuxt: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       nypm: 0.3.8
       ohash: 1.1.3
       pacote: 18.0.0
@@ -14594,10 +14119,10 @@ snapshots:
       semver: 7.6.0
       simple-git: 3.24.0
       sirv: 2.0.4
-      unimport: 3.7.1(rollup@4.26.0)
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
-      vite-plugin-inspect: 0.8.4(@nuxt/kit@3.11.2(rollup@4.26.0))(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
-      vite-plugin-vue-inspector: 4.0.2(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      unimport: 3.7.1(rollup@4.21.2)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
+      vite-plugin-inspect: 0.8.4(@nuxt/kit@3.11.2(rollup@4.21.2))(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
+      vite-plugin-vue-inspector: 4.0.2(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       which: 3.0.1
       ws: 8.16.0
     transitivePeerDependencies:
@@ -14669,6 +14194,52 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@nuxt/devtools@1.4.1(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))':
+    dependencies:
+      '@antfu/utils': 0.7.10
+      '@nuxt/devtools-kit': 1.4.1(magicast@0.3.4)(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
+      '@nuxt/devtools-wizard': 1.4.1
+      '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.21.2)
+      '@vue/devtools-core': 7.3.3(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
+      '@vue/devtools-kit': 7.3.3
+      birpc: 0.2.17
+      consola: 3.2.3
+      cronstrue: 2.50.0
+      destr: 2.0.3
+      error-stack-parser-es: 0.1.5
+      execa: 7.2.0
+      fast-npm-meta: 0.2.2
+      flatted: 3.3.1
+      get-port-please: 3.1.2
+      hookable: 5.5.3
+      image-meta: 0.2.1
+      is-installed-globally: 1.0.0
+      launch-editor: 2.8.2
+      local-pkg: 0.5.0
+      magicast: 0.3.4
+      nypm: 0.3.11
+      ohash: 1.1.3
+      pathe: 1.1.2
+      perfect-debounce: 1.0.0
+      pkg-types: 1.2.0
+      rc9: 2.1.2
+      scule: 1.3.0
+      semver: 7.6.3
+      simple-git: 3.26.0
+      sirv: 2.0.4
+      tinyglobby: 0.2.5
+      unimport: 3.11.1(rollup@4.21.2)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
+      vite-plugin-inspect: 0.8.7(@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@4.21.2))(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
+      vite-plugin-vue-inspector: 5.2.0(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
+      which: 3.0.1
+      ws: 8.18.0
+    transitivePeerDependencies:
+      - bufferutil
+      - rollup
+      - supports-color
+      - utf-8-validate
+
   '@nuxt/devtools@1.4.1(rollup@4.21.2)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))':
     dependencies:
       '@antfu/utils': 0.7.10
@@ -14707,52 +14278,6 @@ snapshots:
       vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
       vite-plugin-inspect: 0.8.7(@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@4.21.2))(rollup@4.21.2)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
       vite-plugin-vue-inspector: 5.2.0(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
-      which: 3.0.1
-      ws: 8.18.0
-    transitivePeerDependencies:
-      - bufferutil
-      - rollup
-      - supports-color
-      - utf-8-validate
-
-  '@nuxt/devtools@1.4.1(rollup@4.26.0)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))':
-    dependencies:
-      '@antfu/utils': 0.7.10
-      '@nuxt/devtools-kit': 1.4.1(magicast@0.3.4)(rollup@4.26.0)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
-      '@nuxt/devtools-wizard': 1.4.1
-      '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.26.0)
-      '@vue/devtools-core': 7.3.3(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
-      '@vue/devtools-kit': 7.3.3
-      birpc: 0.2.17
-      consola: 3.2.3
-      cronstrue: 2.50.0
-      destr: 2.0.3
-      error-stack-parser-es: 0.1.5
-      execa: 7.2.0
-      fast-npm-meta: 0.2.2
-      flatted: 3.3.1
-      get-port-please: 3.1.2
-      hookable: 5.5.3
-      image-meta: 0.2.1
-      is-installed-globally: 1.0.0
-      launch-editor: 2.8.2
-      local-pkg: 0.5.0
-      magicast: 0.3.4
-      nypm: 0.3.11
-      ohash: 1.1.3
-      pathe: 1.1.2
-      perfect-debounce: 1.0.0
-      pkg-types: 1.2.0
-      rc9: 2.1.2
-      scule: 1.3.0
-      semver: 7.6.3
-      simple-git: 3.26.0
-      sirv: 2.0.4
-      tinyglobby: 0.2.5
-      unimport: 3.11.1(rollup@4.26.0)
-      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
-      vite-plugin-inspect: 0.8.7(@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@4.26.0))(rollup@4.26.0)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
-      vite-plugin-vue-inspector: 5.2.0(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       which: 3.0.1
       ws: 8.18.0
     transitivePeerDependencies:
@@ -14809,30 +14334,6 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/kit@3.11.2(rollup@4.26.0)':
-    dependencies:
-      '@nuxt/schema': 3.11.2(rollup@4.26.0)
-      c12: 1.10.0
-      consola: 3.2.3
-      defu: 6.1.4
-      globby: 14.0.1
-      hash-sum: 2.0.0
-      ignore: 5.3.1
-      jiti: 1.21.0
-      knitwork: 1.1.0
-      mlly: 1.6.1
-      pathe: 1.1.2
-      pkg-types: 1.1.0
-      scule: 1.3.0
-      semver: 7.6.0
-      ufo: 1.5.3
-      unctx: 2.3.1
-      unimport: 3.7.1(rollup@4.26.0)
-      untyped: 1.4.2
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-
   '@nuxt/kit@3.12.4(magicast@0.3.4)(rollup@3.29.4)':
     dependencies:
       '@nuxt/schema': 3.12.4(rollup@3.29.4)
@@ -14881,33 +14382,6 @@ snapshots:
       ufo: 1.5.4
       unctx: 2.3.1
       unimport: 3.11.1(rollup@4.21.2)
-      untyped: 1.4.2
-    transitivePeerDependencies:
-      - magicast
-      - rollup
-      - supports-color
-
-  '@nuxt/kit@3.12.4(magicast@0.3.4)(rollup@4.26.0)':
-    dependencies:
-      '@nuxt/schema': 3.12.4(rollup@4.26.0)
-      c12: 1.11.2(magicast@0.3.4)
-      consola: 3.2.3
-      defu: 6.1.4
-      destr: 2.0.3
-      globby: 14.0.2
-      hash-sum: 2.0.0
-      ignore: 5.3.1
-      jiti: 1.21.6
-      klona: 2.0.6
-      knitwork: 1.1.0
-      mlly: 1.7.1
-      pathe: 1.1.2
-      pkg-types: 1.2.0
-      scule: 1.3.0
-      semver: 7.6.3
-      ufo: 1.5.4
-      unctx: 2.3.1
-      unimport: 3.11.1(rollup@4.26.0)
       untyped: 1.4.2
     transitivePeerDependencies:
       - magicast
@@ -14968,33 +14442,6 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@4.26.0)':
-    dependencies:
-      '@nuxt/schema': 3.13.0(rollup@4.26.0)
-      c12: 1.11.2(magicast@0.3.4)
-      consola: 3.2.3
-      defu: 6.1.4
-      destr: 2.0.3
-      globby: 14.0.2
-      hash-sum: 2.0.0
-      ignore: 5.3.2
-      jiti: 1.21.6
-      klona: 2.0.6
-      knitwork: 1.1.0
-      mlly: 1.7.1
-      pathe: 1.1.2
-      pkg-types: 1.2.0
-      scule: 1.3.0
-      semver: 7.6.3
-      ufo: 1.5.4
-      unctx: 2.3.1
-      unimport: 3.11.1(rollup@4.26.0)
-      untyped: 1.4.2
-    transitivePeerDependencies:
-      - magicast
-      - rollup
-      - supports-color
-
   '@nuxt/schema@3.11.2(rollup@3.29.4)':
     dependencies:
       '@nuxt/ui-templates': 1.3.3
@@ -15024,23 +14471,6 @@ snapshots:
       std-env: 3.7.0
       ufo: 1.5.3
       unimport: 3.7.1(rollup@4.21.2)
-      untyped: 1.4.2
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-
-  '@nuxt/schema@3.11.2(rollup@4.26.0)':
-    dependencies:
-      '@nuxt/ui-templates': 1.3.3
-      consola: 3.2.3
-      defu: 6.1.4
-      hookable: 5.5.3
-      pathe: 1.1.2
-      pkg-types: 1.1.0
-      scule: 1.3.0
-      std-env: 3.7.0
-      ufo: 1.5.3
-      unimport: 3.7.1(rollup@4.26.0)
       untyped: 1.4.2
     transitivePeerDependencies:
       - rollup
@@ -15082,24 +14512,6 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/schema@3.12.4(rollup@4.26.0)':
-    dependencies:
-      compatx: 0.1.8
-      consola: 3.2.3
-      defu: 6.1.4
-      hookable: 5.5.3
-      pathe: 1.1.2
-      pkg-types: 1.2.0
-      scule: 1.3.0
-      std-env: 3.7.0
-      ufo: 1.5.4
-      uncrypto: 0.1.3
-      unimport: 3.11.1(rollup@4.26.0)
-      untyped: 1.4.2
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-
   '@nuxt/schema@3.13.0(rollup@3.29.4)':
     dependencies:
       compatx: 0.1.8
@@ -15131,24 +14543,6 @@ snapshots:
       ufo: 1.5.4
       uncrypto: 0.1.3
       unimport: 3.11.1(rollup@4.21.2)
-      untyped: 1.4.2
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-
-  '@nuxt/schema@3.13.0(rollup@4.26.0)':
-    dependencies:
-      compatx: 0.1.8
-      consola: 3.2.3
-      defu: 6.1.4
-      hookable: 5.5.3
-      pathe: 1.1.2
-      pkg-types: 1.2.0
-      scule: 1.3.0
-      std-env: 3.7.0
-      ufo: 1.5.4
-      uncrypto: 0.1.3
-      unimport: 3.11.1(rollup@4.26.0)
       untyped: 1.4.2
     transitivePeerDependencies:
       - rollup
@@ -15200,35 +14594,12 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/telemetry@2.5.4(rollup@4.26.0)':
-    dependencies:
-      '@nuxt/kit': 3.11.2(rollup@4.26.0)
-      ci-info: 4.0.0
-      consola: 3.2.3
-      create-require: 1.1.1
-      defu: 6.1.4
-      destr: 2.0.3
-      dotenv: 16.4.5
-      git-url-parse: 14.0.0
-      is-docker: 3.0.0
-      jiti: 1.21.0
-      mri: 1.2.0
-      nanoid: 5.0.7
-      ofetch: 1.3.4
-      parse-git-config: 3.0.0
-      pathe: 1.1.2
-      rc9: 2.1.2
-      std-env: 3.7.0
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-
   '@nuxt/ui-templates@1.3.3': {}
 
-  '@nuxt/vite-builder@3.11.2(@types/node@20.11.15)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.26.0)(terser@5.27.0)(typescript@5.3.3)(vue@3.4.24(typescript@5.3.3))':
+  '@nuxt/vite-builder@3.11.2(@types/node@20.11.15)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(vue@3.4.24(typescript@5.3.3))':
     dependencies:
-      '@nuxt/kit': 3.11.2(rollup@4.26.0)
-      '@rollup/plugin-replace': 5.0.7(rollup@4.26.0)
+      '@nuxt/kit': 3.11.2(rollup@4.21.2)
+      '@rollup/plugin-replace': 5.0.7(rollup@4.21.2)
       '@vitejs/plugin-vue': 5.0.4(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
       '@vitejs/plugin-vue-jsx': 3.1.0(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
       autoprefixer: 10.4.19(postcss@8.4.38)
@@ -15251,7 +14622,7 @@ snapshots:
       perfect-debounce: 1.0.0
       pkg-types: 1.1.0
       postcss: 8.4.38
-      rollup-plugin-visualizer: 5.12.0(rollup@4.26.0)
+      rollup-plugin-visualizer: 5.12.0(rollup@4.21.2)
       std-env: 3.7.0
       strip-literal: 2.1.0
       ufo: 1.5.3
@@ -15368,65 +14739,6 @@ snapshots:
       pkg-types: 1.2.0
       postcss: 8.4.44
       rollup-plugin-visualizer: 5.12.0(rollup@4.21.2)
-      std-env: 3.7.0
-      strip-literal: 2.1.0
-      ufo: 1.5.4
-      unenv: 1.10.0
-      unplugin: 1.12.3
-      vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
-      vite-node: 2.0.5(@types/node@20.12.12)(terser@5.27.0)
-      vite-plugin-checker: 0.7.2(eslint@8.56.0)(optionator@0.9.3)(typescript@5.4.5)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
-      vue: 3.5.0(typescript@5.4.5)
-      vue-bundle-renderer: 2.1.0
-    transitivePeerDependencies:
-      - '@biomejs/biome'
-      - '@types/node'
-      - eslint
-      - less
-      - lightningcss
-      - magicast
-      - meow
-      - optionator
-      - rollup
-      - sass
-      - sass-embedded
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - typescript
-      - uWebSockets.js
-      - vls
-      - vti
-      - vue-tsc
-
-  '@nuxt/vite-builder@3.12.4(@types/node@20.12.12)(eslint@8.56.0)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.26.0)(terser@5.27.0)(typescript@5.4.5)(vue@3.5.0(typescript@5.4.5))':
-    dependencies:
-      '@nuxt/kit': 3.12.4(magicast@0.3.4)(rollup@4.26.0)
-      '@rollup/plugin-replace': 5.0.7(rollup@4.26.0)
-      '@vitejs/plugin-vue': 5.1.3(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))(vue@3.5.0(typescript@5.4.5))
-      '@vitejs/plugin-vue-jsx': 4.0.1(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))(vue@3.5.0(typescript@5.4.5))
-      autoprefixer: 10.4.19(postcss@8.4.44)
-      clear: 0.1.0
-      consola: 3.2.3
-      cssnano: 7.0.5(postcss@8.4.44)
-      defu: 6.1.4
-      esbuild: 0.23.1
-      escape-string-regexp: 5.0.0
-      estree-walker: 3.0.3
-      externality: 1.0.2
-      get-port-please: 3.1.2
-      h3: 1.12.0
-      knitwork: 1.1.0
-      magic-string: 0.30.11
-      mlly: 1.7.1
-      ohash: 1.1.3
-      pathe: 1.1.2
-      perfect-debounce: 1.0.0
-      pkg-types: 1.2.0
-      postcss: 8.4.44
-      rollup-plugin-visualizer: 5.12.0(rollup@4.26.0)
       std-env: 3.7.0
       strip-literal: 2.1.0
       ufo: 1.5.4
@@ -15702,7 +15014,7 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  '@remix-run/dev@2.9.2(@remix-run/react@2.9.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5))(@remix-run/serve@2.9.2(typescript@5.4.5))(@types/node@20.12.12)(terser@5.27.0)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))(typescript@5.4.5)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))':
+  '@remix-run/dev@2.9.2(@remix-run/react@2.9.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5))(@remix-run/serve@2.9.2(typescript@5.4.5))(@types/node@20.12.12)(terser@5.27.0)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))(typescript@5.4.5)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))':
     dependencies:
       '@babel/core': 7.24.4
       '@babel/generator': 7.24.4
@@ -15761,7 +15073,7 @@ snapshots:
     optionalDependencies:
       '@remix-run/serve': 2.9.2(typescript@5.4.5)
       typescript: 5.4.5
-      vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -15985,12 +15297,12 @@ snapshots:
     optionalDependencies:
       rollup: 4.9.6
 
-  '@rollup/plugin-replace@5.0.5(rollup@4.26.0)':
+  '@rollup/plugin-replace@5.0.5(rollup@4.21.2)':
     dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.26.0)
+      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
       magic-string: 0.30.10
     optionalDependencies:
-      rollup: 4.26.0
+      rollup: 4.21.2
 
   '@rollup/plugin-replace@5.0.5(rollup@4.9.6)':
     dependencies:
@@ -16012,13 +15324,6 @@ snapshots:
       magic-string: 0.30.11
     optionalDependencies:
       rollup: 4.21.2
-
-  '@rollup/plugin-replace@5.0.7(rollup@4.26.0)':
-    dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.26.0)
-      magic-string: 0.30.11
-    optionalDependencies:
-      rollup: 4.26.0
 
   '@rollup/plugin-terser@0.4.4(rollup@4.21.2)':
     dependencies:
@@ -16073,14 +15378,6 @@ snapshots:
     optionalDependencies:
       rollup: 4.21.2
 
-  '@rollup/pluginutils@5.1.0(rollup@4.26.0)':
-    dependencies:
-      '@types/estree': 1.0.5
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
-    optionalDependencies:
-      rollup: 4.26.0
-
   '@rollup/pluginutils@5.1.0(rollup@4.9.6)':
     dependencies:
       '@types/estree': 1.0.5
@@ -16089,198 +15386,88 @@ snapshots:
     optionalDependencies:
       rollup: 4.9.6
 
-  '@rollup/pluginutils@5.1.3(rollup@4.26.0)':
-    dependencies:
-      '@types/estree': 1.0.6
-      estree-walker: 2.0.2
-      picomatch: 4.0.2
-    optionalDependencies:
-      rollup: 4.26.0
-
-  '@rollup/rollup-android-arm-eabi@4.16.2':
-    optional: true
-
   '@rollup/rollup-android-arm-eabi@4.21.2':
-    optional: true
-
-  '@rollup/rollup-android-arm-eabi@4.26.0':
     optional: true
 
   '@rollup/rollup-android-arm-eabi@4.9.6':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.16.2':
-    optional: true
-
   '@rollup/rollup-android-arm64@4.21.2':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.26.0':
     optional: true
 
   '@rollup/rollup-android-arm64@4.9.6':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.16.2':
-    optional: true
-
   '@rollup/rollup-darwin-arm64@4.21.2':
-    optional: true
-
-  '@rollup/rollup-darwin-arm64@4.26.0':
     optional: true
 
   '@rollup/rollup-darwin-arm64@4.9.6':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.16.2':
-    optional: true
-
   '@rollup/rollup-darwin-x64@4.21.2':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.26.0':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.9.6':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.26.0':
-    optional: true
-
-  '@rollup/rollup-freebsd-x64@4.26.0':
-    optional: true
-
-  '@rollup/rollup-linux-arm-gnueabihf@4.16.2':
-    optional: true
-
   '@rollup/rollup-linux-arm-gnueabihf@4.21.2':
-    optional: true
-
-  '@rollup/rollup-linux-arm-gnueabihf@4.26.0':
     optional: true
 
   '@rollup/rollup-linux-arm-gnueabihf@4.9.6':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.16.2':
-    optional: true
-
   '@rollup/rollup-linux-arm-musleabihf@4.21.2':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.26.0':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-gnu@4.16.2':
     optional: true
 
   '@rollup/rollup-linux-arm64-gnu@4.21.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.26.0':
-    optional: true
-
   '@rollup/rollup-linux-arm64-gnu@4.9.6':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.16.2':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.21.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.26.0':
-    optional: true
-
   '@rollup/rollup-linux-arm64-musl@4.9.6':
-    optional: true
-
-  '@rollup/rollup-linux-powerpc64le-gnu@4.16.2':
     optional: true
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.21.2':
     optional: true
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.26.0':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-gnu@4.16.2':
-    optional: true
-
   '@rollup/rollup-linux-riscv64-gnu@4.21.2':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-gnu@4.26.0':
     optional: true
 
   '@rollup/rollup-linux-riscv64-gnu@4.9.6':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.16.2':
-    optional: true
-
   '@rollup/rollup-linux-s390x-gnu@4.21.2':
-    optional: true
-
-  '@rollup/rollup-linux-s390x-gnu@4.26.0':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.16.2':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.21.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.26.0':
-    optional: true
-
   '@rollup/rollup-linux-x64-gnu@4.9.6':
-    optional: true
-
-  '@rollup/rollup-linux-x64-musl@4.16.2':
     optional: true
 
   '@rollup/rollup-linux-x64-musl@4.21.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.26.0':
-    optional: true
-
   '@rollup/rollup-linux-x64-musl@4.9.6':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.16.2':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.21.2':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.26.0':
-    optional: true
-
   '@rollup/rollup-win32-arm64-msvc@4.9.6':
-    optional: true
-
-  '@rollup/rollup-win32-ia32-msvc@4.16.2':
     optional: true
 
   '@rollup/rollup-win32-ia32-msvc@4.21.2':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.26.0':
-    optional: true
-
   '@rollup/rollup-win32-ia32-msvc@4.9.6':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.16.2':
-    optional: true
-
   '@rollup/rollup-win32-x64-msvc@4.21.2':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.26.0':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.9.6':
@@ -16390,61 +15577,9 @@ snapshots:
       - vinxi
       - vite
 
-  '@solidjs/start@1.0.6(rollup@4.26.0)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))':
+  '@sveltejs/adapter-auto@3.2.0(@sveltejs/kit@2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0)))':
     dependencies:
-      '@vinxi/plugin-directives': 0.4.1(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))
-      '@vinxi/server-components': 0.4.1(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))
-      '@vinxi/server-functions': 0.4.1(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))
-      defu: 6.1.4
-      error-stack-parser: 2.1.4
-      glob: 10.3.10
-      html-to-image: 1.11.11
-      radix3: 1.1.2
-      seroval: 1.1.0
-      seroval-plugins: 1.1.0(seroval@1.1.0)
-      shikiji: 0.9.19
-      source-map-js: 1.2.0
-      terracotta: 1.0.5(solid-js@1.8.19)
-      vite-plugin-inspect: 0.7.42(rollup@4.26.0)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
-      vite-plugin-solid: 2.10.2(solid-js@1.8.19)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
-    transitivePeerDependencies:
-      - '@nuxt/kit'
-      - '@testing-library/jest-dom'
-      - rollup
-      - solid-js
-      - supports-color
-      - vinxi
-      - vite
-
-  '@solidjs/start@1.0.6(rollup@4.26.0)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))':
-    dependencies:
-      '@vinxi/plugin-directives': 0.4.1(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))
-      '@vinxi/server-components': 0.4.1(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))
-      '@vinxi/server-functions': 0.4.1(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))
-      defu: 6.1.4
-      error-stack-parser: 2.1.4
-      glob: 10.3.10
-      html-to-image: 1.11.11
-      radix3: 1.1.2
-      seroval: 1.1.0
-      seroval-plugins: 1.1.0(seroval@1.1.0)
-      shikiji: 0.9.19
-      source-map-js: 1.2.0
-      terracotta: 1.0.5(solid-js@1.8.19)
-      vite-plugin-inspect: 0.7.42(rollup@4.26.0)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
-      vite-plugin-solid: 2.10.2(solid-js@1.8.19)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
-    transitivePeerDependencies:
-      - '@nuxt/kit'
-      - '@testing-library/jest-dom'
-      - rollup
-      - solid-js
-      - supports-color
-      - vinxi
-      - vite
-
-  '@sveltejs/adapter-auto@3.2.0(@sveltejs/kit@2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)))':
-    dependencies:
-      '@sveltejs/kit': 2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+      '@sveltejs/kit': 2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
       import-meta-resolve: 4.1.0
 
   '@sveltejs/kit@2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))':
@@ -16465,9 +15600,9 @@ snapshots:
       tiny-glob: 0.2.9
       vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
 
-  '@sveltejs/kit@2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))':
+  '@sveltejs/kit@2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.2.15)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.0.0
@@ -16481,11 +15616,11 @@ snapshots:
       sirv: 2.0.4
       svelte: 4.2.15
       tiny-glob: 0.2.9
-      vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
 
-  '@sveltejs/kit@2.5.7(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))':
+  '@sveltejs/kit@2.5.7(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.2.15)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.0.0
@@ -16499,7 +15634,7 @@ snapshots:
       sirv: 2.0.4
       svelte: 4.2.15
       tiny-glob: 0.2.9
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
 
   '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))':
     dependencies:
@@ -16510,21 +15645,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.2.15)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
       debug: 4.3.4
       svelte: 4.2.15
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))':
-    dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
-      debug: 4.3.4
-      svelte: 4.2.15
-      vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -16542,31 +15668,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))':
+  '@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
       debug: 4.3.4
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.10
       svelte: 4.2.15
       svelte-hmr: 0.16.0(svelte@4.2.15)
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
-      vitefu: 0.2.5(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
-    transitivePeerDependencies:
-      - supports-color
-
-  '@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))':
-    dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
-      debug: 4.3.4
-      deepmerge: 4.3.1
-      kleur: 4.1.5
-      magic-string: 0.30.10
-      svelte: 4.2.15
-      svelte-hmr: 0.16.0(svelte@4.2.15)
-      vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
-      vitefu: 0.2.5(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+      vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
+      vitefu: 0.2.5(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -16602,7 +15714,7 @@ snapshots:
 
   '@types/acorn@4.0.6':
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.5
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -16654,8 +15766,6 @@ snapshots:
       '@types/estree': 1.0.5
 
   '@types/estree@1.0.5': {}
-
-  '@types/estree@1.0.6': {}
 
   '@types/hast@2.3.10':
     dependencies:
@@ -16973,20 +16083,20 @@ snapshots:
       unhead: 1.9.7
       vue: 3.4.24(typescript@5.3.3)
 
-  '@unocss/astro@0.59.4(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))':
+  '@unocss/astro@0.59.4(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))':
     dependencies:
       '@unocss/core': 0.59.4
       '@unocss/reset': 0.59.4
-      '@unocss/vite': 0.59.4(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      '@unocss/vite': 0.59.4(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
     optionalDependencies:
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
     transitivePeerDependencies:
       - rollup
 
-  '@unocss/cli@0.59.4(rollup@4.26.0)':
+  '@unocss/cli@0.59.4(rollup@4.21.2)':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@rollup/pluginutils': 5.1.3(rollup@4.26.0)
+      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
       '@unocss/config': 0.59.4
       '@unocss/core': 0.59.4
       '@unocss/preset-uno': 0.59.4
@@ -16995,7 +16105,7 @@ snapshots:
       colorette: 2.0.20
       consola: 3.2.3
       fast-glob: 3.3.2
-      magic-string: 0.30.12
+      magic-string: 0.30.11
       pathe: 1.1.2
       perfect-debounce: 1.0.0
     transitivePeerDependencies:
@@ -17026,7 +16136,7 @@ snapshots:
       '@unocss/rule-utils': 0.59.4
       css-tree: 2.3.1
       fast-glob: 3.3.2
-      magic-string: 0.30.12
+      magic-string: 0.30.11
       postcss: 8.4.38
 
   '@unocss/preset-attributify@0.59.4':
@@ -17035,9 +16145,9 @@ snapshots:
 
   '@unocss/preset-icons@0.59.4':
     dependencies:
-      '@iconify/utils': 2.1.33
+      '@iconify/utils': 2.1.23
       '@unocss/core': 0.59.4
-      ofetch: 1.4.1
+      ofetch: 1.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -17066,7 +16176,7 @@ snapshots:
   '@unocss/preset-web-fonts@0.59.4':
     dependencies:
       '@unocss/core': 0.59.4
-      ofetch: 1.4.1
+      ofetch: 1.3.4
 
   '@unocss/preset-wind@0.59.4':
     dependencies:
@@ -17079,15 +16189,15 @@ snapshots:
   '@unocss/rule-utils@0.59.4':
     dependencies:
       '@unocss/core': 0.59.4
-      magic-string: 0.30.12
+      magic-string: 0.30.11
 
   '@unocss/scope@0.59.4': {}
 
   '@unocss/transformer-attributify-jsx-babel@0.59.4':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.25.2)
-      '@babel/preset-typescript': 7.26.0(@babel/core@7.25.2)
+      '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.25.2)
+      '@babel/preset-typescript': 7.24.1(@babel/core@7.25.2)
       '@unocss/core': 0.59.4
     transitivePeerDependencies:
       - supports-color
@@ -17110,10 +16220,10 @@ snapshots:
     dependencies:
       '@unocss/core': 0.59.4
 
-  '@unocss/vite@0.59.4(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))':
+  '@unocss/vite@0.59.4(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@rollup/pluginutils': 5.1.3(rollup@4.26.0)
+      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
       '@unocss/config': 0.59.4
       '@unocss/core': 0.59.4
       '@unocss/inspector': 0.59.4
@@ -17121,8 +16231,8 @@ snapshots:
       '@unocss/transformer-directives': 0.59.4
       chokidar: 3.6.0
       fast-glob: 3.3.2
-      magic-string: 0.30.12
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+      magic-string: 0.30.11
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
     transitivePeerDependencies:
       - rollup
 
@@ -17332,14 +16442,14 @@ snapshots:
       recast: 0.23.9
       vinxi: 0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0)
 
-  '@vitejs/plugin-react@4.2.1(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))':
+  '@vitejs/plugin-react@4.2.1(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))':
     dependencies:
       '@babel/core': 7.23.9
       '@babel/plugin-transform-react-jsx-self': 7.23.3(@babel/core@7.23.9)
       '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.23.9)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.0
-      vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -17474,10 +16584,10 @@ snapshots:
       loupe: 2.3.7
       pretty-format: 29.7.0
 
-  '@vue-macros/common@1.10.2(rollup@4.26.0)(vue@3.4.24(typescript@5.3.3))':
+  '@vue-macros/common@1.10.2(rollup@4.21.2)(vue@3.4.24(typescript@5.3.3))':
     dependencies:
       '@babel/types': 7.24.0
-      '@rollup/pluginutils': 5.1.0(rollup@4.26.0)
+      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
       '@vue/compiler-sfc': 3.4.24
       ast-kit: 0.12.1
       local-pkg: 0.5.0
@@ -17504,19 +16614,6 @@ snapshots:
     dependencies:
       '@babel/types': 7.25.6
       '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
-      '@vue/compiler-sfc': 3.5.0
-      ast-kit: 1.1.0
-      local-pkg: 0.5.0
-      magic-string-ast: 0.6.2
-    optionalDependencies:
-      vue: 3.5.0(typescript@5.4.5)
-    transitivePeerDependencies:
-      - rollup
-
-  '@vue-macros/common@1.12.2(rollup@4.26.0)(vue@3.5.0(typescript@5.4.5))':
-    dependencies:
-      '@babel/types': 7.25.6
-      '@rollup/pluginutils': 5.1.0(rollup@4.26.0)
       '@vue/compiler-sfc': 3.5.0
       ast-kit: 1.1.0
       local-pkg: 0.5.0
@@ -17604,7 +16701,7 @@ snapshots:
       '@vue/shared': 3.5.0
       entities: 4.5.0
       estree-walker: 2.0.2
-      source-map-js: 1.2.1
+      source-map-js: 1.2.0
 
   '@vue/compiler-dom@3.4.21':
     dependencies:
@@ -17654,7 +16751,7 @@ snapshots:
       '@vue/shared': 3.5.0
       estree-walker: 2.0.2
       magic-string: 0.30.11
-      postcss: 8.4.49
+      postcss: 8.4.44
       source-map-js: 1.2.0
 
   '@vue/compiler-ssr@3.4.21':
@@ -17676,12 +16773,12 @@ snapshots:
 
   '@vue/devtools-api@6.6.3': {}
 
-  '@vue/devtools-applet@7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))':
+  '@vue/devtools-applet@7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))':
     dependencies:
-      '@vue/devtools-core': 7.0.27(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
+      '@vue/devtools-core': 7.0.27(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
       '@vue/devtools-kit': 7.0.27(vue@3.4.24(typescript@5.3.3))
       '@vue/devtools-shared': 7.0.27
-      '@vue/devtools-ui': 7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vue@3.4.24(typescript@5.3.3))
+      '@vue/devtools-ui': 7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)))(vue@3.4.24(typescript@5.3.3))
       perfect-debounce: 1.0.0
       splitpanes: 3.1.5
       vue: 3.4.24(typescript@5.3.3)
@@ -17704,14 +16801,14 @@ snapshots:
       - unocss
       - vite
 
-  '@vue/devtools-core@7.0.27(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))':
+  '@vue/devtools-core@7.0.27(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))':
     dependencies:
       '@vue/devtools-kit': 7.0.27(vue@3.4.24(typescript@5.3.3))
       '@vue/devtools-shared': 7.0.27
       mitt: 3.0.1
       nanoid: 3.3.7
       pathe: 1.1.2
-      vite-hot-client: 0.2.3(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      vite-hot-client: 0.2.3(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
     transitivePeerDependencies:
       - vite
       - vue
@@ -17765,16 +16862,16 @@ snapshots:
     dependencies:
       rfdc: 1.4.1
 
-  '@vue/devtools-ui@7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vue@3.4.24(typescript@5.3.3))':
+  '@vue/devtools-ui@7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)))(vue@3.4.24(typescript@5.3.3))':
     dependencies:
       '@unocss/reset': 0.59.4
       '@vueuse/components': 10.9.0(vue@3.4.24(typescript@5.3.3))
       '@vueuse/core': 10.9.0(vue@3.4.24(typescript@5.3.3))
       '@vueuse/integrations': 10.9.0(axios@0.25.0)(focus-trap@7.5.4)(vue@3.4.24(typescript@5.3.3))
       colord: 2.9.3
-      floating-vue: 5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3))
+      floating-vue: 5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3))
       focus-trap: 7.5.4
-      unocss: 0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      unocss: 0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       vue: 3.4.24(typescript@5.3.3)
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -18111,17 +17208,15 @@ snapshots:
 
   acorn@8.12.1: {}
 
-  acorn@8.14.0: {}
-
   agent-base@6.0.2:
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.6
     transitivePeerDependencies:
       - supports-color
 
   agent-base@7.1.1:
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.6
     transitivePeerDependencies:
       - supports-color
 
@@ -18296,10 +17391,10 @@ snapshots:
       '@babel/parser': 7.24.8
       pathe: 1.1.2
 
-  ast-kit@0.9.5(rollup@4.26.0):
+  ast-kit@0.9.5(rollup@4.21.2):
     dependencies:
       '@babel/parser': 7.24.8
-      '@rollup/pluginutils': 5.1.0(rollup@4.26.0)
+      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
       pathe: 1.1.2
     transitivePeerDependencies:
       - rollup
@@ -18315,10 +17410,10 @@ snapshots:
     dependencies:
       tslib: 2.6.2
 
-  ast-walker-scope@0.5.0(rollup@4.26.0):
+  ast-walker-scope@0.5.0(rollup@4.21.2):
     dependencies:
       '@babel/parser': 7.24.4
-      ast-kit: 0.9.5(rollup@4.26.0)
+      ast-kit: 0.9.5(rollup@4.21.2)
     transitivePeerDependencies:
       - rollup
 
@@ -18924,8 +18019,6 @@ snapshots:
 
   confbox@0.1.7: {}
 
-  confbox@0.1.8: {}
-
   connect@3.7.0:
     dependencies:
       debug: 2.6.9
@@ -19025,7 +18118,7 @@ snapshots:
   css-tree@2.2.1:
     dependencies:
       mdn-data: 2.0.28
-      source-map-js: 1.2.1
+      source-map-js: 1.2.0
 
   css-tree@2.3.1:
     dependencies:
@@ -19171,10 +18264,6 @@ snapshots:
   debug@4.3.6:
     dependencies:
       ms: 2.1.2
-
-  debug@4.3.7:
-    dependencies:
-      ms: 2.1.3
 
   decamelize-keys@1.1.1:
     dependencies:
@@ -20022,7 +19111,7 @@ snapshots:
 
   estree-util-attach-comments@2.1.1:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.5
 
   estree-util-build-jsx@2.2.2:
     dependencies:
@@ -20272,13 +19361,13 @@ snapshots:
 
   flatted@3.3.1: {}
 
-  floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3)):
+  floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)):
     dependencies:
       '@floating-ui/dom': 1.1.1
       vue: 3.4.24(typescript@5.3.3)
       vue-resize: 2.0.0-alpha.1(vue@3.4.24(typescript@5.3.3))
     optionalDependencies:
-      '@nuxt/kit': 3.11.2(rollup@4.26.0)
+      '@nuxt/kit': 3.11.2(rollup@4.21.2)
 
   focus-trap@7.5.4:
     dependencies:
@@ -20672,7 +19761,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.4
+      debug: 4.3.6
     transitivePeerDependencies:
       - supports-color
 
@@ -20689,14 +19778,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.3.6
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.4:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.4
+      debug: 4.3.6
     transitivePeerDependencies:
       - supports-color
 
@@ -20804,7 +19893,7 @@ snapshots:
     dependencies:
       '@ioredis/commands': 1.2.0
       cluster-key-slot: 1.1.2
-      debug: 4.3.4
+      debug: 4.3.6
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
@@ -21055,7 +20144,7 @@ snapshots:
   istanbul-lib-source-maps@5.0.4:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
-      debug: 4.3.4
+      debug: 4.3.6
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -21370,10 +20459,6 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  magic-string@0.30.12:
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.0
-
   magic-string@0.30.5:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
@@ -21597,7 +20682,7 @@ snapshots:
 
   micromark-extension-mdx-expression@1.0.8:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.5
       micromark-factory-mdx-expression: 1.0.9
       micromark-factory-space: 1.1.0
       micromark-util-character: 1.2.0
@@ -21609,7 +20694,7 @@ snapshots:
   micromark-extension-mdx-jsx@1.0.5:
     dependencies:
       '@types/acorn': 4.0.6
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.5
       estree-util-is-identifier-name: 2.1.0
       micromark-factory-mdx-expression: 1.0.9
       micromark-factory-space: 1.1.0
@@ -21625,7 +20710,7 @@ snapshots:
 
   micromark-extension-mdxjs-esm@1.0.5:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.5
       micromark-core-commonmark: 1.1.0
       micromark-util-character: 1.2.0
       micromark-util-events-to-acorn: 1.2.3
@@ -21661,7 +20746,7 @@ snapshots:
 
   micromark-factory-mdx-expression@1.0.9:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.5
       micromark-util-character: 1.2.0
       micromark-util-events-to-acorn: 1.2.3
       micromark-util-symbol: 1.1.0
@@ -21725,7 +20810,7 @@ snapshots:
   micromark-util-events-to-acorn@1.2.3:
     dependencies:
       '@types/acorn': 4.0.6
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.5
       '@types/unist': 2.0.10
       estree-util-visit: 1.2.1
       micromark-util-symbol: 1.1.0
@@ -21763,7 +20848,7 @@ snapshots:
   micromark@3.2.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.4
+      debug: 4.3.6
       decode-named-character-reference: 1.0.2
       micromark-core-commonmark: 1.1.0
       micromark-factory-space: 1.1.0
@@ -21940,13 +21025,6 @@ snapshots:
       acorn: 8.12.1
       pathe: 1.1.2
       pkg-types: 1.2.0
-      ufo: 1.5.4
-
-  mlly@1.7.3:
-    dependencies:
-      acorn: 8.14.0
-      pathe: 1.1.2
-      pkg-types: 1.2.1
       ufo: 1.5.4
 
   modern-ahocorasick@1.0.1: {}
@@ -22478,15 +21556,15 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.26.0)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
+  nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.2.0(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3)))(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.26.0)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.26.0)(unocss@0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
-      '@nuxt/kit': 3.11.2(rollup@4.26.0)
-      '@nuxt/schema': 3.11.2(rollup@4.26.0)
-      '@nuxt/telemetry': 2.5.4(rollup@4.26.0)
+      '@nuxt/devtools': 1.2.0(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.21.2)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
+      '@nuxt/kit': 3.11.2(rollup@4.21.2)
+      '@nuxt/schema': 3.11.2(rollup@4.21.2)
+      '@nuxt/telemetry': 2.5.4(rollup@4.21.2)
       '@nuxt/ui-templates': 1.3.3
-      '@nuxt/vite-builder': 3.11.2(@types/node@20.11.15)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.26.0)(terser@5.27.0)(typescript@5.3.3)(vue@3.4.24(typescript@5.3.3))
+      '@nuxt/vite-builder': 3.11.2(@types/node@20.11.15)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(vue@3.4.24(typescript@5.3.3))
       '@unhead/dom': 1.9.7
       '@unhead/ssr': 1.9.7
       '@unhead/vue': 1.9.7(vue@3.4.24(typescript@5.3.3))
@@ -22527,9 +21605,9 @@ snapshots:
       uncrypto: 0.1.3
       unctx: 2.3.1
       unenv: 1.9.0
-      unimport: 3.7.1(rollup@4.26.0)
+      unimport: 3.7.1(rollup@4.21.2)
       unplugin: 1.10.1
-      unplugin-vue-router: 0.7.0(rollup@4.26.0)(vue-router@4.3.2(vue@3.4.24(typescript@5.3.3)))(vue@3.4.24(typescript@5.3.3))
+      unplugin-vue-router: 0.7.0(rollup@4.21.2)(vue-router@4.3.2(vue@3.4.24(typescript@5.3.3)))(vue@3.4.24(typescript@5.3.3))
       unstorage: 1.10.2(ioredis@5.4.1)
       untyped: 1.4.2
       vue: 3.4.24(typescript@5.3.3)
@@ -22702,10 +21780,10 @@ snapshots:
       - vue-tsc
       - xml2js
 
-  nuxt@3.12.4(@parcel/watcher@2.4.1)(@types/node@20.12.12)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.4.5)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0)):
+  nuxt@3.12.4(@parcel/watcher@2.4.1)(@types/node@20.12.12)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.4.5)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.4.1(rollup@4.21.2)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
+      '@nuxt/devtools': 1.4.1(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       '@nuxt/kit': 3.12.4(magicast@0.3.4)(rollup@4.21.2)
       '@nuxt/schema': 3.12.4(rollup@4.21.2)
       '@nuxt/telemetry': 2.5.4(rollup@4.21.2)
@@ -22809,14 +21887,14 @@ snapshots:
       - vue-tsc
       - xml2js
 
-  nuxt@3.12.4(@parcel/watcher@2.4.1)(@types/node@20.12.12)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.26.0)(terser@5.27.0)(typescript@5.4.5)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)):
+  nuxt@3.12.4(@parcel/watcher@2.4.1)(@types/node@20.12.12)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.4.5)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0)):
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.4.1(rollup@4.26.0)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
-      '@nuxt/kit': 3.12.4(magicast@0.3.4)(rollup@4.26.0)
-      '@nuxt/schema': 3.12.4(rollup@4.26.0)
-      '@nuxt/telemetry': 2.5.4(rollup@4.26.0)
-      '@nuxt/vite-builder': 3.12.4(@types/node@20.12.12)(eslint@8.56.0)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.26.0)(terser@5.27.0)(typescript@5.4.5)(vue@3.5.0(typescript@5.4.5))
+      '@nuxt/devtools': 1.4.1(rollup@4.21.2)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
+      '@nuxt/kit': 3.12.4(magicast@0.3.4)(rollup@4.21.2)
+      '@nuxt/schema': 3.12.4(rollup@4.21.2)
+      '@nuxt/telemetry': 2.5.4(rollup@4.21.2)
+      '@nuxt/vite-builder': 3.12.4(@types/node@20.12.12)(eslint@8.56.0)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.4.5)(vue@3.5.0(typescript@5.4.5))
       '@unhead/dom': 1.10.4
       '@unhead/ssr': 1.10.4
       '@unhead/vue': 1.10.4(vue@3.5.0(typescript@5.4.5))
@@ -22861,9 +21939,9 @@ snapshots:
       uncrypto: 0.1.3
       unctx: 2.3.1
       unenv: 1.10.0
-      unimport: 3.11.1(rollup@4.26.0)
+      unimport: 3.11.1(rollup@4.21.2)
       unplugin: 1.12.3
-      unplugin-vue-router: 0.10.7(rollup@4.26.0)(vue-router@4.4.3(vue@3.5.0(typescript@5.4.5)))(vue@3.5.0(typescript@5.4.5))
+      unplugin-vue-router: 0.10.7(rollup@4.21.2)(vue-router@4.4.3(vue@3.5.0(typescript@5.4.5)))(vue@3.5.0(typescript@5.4.5))
       unstorage: 1.10.2(ioredis@5.4.1)
       untyped: 1.4.2
       vue: 3.5.0(typescript@5.4.5)
@@ -22993,12 +22071,6 @@ snapshots:
       node-fetch-native: 1.6.4
       ufo: 1.5.3
 
-  ofetch@1.4.1:
-    dependencies:
-      destr: 2.0.3
-      node-fetch-native: 1.6.4
-      ufo: 1.5.4
-
   ohash@1.1.3: {}
 
   on-finished@2.3.0:
@@ -23121,8 +22193,6 @@ snapshots:
       aggregate-error: 3.1.0
 
   p-try@2.2.0: {}
-
-  package-manager-detector@0.2.2: {}
 
   pacote@18.0.0:
     dependencies:
@@ -23251,8 +22321,6 @@ snapshots:
 
   picocolors@1.0.1: {}
 
-  picocolors@1.1.1: {}
-
   picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
@@ -23283,12 +22351,6 @@ snapshots:
     dependencies:
       confbox: 0.1.7
       mlly: 1.7.1
-      pathe: 1.1.2
-
-  pkg-types@1.2.1:
-    dependencies:
-      confbox: 0.1.8
-      mlly: 1.7.3
       pathe: 1.1.2
 
   postcss-calc@10.0.2(postcss@8.4.44):
@@ -23396,12 +22458,12 @@ snapshots:
       postcss: 8.4.38
       ts-node: 10.9.2(@types/node@20.12.12)(typescript@5.4.5)
 
-  postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.3.3)):
+  postcss-load-config@4.0.2(postcss@8.4.44)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.3.3)):
     dependencies:
       lilconfig: 3.1.1
       yaml: 2.3.4
     optionalDependencies:
-      postcss: 8.4.49
+      postcss: 8.4.44
       ts-node: 10.9.2(@types/node@20.12.12)(typescript@5.3.3)
     optional: true
 
@@ -23695,12 +22757,6 @@ snapshots:
       nanoid: 3.3.7
       picocolors: 1.0.1
       source-map-js: 1.2.0
-
-  postcss@8.4.49:
-    dependencies:
-      nanoid: 3.3.7
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   preferred-pm@3.1.2:
     dependencies:
@@ -24155,15 +23211,6 @@ snapshots:
     optionalDependencies:
       rollup: 4.21.2
 
-  rollup-plugin-visualizer@5.12.0(rollup@4.26.0):
-    dependencies:
-      open: 8.4.2
-      picomatch: 2.3.1
-      source-map: 0.7.4
-      yargs: 17.7.2
-    optionalDependencies:
-      rollup: 4.26.0
-
   rollup-route-manifest@1.0.0(rollup@3.29.4):
     dependencies:
       rollup: 3.29.4
@@ -24171,28 +23218,6 @@ snapshots:
 
   rollup@3.29.4:
     optionalDependencies:
-      fsevents: 2.3.3
-
-  rollup@4.16.2:
-    dependencies:
-      '@types/estree': 1.0.5
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.16.2
-      '@rollup/rollup-android-arm64': 4.16.2
-      '@rollup/rollup-darwin-arm64': 4.16.2
-      '@rollup/rollup-darwin-x64': 4.16.2
-      '@rollup/rollup-linux-arm-gnueabihf': 4.16.2
-      '@rollup/rollup-linux-arm-musleabihf': 4.16.2
-      '@rollup/rollup-linux-arm64-gnu': 4.16.2
-      '@rollup/rollup-linux-arm64-musl': 4.16.2
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.16.2
-      '@rollup/rollup-linux-riscv64-gnu': 4.16.2
-      '@rollup/rollup-linux-s390x-gnu': 4.16.2
-      '@rollup/rollup-linux-x64-gnu': 4.16.2
-      '@rollup/rollup-linux-x64-musl': 4.16.2
-      '@rollup/rollup-win32-arm64-msvc': 4.16.2
-      '@rollup/rollup-win32-ia32-msvc': 4.16.2
-      '@rollup/rollup-win32-x64-msvc': 4.16.2
       fsevents: 2.3.3
 
   rollup@4.21.2:
@@ -24215,30 +23240,6 @@ snapshots:
       '@rollup/rollup-win32-arm64-msvc': 4.21.2
       '@rollup/rollup-win32-ia32-msvc': 4.21.2
       '@rollup/rollup-win32-x64-msvc': 4.21.2
-      fsevents: 2.3.3
-
-  rollup@4.26.0:
-    dependencies:
-      '@types/estree': 1.0.6
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.26.0
-      '@rollup/rollup-android-arm64': 4.26.0
-      '@rollup/rollup-darwin-arm64': 4.26.0
-      '@rollup/rollup-darwin-x64': 4.26.0
-      '@rollup/rollup-freebsd-arm64': 4.26.0
-      '@rollup/rollup-freebsd-x64': 4.26.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.26.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.26.0
-      '@rollup/rollup-linux-arm64-gnu': 4.26.0
-      '@rollup/rollup-linux-arm64-musl': 4.26.0
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.26.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.26.0
-      '@rollup/rollup-linux-s390x-gnu': 4.26.0
-      '@rollup/rollup-linux-x64-gnu': 4.26.0
-      '@rollup/rollup-linux-x64-musl': 4.26.0
-      '@rollup/rollup-win32-arm64-msvc': 4.26.0
-      '@rollup/rollup-win32-ia32-msvc': 4.26.0
-      '@rollup/rollup-win32-x64-msvc': 4.26.0
       fsevents: 2.3.3
 
   rollup@4.9.6:
@@ -24530,7 +23531,7 @@ snapshots:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
-      debug: 4.3.4
+      debug: 4.3.6
     transitivePeerDependencies:
       - supports-color
 
@@ -24587,7 +23588,7 @@ snapshots:
   socks-proxy-agent@8.0.3:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.4
+      debug: 4.3.6
       socks: 2.8.3
     transitivePeerDependencies:
       - supports-color
@@ -24668,8 +23669,6 @@ snapshots:
       sander: 0.5.1
 
   source-map-js@1.2.0: {}
-
-  source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
     dependencies:
@@ -24911,7 +23910,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@3.7.0(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.3.3)))(postcss@8.4.49)(svelte@4.2.15):
+  svelte-check@3.7.0(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.44)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.3.3)))(postcss@8.4.44)(svelte@4.2.15):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 3.6.0
@@ -24920,7 +23919,7 @@ snapshots:
       picocolors: 1.0.0
       sade: 1.8.1
       svelte: 4.2.15
-      svelte-preprocess: 5.1.4(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.3.3)))(postcss@8.4.49)(svelte@4.2.15)(typescript@5.4.5)
+      svelte-preprocess: 5.1.4(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.44)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.3.3)))(postcss@8.4.44)(svelte@4.2.15)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -24937,7 +23936,7 @@ snapshots:
     dependencies:
       svelte: 4.2.15
 
-  svelte-preprocess@5.1.4(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.3.3)))(postcss@8.4.49)(svelte@4.2.15)(typescript@5.4.5):
+  svelte-preprocess@5.1.4(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.44)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.3.3)))(postcss@8.4.44)(svelte@4.2.15)(typescript@5.4.5):
     dependencies:
       '@types/pug': 2.0.10
       detect-indent: 6.1.0
@@ -24947,8 +23946,8 @@ snapshots:
       svelte: 4.2.15
     optionalDependencies:
       '@babel/core': 7.25.2
-      postcss: 8.4.49
-      postcss-load-config: 4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.3.3))
+      postcss: 8.4.44
+      postcss-load-config: 4.0.2(postcss@8.4.44)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.3.3))
       typescript: 5.4.5
 
   svelte@4.2.15:
@@ -24978,7 +23977,7 @@ snapshots:
       css-tree: 2.3.1
       css-what: 6.1.0
       csso: 5.0.5
-      picocolors: 1.1.1
+      picocolors: 1.0.1
 
   svgo@3.3.2:
     dependencies:
@@ -24988,7 +23987,7 @@ snapshots:
       css-tree: 2.3.1
       css-what: 6.1.0
       csso: 5.0.5
-      picocolors: 1.1.1
+      picocolors: 1.0.1
 
   synckit@0.8.8:
     dependencies:
@@ -25183,8 +24182,6 @@ snapshots:
 
   tinybench@2.7.0: {}
 
-  tinyexec@0.3.1: {}
-
   tinyglobby@0.2.5:
     dependencies:
       fdir: 6.3.0(picomatch@4.0.2)
@@ -25359,7 +24356,7 @@ snapshots:
   tuf-js@2.2.0:
     dependencies:
       '@tufjs/models': 2.0.0
-      debug: 4.3.4
+      debug: 4.3.6
       make-fetch-happen: 13.0.0
     transitivePeerDependencies:
       - supports-color
@@ -25631,24 +24628,6 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  unimport@3.11.1(rollup@4.26.0):
-    dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.26.0)
-      acorn: 8.12.1
-      escape-string-regexp: 5.0.0
-      estree-walker: 3.0.3
-      fast-glob: 3.3.2
-      local-pkg: 0.5.0
-      magic-string: 0.30.11
-      mlly: 1.7.1
-      pathe: 1.1.2
-      pkg-types: 1.2.0
-      scule: 1.3.0
-      strip-literal: 2.1.0
-      unplugin: 1.12.3
-    transitivePeerDependencies:
-      - rollup
-
   unimport@3.7.1(rollup@3.29.4):
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
@@ -25670,24 +24649,6 @@ snapshots:
   unimport@3.7.1(rollup@4.21.2):
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
-      acorn: 8.11.3
-      escape-string-regexp: 5.0.0
-      estree-walker: 3.0.3
-      fast-glob: 3.3.2
-      local-pkg: 0.5.0
-      magic-string: 0.30.11
-      mlly: 1.6.1
-      pathe: 1.1.2
-      pkg-types: 1.1.0
-      scule: 1.3.0
-      strip-literal: 1.3.0
-      unplugin: 1.10.1
-    transitivePeerDependencies:
-      - rollup
-
-  unimport@3.7.1(rollup@4.26.0):
-    dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.26.0)
       acorn: 8.11.3
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
@@ -25751,10 +24712,10 @@ snapshots:
 
   universalify@2.0.0: {}
 
-  unocss@0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
+  unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
-      '@unocss/astro': 0.59.4(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
-      '@unocss/cli': 0.59.4(rollup@4.26.0)
+      '@unocss/astro': 0.59.4(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
+      '@unocss/cli': 0.59.4(rollup@4.21.2)
       '@unocss/core': 0.59.4
       '@unocss/extractor-arbitrary-variants': 0.59.4
       '@unocss/postcss': 0.59.4(postcss@8.4.38)
@@ -25772,9 +24733,9 @@ snapshots:
       '@unocss/transformer-compile-class': 0.59.4
       '@unocss/transformer-directives': 0.59.4
       '@unocss/transformer-variant-group': 0.59.4
-      '@unocss/vite': 0.59.4(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      '@unocss/vite': 0.59.4(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
     optionalDependencies:
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
     transitivePeerDependencies:
       - postcss
       - rollup
@@ -25826,34 +24787,12 @@ snapshots:
       - rollup
       - vue
 
-  unplugin-vue-router@0.10.7(rollup@4.26.0)(vue-router@4.4.3(vue@3.5.0(typescript@5.4.5)))(vue@3.5.0(typescript@5.4.5)):
-    dependencies:
-      '@babel/types': 7.25.6
-      '@rollup/pluginutils': 5.1.0(rollup@4.26.0)
-      '@vue-macros/common': 1.12.2(rollup@4.26.0)(vue@3.5.0(typescript@5.4.5))
-      ast-walker-scope: 0.6.2
-      chokidar: 3.6.0
-      fast-glob: 3.3.2
-      json5: 2.2.3
-      local-pkg: 0.5.0
-      magic-string: 0.30.11
-      mlly: 1.7.1
-      pathe: 1.1.2
-      scule: 1.3.0
-      unplugin: 1.12.3
-      yaml: 2.5.0
-    optionalDependencies:
-      vue-router: 4.4.3(vue@3.5.0(typescript@5.4.5))
-    transitivePeerDependencies:
-      - rollup
-      - vue
-
-  unplugin-vue-router@0.7.0(rollup@4.26.0)(vue-router@4.3.2(vue@3.4.24(typescript@5.3.3)))(vue@3.4.24(typescript@5.3.3)):
+  unplugin-vue-router@0.7.0(rollup@4.21.2)(vue-router@4.3.2(vue@3.4.24(typescript@5.3.3)))(vue@3.4.24(typescript@5.3.3)):
     dependencies:
       '@babel/types': 7.24.0
-      '@rollup/pluginutils': 5.1.0(rollup@4.26.0)
-      '@vue-macros/common': 1.10.2(rollup@4.26.0)(vue@3.4.24(typescript@5.3.3))
-      ast-walker-scope: 0.5.0(rollup@4.26.0)
+      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      '@vue-macros/common': 1.10.2(rollup@4.21.2)(vue@3.4.24(typescript@5.3.3))
+      ast-walker-scope: 0.5.0(rollup@4.21.2)
       chokidar: 3.6.0
       fast-glob: 3.3.2
       json5: 2.2.3
@@ -26155,10 +25094,6 @@ snapshots:
     dependencies:
       vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
 
-  vite-hot-client@0.2.3(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
-    dependencies:
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
-
   vite-node@1.5.0(@types/node@20.10.0)(terser@5.27.0):
     dependencies:
       cac: 6.7.14
@@ -26346,50 +25281,20 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@0.7.42(rollup@4.26.0)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0)):
+  vite-plugin-inspect@0.8.4(@nuxt/kit@3.11.2(rollup@4.21.2))(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
       '@antfu/utils': 0.7.7
-      '@rollup/pluginutils': 5.1.0(rollup@4.26.0)
-      debug: 4.3.4
-      error-stack-parser-es: 0.1.1
-      fs-extra: 11.2.0
-      open: 9.1.0
-      picocolors: 1.0.0
-      sirv: 2.0.4
-      vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-
-  vite-plugin-inspect@0.7.42(rollup@4.26.0)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)):
-    dependencies:
-      '@antfu/utils': 0.7.7
-      '@rollup/pluginutils': 5.1.0(rollup@4.26.0)
-      debug: 4.3.4
-      error-stack-parser-es: 0.1.1
-      fs-extra: 11.2.0
-      open: 9.1.0
-      picocolors: 1.0.0
-      sirv: 2.0.4
-      vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-
-  vite-plugin-inspect@0.8.4(@nuxt/kit@3.11.2(rollup@4.26.0))(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
-    dependencies:
-      '@antfu/utils': 0.7.7
-      '@rollup/pluginutils': 5.1.0(rollup@4.26.0)
-      debug: 4.3.4
+      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      debug: 4.3.6
       error-stack-parser-es: 0.1.1
       fs-extra: 11.2.0
       open: 10.1.0
       perfect-debounce: 1.0.0
       picocolors: 1.0.1
       sirv: 2.0.4
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
     optionalDependencies:
-      '@nuxt/kit': 3.11.2(rollup@4.26.0)
+      '@nuxt/kit': 3.11.2(rollup@4.21.2)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -26412,6 +25317,24 @@ snapshots:
       - rollup
       - supports-color
 
+  vite-plugin-inspect@0.8.7(@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@4.21.2))(rollup@4.21.2)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)):
+    dependencies:
+      '@antfu/utils': 0.7.10
+      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      debug: 4.3.6
+      error-stack-parser-es: 0.1.5
+      fs-extra: 11.2.0
+      open: 10.1.0
+      perfect-debounce: 1.0.0
+      picocolors: 1.0.1
+      sirv: 2.0.4
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
+    optionalDependencies:
+      '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.21.2)
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+
   vite-plugin-inspect@0.8.7(@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@4.21.2))(rollup@4.21.2)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0)):
     dependencies:
       '@antfu/utils': 0.7.10
@@ -26426,24 +25349,6 @@ snapshots:
       vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
     optionalDependencies:
       '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.21.2)
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-
-  vite-plugin-inspect@0.8.7(@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@4.26.0))(rollup@4.26.0)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)):
-    dependencies:
-      '@antfu/utils': 0.7.10
-      '@rollup/pluginutils': 5.1.0(rollup@4.26.0)
-      debug: 4.3.6
-      error-stack-parser-es: 0.1.5
-      fs-extra: 11.2.0
-      open: 10.1.0
-      perfect-debounce: 1.0.0
-      picocolors: 1.0.1
-      sirv: 2.0.4
-      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
-    optionalDependencies:
-      '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.26.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -26474,20 +25379,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-solid@2.10.2(solid-js@1.8.19)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)):
-    dependencies:
-      '@babel/core': 7.24.4
-      '@types/babel__core': 7.20.5
-      babel-preset-solid: 1.8.19(@babel/core@7.24.4)
-      merge-anything: 5.1.7
-      solid-js: 1.8.19
-      solid-refresh: 0.6.3(solid-js@1.8.19)
-      vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
-      vitefu: 0.2.5(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
-    transitivePeerDependencies:
-      - supports-color
-
-  vite-plugin-vue-inspector@4.0.2(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
+  vite-plugin-vue-inspector@4.0.2(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
       '@babel/core': 7.24.4
       '@babel/plugin-proposal-decorators': 7.24.1(@babel/core@7.24.4)
@@ -26498,7 +25390,7 @@ snapshots:
       '@vue/compiler-dom': 3.4.24
       kolorist: 1.8.0
       magic-string: 0.30.11
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -26554,17 +25446,6 @@ snapshots:
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@4.3.2(typescript@5.3.3)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
-    dependencies:
-      debug: 4.3.4
-      globrex: 0.1.2
-      tsconfck: 3.0.3(typescript@5.3.3)
-    optionalDependencies:
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   vite-tsconfig-paths@4.3.2(typescript@5.4.5)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0)):
     dependencies:
       debug: 4.3.4
@@ -26576,13 +25457,13 @@ snapshots:
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@4.3.2(typescript@5.4.5)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)):
+  vite-tsconfig-paths@5.1.2(typescript@5.3.3)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.6
       globrex: 0.1.2
-      tsconfck: 3.0.3(typescript@5.4.5)
+      tsconfck: 3.0.3(typescript@5.3.3)
     optionalDependencies:
-      vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -26597,11 +25478,11 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.27.0
 
-  vite@5.2.10(@types/node@20.11.15)(terser@5.27.0):
+  vite@5.2.14(@types/node@20.11.15)(terser@5.27.0):
     dependencies:
       esbuild: 0.20.2
-      postcss: 8.4.38
-      rollup: 4.16.2
+      postcss: 8.4.44
+      rollup: 4.21.2
     optionalDependencies:
       '@types/node': 20.11.15
       fsevents: 2.3.3
@@ -26610,34 +25491,14 @@ snapshots:
   vite@5.4.11(@types/node@20.10.0)(terser@5.27.0):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.4.49
-      rollup: 4.26.0
+      postcss: 8.4.44
+      rollup: 4.21.2
     optionalDependencies:
       '@types/node': 20.10.0
       fsevents: 2.3.3
       terser: 5.27.0
 
   vite@5.4.11(@types/node@20.11.15)(terser@5.27.0):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.4.49
-      rollup: 4.26.0
-    optionalDependencies:
-      '@types/node': 20.11.15
-      fsevents: 2.3.3
-      terser: 5.27.0
-
-  vite@5.4.11(@types/node@20.12.12)(terser@5.27.0):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.4.49
-      rollup: 4.26.0
-    optionalDependencies:
-      '@types/node': 20.12.12
-      fsevents: 2.3.3
-      terser: 5.27.0
-
-  vite@5.4.3(@types/node@20.11.15)(terser@5.27.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.44
@@ -26647,7 +25508,7 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.27.0
 
-  vite@5.4.3(@types/node@20.12.12)(terser@5.27.0):
+  vite@5.4.11(@types/node@20.12.12)(terser@5.27.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.44
@@ -26664,14 +25525,6 @@ snapshots:
   vitefu@0.2.5(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0)):
     optionalDependencies:
       vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
-
-  vitefu@0.2.5(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
-    optionalDependencies:
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
-
-  vitefu@0.2.5(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)):
-    optionalDependencies:
-      vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
 
   vitest@1.5.0(@types/node@20.10.0)(terser@5.27.0):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,7 +57,7 @@ importers:
         specifier: ^5.3.3
         version: 5.3.3
       vite:
-        specifier: ^5.3.6
+        specifier: ^5.2.14
         version: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
       vite-tsconfig-paths:
         specifier: ^4.3.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,10 +58,10 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.2.14
-        version: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+        version: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.3.3)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+        version: 4.3.2(typescript@5.3.3)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       vitest:
         specifier: ^1.5.0
         version: 1.5.0(@types/node@20.11.15)(terser@5.27.0)
@@ -177,7 +177,7 @@ importers:
     dependencies:
       nuxt:
         specifier: ^3.12.4
-        version: 3.12.4(@parcel/watcher@2.4.1)(@types/node@20.12.12)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.4.5)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+        version: 3.12.4(@parcel/watcher@2.4.1)(@types/node@20.12.12)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.4.5)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
       vue:
         specifier: ^3.4.21
         version: 3.4.24(typescript@5.4.5)
@@ -349,7 +349,7 @@ importers:
         version: 0.14.1(solid-js@1.8.19)
       '@solidjs/start':
         specifier: ^1.0.6
-        version: 1.0.6(rollup@4.21.2)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+        version: 1.0.6(rollup@4.21.2)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
       solid-js:
         specifier: ^1.8.18
         version: 1.8.19
@@ -358,7 +358,7 @@ importers:
         version: 0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0)
       vite-plugin-solid:
         specifier: ^2.10.2
-        version: 2.10.2(solid-js@1.8.19)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+        version: 2.10.2(solid-js@1.8.19)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
 
   examples/sveltekit:
     devDependencies:
@@ -385,7 +385,7 @@ importers:
         version: 4.2.15
       svelte-check:
         specifier: ^3.6.0
-        version: 3.7.0(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.44)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.3.3)))(postcss@8.4.44)(svelte@4.2.15)
+        version: 3.7.0(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.3.3)))(postcss@8.4.49)(svelte@4.2.15)
       tslib:
         specifier: ^2.4.1
         version: 2.6.2
@@ -511,10 +511,10 @@ importers:
         version: 4.17.21
       solid-start:
         specifier: ^0.3.11
-        version: 0.3.11(@solidjs/meta@0.29.4(solid-js@1.8.19))(@solidjs/router@0.14.1(solid-js@1.8.19))(solid-js@1.8.19)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+        version: 0.3.11(@solidjs/meta@0.29.4(solid-js@1.8.19))(@solidjs/router@0.14.1(solid-js@1.8.19))(solid-js@1.8.19)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       vite-plugin-solid:
         specifier: ^2.10.2
-        version: 2.10.2(solid-js@1.8.19)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+        version: 2.10.2(solid-js@1.8.19)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
     devDependencies:
       '@codecov/bundle-analyzer':
         specifier: workspace:^
@@ -545,7 +545,7 @@ importers:
         version: link:../packages/webpack-plugin
       '@remix-run/dev':
         specifier: ^2.9.2
-        version: 2.9.2(@remix-run/react@2.9.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5))(@remix-run/serve@2.9.2(typescript@5.4.5))(@types/node@20.11.15)(terser@5.27.0)(ts-node@10.9.2(@types/node@20.11.15)(typescript@5.4.5))(typescript@5.4.5)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+        version: 2.9.2(@remix-run/react@2.9.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5))(@remix-run/serve@2.9.2(typescript@5.4.5))(@types/node@20.11.15)(terser@5.27.0)(ts-node@10.9.2(@types/node@20.11.15)(typescript@5.4.5))(typescript@5.4.5)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       '@rollup/plugin-commonjs':
         specifier: ^25.0.7
         version: 25.0.7(rollup@3.29.4)
@@ -554,10 +554,10 @@ importers:
         version: 15.2.3(rollup@3.29.4)
       '@solidjs/start':
         specifier: ^1.0.6
-        version: 1.0.6(rollup@3.29.4)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.11.15)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+        version: 1.0.6(rollup@3.29.4)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.11.15)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       '@sveltejs/kit':
         specifier: ^2.5.25
-        version: 2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+        version: 2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       '@types/bun':
         specifier: ^1.0.6
         version: 1.0.6
@@ -572,7 +572,7 @@ importers:
         version: 4.4.0
       nuxt:
         specifier: 3.12.4
-        version: 3.12.4(@parcel/watcher@2.4.1)(@types/node@20.11.15)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@3.29.4)(terser@5.27.0)(typescript@5.4.5)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+        version: 3.12.4(@parcel/watcher@2.4.1)(@types/node@20.11.15)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@3.29.4)(terser@5.27.0)(typescript@5.4.5)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -651,7 +651,7 @@ importers:
     dependencies:
       nuxt:
         specifier: ^3.12.4
-        version: 3.12.4(@parcel/watcher@2.4.1)(@types/node@20.12.12)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.4.5)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+        version: 3.12.4(@parcel/watcher@2.4.1)(@types/node@20.12.12)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.26.0)(terser@5.27.0)(typescript@5.4.5)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       vue:
         specifier: ^3.4.21
         version: 3.4.24(typescript@5.4.5)
@@ -749,7 +749,7 @@ importers:
         version: 0.14.1(solid-js@1.8.19)
       '@solidjs/start':
         specifier: ^1.0.6
-        version: 1.0.6(rollup@4.21.2)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+        version: 1.0.6(rollup@4.26.0)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
       solid-js:
         specifier: ^1.8.18
         version: 1.8.19
@@ -758,7 +758,7 @@ importers:
         version: 0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0)
       vite-plugin-solid:
         specifier: ^2.10.2
-        version: 2.10.2(solid-js@1.8.19)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+        version: 2.10.2(solid-js@1.8.19)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
 
   integration-tests/test-apps/sveltekit:
     devDependencies:
@@ -874,7 +874,7 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.11.15)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.21.2)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.26.0)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.3.3)
@@ -898,7 +898,7 @@ importers:
         version: 2.0.0(typescript@5.3.3)
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.3.3)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+        version: 4.3.2(typescript@5.3.3)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       vitest:
         specifier: ^1.5.0
         version: 1.5.0(@types/node@20.11.15)(terser@5.27.0)
@@ -920,7 +920,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.21.2)
+        version: 5.0.5(rollup@4.26.0)
       '@types/node':
         specifier: ^20.10.0
         version: 20.12.12
@@ -932,7 +932,7 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.12.12)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.21.2)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.26.0)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.4.5)
@@ -950,7 +950,7 @@ importers:
         version: 2.0.0(typescript@5.4.5)
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.4.5)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+        version: 4.3.2(typescript@5.4.5)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
       vitest:
         specifier: ^1.5.0
         version: 1.5.0(@types/node@20.12.12)(terser@5.27.0)
@@ -968,17 +968,17 @@ importers:
         version: link:../vite-plugin
       '@nuxt/kit':
         specifier: ^3.11.2
-        version: 3.11.2(rollup@4.21.2)
+        version: 3.11.2(rollup@4.26.0)
       nuxt:
         specifier: 3.x
-        version: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+        version: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.26.0)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
       unplugin:
         specifier: ^1.10.1
         version: 1.10.1
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.21.2)
+        version: 5.0.5(rollup@4.26.0)
       '@types/node':
         specifier: ^20.11.15
         version: 20.11.15
@@ -987,7 +987,7 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.11.15)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.21.2)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.26.0)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.3.3)
@@ -1030,7 +1030,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.21.2)
+        version: 5.0.5(rollup@4.26.0)
       '@types/node':
         specifier: ^20.11.15
         version: 20.12.12
@@ -1039,7 +1039,7 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.12.12)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.21.2)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.26.0)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.4.5)
@@ -1106,7 +1106,7 @@ importers:
         version: 2.0.0(typescript@5.3.3)
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.3.3)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+        version: 4.3.2(typescript@5.3.3)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       vitest:
         specifier: ^1.5.0
         version: 1.5.0(@types/node@20.11.15)(terser@5.27.0)
@@ -1121,14 +1121,14 @@ importers:
         version: link:../vite-plugin
       '@solidjs/start':
         specifier: 1.x
-        version: 1.0.6(rollup@4.21.2)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+        version: 1.0.6(rollup@4.26.0)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
       unplugin:
         specifier: ^1.10.1
         version: 1.10.1
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.21.2)
+        version: 5.0.5(rollup@4.26.0)
       '@types/node':
         specifier: ^20.11.15
         version: 20.12.12
@@ -1137,7 +1137,7 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.12.12)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.21.2)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.26.0)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.4.5)
@@ -1183,7 +1183,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.21.2)
+        version: 5.0.5(rollup@4.26.0)
       '@types/node':
         specifier: ^20.11.15
         version: 20.11.15
@@ -1192,7 +1192,7 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.11.15)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.21.2)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.26.0)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.3.3)
@@ -1229,7 +1229,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.21.2)
+        version: 5.0.5(rollup@4.26.0)
       '@types/node':
         specifier: ^20.11.15
         version: 20.11.15
@@ -1238,7 +1238,7 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.11.15)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.21.2)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.26.0)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.3.3)
@@ -1275,7 +1275,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.21.2)
+        version: 5.0.5(rollup@4.26.0)
       '@types/node':
         specifier: ^20.10.0
         version: 20.10.0
@@ -1287,7 +1287,7 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.10.0)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.21.2)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.26.0)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.3.3)
@@ -1305,7 +1305,7 @@ importers:
         version: 2.0.0(typescript@5.3.3)
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.3.3)(vite@5.4.3(@types/node@20.10.0)(terser@5.27.0))
+        version: 4.3.2(typescript@5.3.3)(vite@5.4.11(@types/node@20.10.0)(terser@5.27.0))
       vitest:
         specifier: ^1.5.0
         version: 1.5.0(@types/node@20.10.0)(terser@5.27.0)
@@ -1336,8 +1336,8 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@antfu/install-pkg@0.1.1':
-    resolution: {integrity: sha512-LyB/8+bSfa0DFGC06zpCEfs89/XoWZwws5ygEa5D+Xsm3OfI+aXQ86VgVG7Acyef+rSZ5HE7J8rrxzrQeM3PjQ==}
+  '@antfu/install-pkg@0.4.1':
+    resolution: {integrity: sha512-T7yB5QNG29afhWVkVq7XeIMBa5U/vs9mX69YqayXypPRmYzUmzwnYltplHmPtZ4HPCn+sQKeXW8I47wCbuBOjw==}
 
   '@antfu/utils@0.7.10':
     resolution: {integrity: sha512-+562v9k4aI80m1+VuMHehNJWLOFjBnXn3tdOitzD0il5b7smkSBal4+a3oKiQTbrwMmN/TBUMDvbdoWDehgOww==}
@@ -1351,6 +1351,10 @@ packages:
 
   '@babel/code-frame@7.24.7':
     resolution: {integrity: sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/code-frame@7.26.2':
+    resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/compat-data@7.23.5':
@@ -1389,12 +1393,20 @@ packages:
     resolution: {integrity: sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/generator@7.26.2':
+    resolution: {integrity: sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-annotate-as-pure@7.22.5':
     resolution: {integrity: sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-annotate-as-pure@7.24.7':
     resolution: {integrity: sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-annotate-as-pure@7.25.9':
+    resolution: {integrity: sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-builder-binary-assignment-operator-visitor@7.24.7':
@@ -1427,6 +1439,12 @@ packages:
 
   '@babel/helper-create-class-features-plugin@7.25.4':
     resolution: {integrity: sha512-ro/bFs3/84MDgDmMwbcHgDa8/E6J3QKNTk4xJJnVeFtGE+tL0K26E3pNxhYz2b67fJpt7Aphw5XcploKXuCvCQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-create-class-features-plugin@7.25.9':
+    resolution: {integrity: sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -1474,6 +1492,10 @@ packages:
     resolution: {integrity: sha512-LABppdt+Lp/RlBxqrh4qgf1oEH/WxdzQNDJIu5gC/W1GyvPVrOBiItmmM8wan2fm4oYqFuFfkXmlGpLQhPY8CA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-member-expression-to-functions@7.25.9':
+    resolution: {integrity: sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-module-imports@7.18.6':
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
     engines: {node: '>=6.9.0'}
@@ -1484,6 +1506,10 @@ packages:
 
   '@babel/helper-module-imports@7.24.7':
     resolution: {integrity: sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.25.9':
+    resolution: {integrity: sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-transforms@7.23.3':
@@ -1504,12 +1530,22 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/helper-module-transforms@7.26.0':
+    resolution: {integrity: sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
   '@babel/helper-optimise-call-expression@7.22.5':
     resolution: {integrity: sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-optimise-call-expression@7.24.7':
     resolution: {integrity: sha512-jKiTsW2xmWwxT1ixIdfXUZp+P5yURx2suzLZr5Hi64rURpDYdMW0pv+Uf17EYk2Rd428Lx4tLsnjGJzYKDM/6A==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-optimise-call-expression@7.25.9':
+    resolution: {integrity: sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-plugin-utils@7.22.5':
@@ -1522,6 +1558,10 @@ packages:
 
   '@babel/helper-plugin-utils@7.24.8':
     resolution: {integrity: sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-plugin-utils@7.25.9':
+    resolution: {integrity: sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-remap-async-to-generator@7.24.7':
@@ -1548,6 +1588,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/helper-replace-supers@7.25.9':
+    resolution: {integrity: sha512-IiDqTOTBQy0sWyeXyGSC5TBJpGFXBkRynjBeXsvbhQFKj2viwJC76Epz35YLU1fpe/Am6Vppb7W7zM4fPQzLsQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
   '@babel/helper-simple-access@7.22.5':
     resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
     engines: {node: '>=6.9.0'}
@@ -1556,12 +1602,20 @@ packages:
     resolution: {integrity: sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-simple-access@7.25.9':
+    resolution: {integrity: sha512-c6WHXuiaRsJTyHYLJV75t9IqsmTbItYfdj99PnzYGQZkYKvan5/2jKJ7gu31J3/BJ/A18grImSPModuyG/Eo0Q==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-skip-transparent-expression-wrappers@7.22.5':
     resolution: {integrity: sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-skip-transparent-expression-wrappers@7.24.7':
     resolution: {integrity: sha512-IO+DLT3LQUElMbpzlatRASEyQtfhSE0+m465v++3jyyXeBTBUjtVZg28/gHeV5mrTJqvEKhKroBGAvhW+qPHiQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.25.9':
+    resolution: {integrity: sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-split-export-declaration@7.22.6':
@@ -1580,6 +1634,10 @@ packages:
     resolution: {integrity: sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.25.9':
+    resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.22.20':
     resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
     engines: {node: '>=6.9.0'}
@@ -1588,12 +1646,20 @@ packages:
     resolution: {integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-identifier@7.25.9':
+    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-option@7.23.5':
     resolution: {integrity: sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.24.8':
     resolution: {integrity: sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.25.9':
+    resolution: {integrity: sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-wrap-function@7.24.7':
@@ -1632,6 +1698,11 @@ packages:
 
   '@babel/parser@7.25.6':
     resolution: {integrity: sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.26.2':
+    resolution: {integrity: sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1737,6 +1808,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-syntax-jsx@7.25.9':
+    resolution: {integrity: sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4':
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
     peerDependencies:
@@ -1787,6 +1864,12 @@ packages:
 
   '@babel/plugin-syntax-typescript@7.25.4':
     resolution: {integrity: sha512-uMOCoHVU52BsSWxPOMVv5qKRdeSlPuImUCB2dlPuBSU+W2/ROE7/Zg8F2Kepbk+8yBa68LlRKxO+xgEVWorsDg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-typescript@7.25.9':
+    resolution: {integrity: sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1941,6 +2024,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-modules-commonjs@7.25.9':
+    resolution: {integrity: sha512-dwh2Ol1jWwL2MgkCzUSOvfmKElqQcuswAZypBSUsScMXvgdT8Ekq5YA6TtqpTVWH+4903NmboMuH1o9i8Rxlyg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-modules-systemjs@7.24.7':
     resolution: {integrity: sha512-GYQE0tW7YoaN13qFh3O1NCY4MPkUiAH3fiF7UcV/I3ajmDKEdG3l+UOcbAm4zUE3gnvUU+Eni7XrVKo9eO9auw==}
     engines: {node: '>=6.9.0'}
@@ -2091,6 +2180,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-typescript@7.25.9':
+    resolution: {integrity: sha512-7PbZQZP50tzv2KGGnhh82GSyMB01yKY9scIjf1a+GfZCtInOWqUH5+1EBU4t9fyR5Oykkkc9vFTs4OHrhHXljQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-unicode-escapes@7.24.7':
     resolution: {integrity: sha512-U3ap1gm5+4edc2Q/P+9VrBNhGkfnf+8ZqppY71Bo/pzZmXhhLdqgaUl6cuB07O1+AQJtCLfaOmswiNbSQ9ivhw==}
     engines: {node: '>=6.9.0'}
@@ -2132,6 +2227,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/preset-typescript@7.26.0':
+    resolution: {integrity: sha512-NMk1IGZ5I/oHhoXEElcm+xUnL/szL6xflkFZmoEU9xj1qSJXpiS7rsspYo92B4DRCDvZn2erT5LdsCeXAKNCkg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/regjsgen@0.8.0':
     resolution: {integrity: sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==}
 
@@ -2155,6 +2256,10 @@ packages:
     resolution: {integrity: sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@7.25.9':
+    resolution: {integrity: sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/traverse@7.23.9':
     resolution: {integrity: sha512-I/4UJ9vs90OkBtY6iiiTORVMyIhJ4kAVmsKo9KFc8UOxMeUfi2hvtIBsET5u9GizXE6/GFSuKCTNfgCswuEjRg==}
     engines: {node: '>=6.9.0'}
@@ -2171,6 +2276,10 @@ packages:
     resolution: {integrity: sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@7.25.9':
+    resolution: {integrity: sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.24.0':
     resolution: {integrity: sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==}
     engines: {node: '>=6.9.0'}
@@ -2181,6 +2290,10 @@ packages:
 
   '@babel/types@7.25.6':
     resolution: {integrity: sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.26.0':
+    resolution: {integrity: sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@0.2.3':
@@ -3251,14 +3364,14 @@ packages:
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
 
-  '@floating-ui/core@1.6.0':
-    resolution: {integrity: sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==}
+  '@floating-ui/core@1.6.8':
+    resolution: {integrity: sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==}
 
   '@floating-ui/dom@1.1.1':
     resolution: {integrity: sha512-TpIO93+DIujg3g7SykEAGZMDtbJRrmnYRCNYSjJlvIbGhBjRSNTLVbNeDQBrzy9qDgUbiWdc7KA0uZHZ2tJmiw==}
 
-  '@floating-ui/utils@0.2.1':
-    resolution: {integrity: sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==}
+  '@floating-ui/utils@0.2.8':
+    resolution: {integrity: sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==}
 
   '@fontsource/fira-mono@4.5.10':
     resolution: {integrity: sha512-bxUnRP8xptGRo8YXeY073DSpfK74XpSb0ZyRNpHV9WvLnJ7TwPOjZll8hTMin7zLC6iOp59pDZ8EQDj1gzgAQQ==}
@@ -3285,8 +3398,8 @@ packages:
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
-  '@iconify/utils@2.1.23':
-    resolution: {integrity: sha512-YGNbHKM5tyDvdWZ92y2mIkrfvm5Fvhe6WJSkWu7vvOFhMtYDP0casZpoRz0XEHZCrYsR4stdGT3cZ52yp5qZdQ==}
+  '@iconify/utils@2.1.33':
+    resolution: {integrity: sha512-jP9h6v/g0BIZx0p7XGJJVtkVnydtbgTgt9mVNcGDYwaa7UhdHdI9dvoq+gKj9sijMSJKxUPEG2JyjsgXjxL7Kw==}
 
   '@img/sharp-darwin-arm64@0.33.5':
     resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
@@ -4188,6 +4301,15 @@ packages:
       rollup:
         optional: true
 
+  '@rollup/pluginutils@5.1.3':
+    resolution: {integrity: sha512-Pnsb6f32CD2W3uCaLZIzDmeFyQ2b8UWMFI7xtwUezpcGBDVDW6y9XgAWIlARiGAo6eNF5FK5aQTr0LFyNyqq5A==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@rollup/rollup-android-arm-eabi@4.16.2':
     resolution: {integrity: sha512-VGodkwtEuZ+ENPz/CpDSl091koMv8ao5jHVMbG1vNK+sbx/48/wVzP84M5xSfDAC69mAKKoEkSo+ym9bXYRK9w==}
     cpu: [arm]
@@ -4195,6 +4317,11 @@ packages:
 
   '@rollup/rollup-android-arm-eabi@4.21.2':
     resolution: {integrity: sha512-fSuPrt0ZO8uXeS+xP3b+yYTCBUd05MoSp2N/MFOgjhhUhMmchXlpTQrTpI8T+YAwAQuK7MafsCOxW7VrPMrJcg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm-eabi@4.26.0':
+    resolution: {integrity: sha512-gJNwtPDGEaOEgejbaseY6xMFu+CPltsc8/T+diUTTbOQLqD+bnrJq9ulH6WD69TqwqWmrfRAtUv30cCFZlbGTQ==}
     cpu: [arm]
     os: [android]
 
@@ -4213,6 +4340,11 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@rollup/rollup-android-arm64@4.26.0':
+    resolution: {integrity: sha512-YJa5Gy8mEZgz5JquFruhJODMq3lTHWLm1fOy+HIANquLzfIOzE9RA5ie3JjCdVb9r46qfAQY/l947V0zfGJ0OQ==}
+    cpu: [arm64]
+    os: [android]
+
   '@rollup/rollup-android-arm64@4.9.6':
     resolution: {integrity: sha512-T14aNLpqJ5wzKNf5jEDpv5zgyIqcpn1MlwCrUXLrwoADr2RkWA0vOWP4XxbO9aiO3dvMCQICZdKeDrFl7UMClw==}
     cpu: [arm64]
@@ -4225,6 +4357,11 @@ packages:
 
   '@rollup/rollup-darwin-arm64@4.21.2':
     resolution: {integrity: sha512-99AhQ3/ZMxU7jw34Sq8brzXqWH/bMnf7ZVhvLk9QU2cOepbQSVTns6qoErJmSiAvU3InRqC2RRZ5ovh1KN0d0Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-arm64@4.26.0':
+    resolution: {integrity: sha512-ErTASs8YKbqTBoPLp/kA1B1Um5YSom8QAc4rKhg7b9tyyVqDBlQxy7Bf2wW7yIlPGPg2UODDQcbkTlruPzDosw==}
     cpu: [arm64]
     os: [darwin]
 
@@ -4243,10 +4380,25 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@rollup/rollup-darwin-x64@4.26.0':
+    resolution: {integrity: sha512-wbgkYDHcdWW+NqP2mnf2NOuEbOLzDblalrOWcPyY6+BRbVhliavon15UploG7PpBRQ2bZJnbmh8o3yLoBvDIHA==}
+    cpu: [x64]
+    os: [darwin]
+
   '@rollup/rollup-darwin-x64@4.9.6':
     resolution: {integrity: sha512-zRDtdJuRvA1dc9Mp6BWYqAsU5oeLixdfUvkTHuiYOHwqYuQ4YgSmi6+/lPvSsqc/I0Omw3DdICx4Tfacdzmhog==}
     cpu: [x64]
     os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.26.0':
+    resolution: {integrity: sha512-Y9vpjfp9CDkAG4q/uwuhZk96LP11fBz/bYdyg9oaHYhtGZp7NrbkQrj/66DYMMP2Yo/QPAsVHkV891KyO52fhg==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.26.0':
+    resolution: {integrity: sha512-A/jvfCZ55EYPsqeaAt/yDAG4q5tt1ZboWMHEvKAH9Zl92DWvMIbnZe/f/eOXze65aJaaKbL+YeM0Hz4kLQvdwg==}
+    cpu: [x64]
+    os: [freebsd]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.16.2':
     resolution: {integrity: sha512-/bjfUiXwy3P5vYr6/ezv//Yle2Y0ak3a+Av/BKoi76nFryjWCkki8AuVoPR7ZU/ckcvAWFo77OnFK14B9B5JsA==}
@@ -4255,6 +4407,11 @@ packages:
 
   '@rollup/rollup-linux-arm-gnueabihf@4.21.2':
     resolution: {integrity: sha512-ztRJJMiE8nnU1YFcdbd9BcH6bGWG1z+jP+IPW2oDUAPxPjo9dverIOyXz76m6IPA6udEL12reYeLojzW2cYL7w==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.26.0':
+    resolution: {integrity: sha512-paHF1bMXKDuizaMODm2bBTjRiHxESWiIyIdMugKeLnjuS1TCS54MF5+Y5Dx8Ui/1RBPVRE09i5OUlaLnv8OGnA==}
     cpu: [arm]
     os: [linux]
 
@@ -4273,6 +4430,11 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rollup/rollup-linux-arm-musleabihf@4.26.0':
+    resolution: {integrity: sha512-cwxiHZU1GAs+TMxvgPfUDtVZjdBdTsQwVnNlzRXC5QzIJ6nhfB4I1ahKoe9yPmoaA/Vhf7m9dB1chGPpDRdGXg==}
+    cpu: [arm]
+    os: [linux]
+
   '@rollup/rollup-linux-arm64-gnu@4.16.2':
     resolution: {integrity: sha512-UN7VAXLyeyGbCQWiOtQN7BqmjTDw1ON2Oos4lfk0YR7yNhFEJWZiwGtvj9Ay4lsT/ueT04sh80Sg2MlWVVZ+Ug==}
     cpu: [arm64]
@@ -4280,6 +4442,11 @@ packages:
 
   '@rollup/rollup-linux-arm64-gnu@4.21.2':
     resolution: {integrity: sha512-69CF19Kp3TdMopyteO/LJbWufOzqqXzkrv4L2sP8kfMaAQ6iwky7NoXTp7bD6/irKgknDKM0P9E/1l5XxVQAhw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.26.0':
+    resolution: {integrity: sha512-4daeEUQutGRCW/9zEo8JtdAgtJ1q2g5oHaoQaZbMSKaIWKDQwQ3Yx0/3jJNmpzrsScIPtx/V+1AfibLisb3AMQ==}
     cpu: [arm64]
     os: [linux]
 
@@ -4298,6 +4465,11 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rollup/rollup-linux-arm64-musl@4.26.0':
+    resolution: {integrity: sha512-eGkX7zzkNxvvS05ROzJ/cO/AKqNvR/7t1jA3VZDi2vRniLKwAWxUr85fH3NsvtxU5vnUUKFHKh8flIBdlo2b3Q==}
+    cpu: [arm64]
+    os: [linux]
+
   '@rollup/rollup-linux-arm64-musl@4.9.6':
     resolution: {integrity: sha512-gpiG0qQJNdYEVad+1iAsGAbgAnZ8j07FapmnIAQgODKcOTjLEWM9sRb+MbQyVsYCnA0Im6M6QIq6ax7liws6eQ==}
     cpu: [arm64]
@@ -4313,6 +4485,11 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@rollup/rollup-linux-powerpc64le-gnu@4.26.0':
+    resolution: {integrity: sha512-Odp/lgHbW/mAqw/pU21goo5ruWsytP7/HCC/liOt0zcGG0llYWKrd10k9Fj0pdj3prQ63N5yQLCLiE7HTX+MYw==}
+    cpu: [ppc64]
+    os: [linux]
+
   '@rollup/rollup-linux-riscv64-gnu@4.16.2':
     resolution: {integrity: sha512-ohkPt0lKoCU0s4B6twro2aft+QROPdUiWwOjPNTzwTsBK5w+2+iT9kySdtOdq0gzWJAdiqsV4NFtXOwGZmIsHA==}
     cpu: [riscv64]
@@ -4320,6 +4497,11 @@ packages:
 
   '@rollup/rollup-linux-riscv64-gnu@4.21.2':
     resolution: {integrity: sha512-RL56JMT6NwQ0lXIQmMIWr1SW28z4E4pOhRRNqwWZeXpRlykRIlEpSWdsgNWJbYBEWD84eocjSGDu/XxbYeCmwg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.26.0':
+    resolution: {integrity: sha512-MBR2ZhCTzUgVD0OJdTzNeF4+zsVogIR1U/FsyuFerwcqjZGvg2nYe24SAHp8O5sN8ZkRVbHwlYeHqcSQ8tcYew==}
     cpu: [riscv64]
     os: [linux]
 
@@ -4338,6 +4520,11 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@rollup/rollup-linux-s390x-gnu@4.26.0':
+    resolution: {integrity: sha512-YYcg8MkbN17fMbRMZuxwmxWqsmQufh3ZJFxFGoHjrE7bv0X+T6l3glcdzd7IKLiwhT+PZOJCblpnNlz1/C3kGQ==}
+    cpu: [s390x]
+    os: [linux]
+
   '@rollup/rollup-linux-x64-gnu@4.16.2':
     resolution: {integrity: sha512-oc5/SlITI/Vj/qL4UM+lXN7MERpiy1HEOnrE+SegXwzf7WP9bzmZd6+MDljCEZTdSY84CpvUv9Rq7bCaftn1+g==}
     cpu: [x64]
@@ -4345,6 +4532,11 @@ packages:
 
   '@rollup/rollup-linux-x64-gnu@4.21.2':
     resolution: {integrity: sha512-B90tYAUoLhU22olrafY3JQCFLnT3NglazdwkHyxNDYF/zAxJt5fJUB/yBoWFoIQ7SQj+KLe3iL4BhOMa9fzgpw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.26.0':
+    resolution: {integrity: sha512-ZuwpfjCwjPkAOxpjAEjabg6LRSfL7cAJb6gSQGZYjGhadlzKKywDkCUnJ+KEfrNY1jH5EEoSIKLCb572jSiglA==}
     cpu: [x64]
     os: [linux]
 
@@ -4363,6 +4555,11 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rollup/rollup-linux-x64-musl@4.26.0':
+    resolution: {integrity: sha512-+HJD2lFS86qkeF8kNu0kALtifMpPCZU80HvwztIKnYwym3KnA1os6nsX4BGSTLtS2QVAGG1P3guRgsYyMA0Yhg==}
+    cpu: [x64]
+    os: [linux]
+
   '@rollup/rollup-linux-x64-musl@4.9.6':
     resolution: {integrity: sha512-ch7M+9Tr5R4FK40FHQk8VnML0Szi2KRujUgHXd/HjuH9ifH72GUmw6lStZBo3c3GB82vHa0ZoUfjfcM7JiiMrQ==}
     cpu: [x64]
@@ -4375,6 +4572,11 @@ packages:
 
   '@rollup/rollup-win32-arm64-msvc@4.21.2':
     resolution: {integrity: sha512-9rRero0E7qTeYf6+rFh3AErTNU1VCQg2mn7CQcI44vNUWM9Ze7MSRS/9RFuSsox+vstRt97+x3sOhEey024FRQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-arm64-msvc@4.26.0':
+    resolution: {integrity: sha512-WUQzVFWPSw2uJzX4j6YEbMAiLbs0BUysgysh8s817doAYhR5ybqTI1wtKARQKo6cGop3pHnrUJPFCsXdoFaimQ==}
     cpu: [arm64]
     os: [win32]
 
@@ -4393,6 +4595,11 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rollup/rollup-win32-ia32-msvc@4.26.0':
+    resolution: {integrity: sha512-D4CxkazFKBfN1akAIY6ieyOqzoOoBV1OICxgUblWxff/pSjCA2khXlASUx7mK6W1oP4McqhgcCsu6QaLj3WMWg==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rollup/rollup-win32-ia32-msvc@4.9.6':
     resolution: {integrity: sha512-J9AFDq/xiRI58eR2NIDfyVmTYGyIZmRcvcAoJ48oDld/NTR8wyiPUu2X/v1navJ+N/FGg68LEbX3Ejd6l8B7MQ==}
     cpu: [ia32]
@@ -4405,6 +4612,11 @@ packages:
 
   '@rollup/rollup-win32-x64-msvc@4.21.2':
     resolution: {integrity: sha512-6UUxd0+SKomjdzuAcp+HAmxw1FlGBnl1v2yEPSabtx4lBfdXHDVsW7+lQkgz9cNFJGY3AWR7+V8P5BqkD9L9nA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.26.0':
+    resolution: {integrity: sha512-2x8MO1rm4PGEP0xWbubJW5RtbNLk3puzAMaLQd3B3JHVw4KcHlmXcO+Wewx9zCoo7EUFiMlu/aZbCJ7VjMzAag==}
     cpu: [x64]
     os: [win32]
 
@@ -4584,6 +4796,9 @@ packages:
 
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
+
+  '@types/estree@1.0.6':
+    resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
   '@types/hast@2.3.10':
     resolution: {integrity: sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==}
@@ -5293,6 +5508,7 @@ packages:
 
   acorn-import-assertions@1.9.0:
     resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
+    deprecated: package has been renamed to acorn-import-attributes
     peerDependencies:
       acorn: ^8
 
@@ -5331,6 +5547,11 @@ packages:
 
   acorn@8.12.1:
     resolution: {integrity: sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  acorn@8.14.0:
+    resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -6009,6 +6230,9 @@ packages:
   confbox@0.1.7:
     resolution: {integrity: sha512-uJcB/FKZtBMCJpK8MQji6bJHgu1tixKPxRLeGkNzBoOZzpnZUJm0jm2/sBDWcuBx1dYgxV4JU+g5hmNxCyAmdA==}
 
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
   connect@3.7.0:
     resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
     engines: {node: '>= 0.10.0'}
@@ -6242,6 +6466,15 @@ packages:
 
   debug@4.3.6:
     resolution: {integrity: sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.3.7:
+    resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -6721,6 +6954,7 @@ packages:
   eslint@8.56.0:
     resolution: {integrity: sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   esm-env@1.0.0:
@@ -8012,6 +8246,9 @@ packages:
   magic-string@0.30.11:
     resolution: {integrity: sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==}
 
+  magic-string@0.30.12:
+    resolution: {integrity: sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==}
+
   magic-string@0.30.5:
     resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
     engines: {node: '>=12'}
@@ -8373,6 +8610,9 @@ packages:
   mlly@1.7.1:
     resolution: {integrity: sha512-rrVRZRELyQzrIUAVMHxP97kv+G786pHmOKzuFII8zDYahFBS7qnHh2AlYSl1GAHhaMPCz6/oHjVMcfFYgFYHgA==}
 
+  mlly@1.7.3:
+    resolution: {integrity: sha512-xUsx5n/mN0uQf4V548PKQ+YShA4/IW0KI1dZhrNrPCLG+xizETbHTkOa1f8/xut9JRPp8kQuMnz0oqwkTiLo/A==}
+
   modern-ahocorasick@1.0.1:
     resolution: {integrity: sha512-yoe+JbhTClckZ67b2itRtistFKf8yPYelHLc7e5xAwtNAXxM6wJTUx2C7QeVSJFDzKT7bCIFyBVybPMKvmB9AA==}
 
@@ -8730,6 +8970,9 @@ packages:
   ofetch@1.3.4:
     resolution: {integrity: sha512-KLIET85ik3vhEfS+3fDlc/BAZiAp+43QEC/yCo5zkNoY2YaKvNkOaFr/6wCFgFH1kuYQM5pMNi0Tg8koiIemtw==}
 
+  ofetch@1.4.1:
+    resolution: {integrity: sha512-QZj2DfGplQAr2oj9KzceK9Hwz6Whxazmn85yYeVuS3u9XTMOGMRx0kO95MQ+vLsj/S/NwBDMMLU5hpxvI6Tklw==}
+
   ohash@1.1.3:
     resolution: {integrity: sha512-zuHHiGTYTA1sYJ/wZN+t5HKZaH23i4yI1HMwbuXm24Nid7Dv0KcuRlKoNKS9UNfAVSBlnGLcuQrnOKWOZoEGaw==}
 
@@ -8832,6 +9075,9 @@ packages:
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
+
+  package-manager-detector@0.2.2:
+    resolution: {integrity: sha512-VgXbyrSNsml4eHWIvxxG/nTL4wgybMTXCV2Un/+yEc3aDKKU6nQBZjbeP3Pl3qm9Qg92X/1ng4ffvCeD/zwHgg==}
 
   pacote@18.0.0:
     resolution: {integrity: sha512-ma7uVt/q3Sb3XbLwUjOeClz+7feHjMOFegHn5whw++x+GzikZkAq/2auklSbRuy6EI2iJh1/ZqCpVaUcxRaeqQ==}
@@ -8949,6 +9195,9 @@ packages:
   picocolors@1.0.1:
     resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
 
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
@@ -8992,6 +9241,9 @@ packages:
 
   pkg-types@1.2.0:
     resolution: {integrity: sha512-+ifYuSSqOQ8CqP4MbZA5hDpb97n3E8SVWdJe+Wms9kj745lmd3b7EZJiqvmLwAlmRfjrI7Hi5z3kdBJ93lFNPA==}
+
+  pkg-types@1.2.1:
+    resolution: {integrity: sha512-sQoqa8alT3nHjGuTjuKgOnvjo4cljkufdtLMnO2LBP/wRwuDlo1tkaEdMxCRhyGRPacv/ztlZgDPm2b7FAmEvw==}
 
   postcss-calc@10.0.2:
     resolution: {integrity: sha512-DT/Wwm6fCKgpYVI7ZEWuPJ4az8hiEHtCUeYjZXqU7Ou4QqYh1Df2yCQ7Ca6N7xqKPFkxN3fhf+u9KSoOCJNAjg==}
@@ -9403,6 +9655,10 @@ packages:
 
   postcss@8.4.44:
     resolution: {integrity: sha512-Aweb9unOEpQ3ezu4Q00DPvvM2ZTUitJdNKeP/+uQgr1IBIqu574IaZoURId7BKtWMREwzKa9OgzPzezWGPWFQw==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.4.49:
+    resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
     engines: {node: ^10 || ^12 || >=14}
 
   preferred-pm@3.1.2:
@@ -9831,6 +10087,11 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rollup@4.26.0:
+    resolution: {integrity: sha512-ilcl12hnWonG8f+NxU6BlgysVA0gvY2l8N0R84S1HcINbW20bvwuCngJkkInV6LXhwRpucsW5k1ovDwEdBVrNg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   rollup@4.9.6:
     resolution: {integrity: sha512-05lzkCS2uASX0CiLFybYfVkwNbKZG5NFQ6Go0VWyogFTXXbR039UVsegViTntkk4OglHBdF54ccApXRRuXRbsg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -10145,6 +10406,10 @@ packages:
 
   source-map-js@1.2.0:
     resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
+    engines: {node: '>=0.10.0'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
   source-map-support@0.5.21:
@@ -10566,6 +10831,9 @@ packages:
 
   tinybench@2.7.0:
     resolution: {integrity: sha512-Qgayeb106x2o4hNzNjsZEfFziw8IbKqtbXBjVh7VIZfBxfD5M4gWtpyx5+YTae2gJ6Y6Dz/KLepiv16RFeQWNA==}
+
+  tinyexec@0.3.1:
+    resolution: {integrity: sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==}
 
   tinyglobby@0.2.5:
     resolution: {integrity: sha512-Dlqgt6h0QkoHttG53/WGADNh9QhcjCAIZMTERAVhdpmIBEejSuLI9ZmGKWzB7tweBjlk30+s/ofi4SLmBeTYhw==}
@@ -11246,6 +11514,37 @@ packages:
       terser:
         optional: true
 
+  vite@5.4.11:
+    resolution: {integrity: sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
   vite@5.4.3:
     resolution: {integrity: sha512-IH+nl64eq9lJjFqU+/yrRnrHPVTlgy42/+IzbOdaFDVlyLgI/wDlf+FCobXLX1cT0X5+7LMyH1mIy2xJdLfo8Q==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -11706,10 +12005,10 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@antfu/install-pkg@0.1.1':
+  '@antfu/install-pkg@0.4.1':
     dependencies:
-      execa: 5.1.1
-      find-up: 5.0.0
+      package-manager-detector: 0.2.2
+      tinyexec: 0.3.1
 
   '@antfu/utils@0.7.10': {}
 
@@ -11723,7 +12022,13 @@ snapshots:
   '@babel/code-frame@7.24.7':
     dependencies:
       '@babel/highlight': 7.24.7
-      picocolors: 1.0.1
+      picocolors: 1.1.1
+
+  '@babel/code-frame@7.26.2':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.25.9
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
 
   '@babel/compat-data@7.23.5': {}
 
@@ -11812,6 +12117,14 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
 
+  '@babel/generator@7.26.2':
+    dependencies:
+      '@babel/parser': 7.26.2
+      '@babel/types': 7.26.0
+      '@jridgewell/gen-mapping': 0.3.5
+      '@jridgewell/trace-mapping': 0.3.25
+      jsesc: 3.0.2
+
   '@babel/helper-annotate-as-pure@7.22.5':
     dependencies:
       '@babel/types': 7.24.9
@@ -11819,6 +12132,10 @@ snapshots:
   '@babel/helper-annotate-as-pure@7.24.7':
     dependencies:
       '@babel/types': 7.24.9
+
+  '@babel/helper-annotate-as-pure@7.25.9':
+    dependencies:
+      '@babel/types': 7.26.0
 
   '@babel/helper-builder-binary-assignment-operator-visitor@7.24.7':
     dependencies:
@@ -11864,19 +12181,6 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.22.6
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.24.4(@babel/core@7.25.2)':
-    dependencies:
-      '@babel/core': 7.25.2
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-function-name': 7.23.0
-      '@babel/helper-member-expression-to-functions': 7.23.0
-      '@babel/helper-optimise-call-expression': 7.22.5
-      '@babel/helper-replace-supers': 7.24.1(@babel/core@7.25.2)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      semver: 6.3.1
-
   '@babel/helper-create-class-features-plugin@7.24.8(@babel/core@7.24.4)':
     dependencies:
       '@babel/core': 7.24.4
@@ -11901,6 +12205,19 @@ snapshots:
       '@babel/helper-replace-supers': 7.25.0(@babel/core@7.25.2)
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
       '@babel/traverse': 7.25.6
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-create-class-features-plugin@7.25.9(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-member-expression-to-functions': 7.25.9
+      '@babel/helper-optimise-call-expression': 7.25.9
+      '@babel/helper-replace-supers': 7.25.9(@babel/core@7.25.2)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
+      '@babel/traverse': 7.25.9
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -11958,6 +12275,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-member-expression-to-functions@7.25.9':
+    dependencies:
+      '@babel/traverse': 7.25.9
+      '@babel/types': 7.26.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-module-imports@7.18.6':
     dependencies:
       '@babel/types': 7.24.9
@@ -11973,6 +12297,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-imports@7.25.9':
+    dependencies:
+      '@babel/traverse': 7.25.9
+      '@babel/types': 7.26.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-module-transforms@7.23.3(@babel/core@7.23.9)':
     dependencies:
       '@babel/core': 7.23.9
@@ -11985,15 +12316,6 @@ snapshots:
   '@babel/helper-module-transforms@7.23.3(@babel/core@7.24.4)':
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-module-imports': 7.22.15
-      '@babel/helper-simple-access': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/helper-validator-identifier': 7.22.20
-
-  '@babel/helper-module-transforms@7.23.3(@babel/core@7.25.2)':
-    dependencies:
-      '@babel/core': 7.25.2
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-simple-access': 7.22.5
@@ -12021,6 +12343,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-transforms@7.26.0(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/traverse': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-optimise-call-expression@7.22.5':
     dependencies:
       '@babel/types': 7.24.9
@@ -12029,11 +12360,17 @@ snapshots:
     dependencies:
       '@babel/types': 7.24.9
 
+  '@babel/helper-optimise-call-expression@7.25.9':
+    dependencies:
+      '@babel/types': 7.26.0
+
   '@babel/helper-plugin-utils@7.22.5': {}
 
   '@babel/helper-plugin-utils@7.24.0': {}
 
   '@babel/helper-plugin-utils@7.24.8': {}
+
+  '@babel/helper-plugin-utils@7.25.9': {}
 
   '@babel/helper-remap-async-to-generator@7.24.7(@babel/core@7.24.4)':
     dependencies:
@@ -12047,13 +12384,6 @@ snapshots:
   '@babel/helper-replace-supers@7.24.1(@babel/core@7.24.4)':
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-member-expression-to-functions': 7.23.0
-      '@babel/helper-optimise-call-expression': 7.22.5
-
-  '@babel/helper-replace-supers@7.24.1(@babel/core@7.25.2)':
-    dependencies:
-      '@babel/core': 7.25.2
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-member-expression-to-functions': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
@@ -12076,6 +12406,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-replace-supers@7.25.9(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-member-expression-to-functions': 7.25.9
+      '@babel/helper-optimise-call-expression': 7.25.9
+      '@babel/traverse': 7.25.9
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-simple-access@7.22.5':
     dependencies:
       '@babel/types': 7.24.9
@@ -12087,6 +12426,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-simple-access@7.25.9':
+    dependencies:
+      '@babel/traverse': 7.25.9
+      '@babel/types': 7.26.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-skip-transparent-expression-wrappers@7.22.5':
     dependencies:
       '@babel/types': 7.24.9
@@ -12095,6 +12441,13 @@ snapshots:
     dependencies:
       '@babel/traverse': 7.24.8
       '@babel/types': 7.24.9
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.25.9':
+    dependencies:
+      '@babel/traverse': 7.25.9
+      '@babel/types': 7.26.0
     transitivePeerDependencies:
       - supports-color
 
@@ -12110,13 +12463,19 @@ snapshots:
 
   '@babel/helper-string-parser@7.24.8': {}
 
+  '@babel/helper-string-parser@7.25.9': {}
+
   '@babel/helper-validator-identifier@7.22.20': {}
 
   '@babel/helper-validator-identifier@7.24.7': {}
 
+  '@babel/helper-validator-identifier@7.25.9': {}
+
   '@babel/helper-validator-option@7.23.5': {}
 
   '@babel/helper-validator-option@7.24.8': {}
+
+  '@babel/helper-validator-option@7.25.9': {}
 
   '@babel/helper-wrap-function@7.24.7':
     dependencies:
@@ -12153,14 +12512,14 @@ snapshots:
       '@babel/helper-validator-identifier': 7.22.20
       chalk: 2.4.2
       js-tokens: 4.0.0
-      picocolors: 1.0.1
+      picocolors: 1.1.1
 
   '@babel/highlight@7.24.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.24.7
       chalk: 2.4.2
       js-tokens: 4.0.0
-      picocolors: 1.0.1
+      picocolors: 1.1.1
 
   '@babel/parser@7.24.4':
     dependencies:
@@ -12173,6 +12532,10 @@ snapshots:
   '@babel/parser@7.25.6':
     dependencies:
       '@babel/types': 7.25.6
+
+  '@babel/parser@7.26.2':
+    dependencies:
+      '@babel/types': 7.26.0
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.24.7(@babel/core@7.24.4)':
     dependencies:
@@ -12276,6 +12639,11 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-syntax-jsx@7.25.9(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-plugin-utils': 7.25.9
+
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.24.4)':
     dependencies:
       '@babel/core': 7.24.4
@@ -12321,15 +12689,15 @@ snapshots:
       '@babel/core': 7.24.4
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-typescript@7.24.1(@babel/core@7.25.2)':
-    dependencies:
-      '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-syntax-typescript@7.25.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-syntax-typescript@7.25.9(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-plugin-utils': 7.25.9
 
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.24.4)':
     dependencies:
@@ -12496,19 +12864,21 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/helper-simple-access': 7.22.5
 
-  '@babel/plugin-transform-modules-commonjs@7.24.1(@babel/core@7.25.2)':
-    dependencies:
-      '@babel/core': 7.25.2
-      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.25.2)
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/helper-simple-access': 7.22.5
-
   '@babel/plugin-transform-modules-commonjs@7.24.8(@babel/core@7.24.4)':
     dependencies:
       '@babel/core': 7.24.4
       '@babel/helper-module-transforms': 7.24.9(@babel/core@7.24.4)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-simple-access': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-commonjs@7.25.9(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.25.2)
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-simple-access': 7.25.9
     transitivePeerDependencies:
       - supports-color
 
@@ -12669,14 +13039,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/plugin-syntax-typescript': 7.24.1(@babel/core@7.24.4)
 
-  '@babel/plugin-transform-typescript@7.24.4(@babel/core@7.25.2)':
-    dependencies:
-      '@babel/core': 7.25.2
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-create-class-features-plugin': 7.24.4(@babel/core@7.25.2)
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/plugin-syntax-typescript': 7.24.1(@babel/core@7.25.2)
-
   '@babel/plugin-transform-typescript@7.25.2(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -12685,6 +13047,17 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
       '@babel/plugin-syntax-typescript': 7.25.4(@babel/core@7.25.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-typescript@7.25.9(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.25.2)
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
+      '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.25.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -12814,14 +13187,16 @@ snapshots:
       '@babel/plugin-transform-modules-commonjs': 7.24.1(@babel/core@7.24.4)
       '@babel/plugin-transform-typescript': 7.24.4(@babel/core@7.24.4)
 
-  '@babel/preset-typescript@7.24.1(@babel/core@7.25.2)':
+  '@babel/preset-typescript@7.26.0(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.0
-      '@babel/helper-validator-option': 7.23.5
-      '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.25.2)
-      '@babel/plugin-transform-modules-commonjs': 7.24.1(@babel/core@7.25.2)
-      '@babel/plugin-transform-typescript': 7.24.4(@babel/core@7.25.2)
+      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-validator-option': 7.25.9
+      '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.25.2)
+      '@babel/plugin-transform-modules-commonjs': 7.25.9(@babel/core@7.25.2)
+      '@babel/plugin-transform-typescript': 7.25.9(@babel/core@7.25.2)
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/regjsgen@0.8.0': {}
 
@@ -12848,6 +13223,12 @@ snapshots:
       '@babel/code-frame': 7.24.7
       '@babel/parser': 7.25.6
       '@babel/types': 7.25.6
+
+  '@babel/template@7.25.9':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/parser': 7.26.2
+      '@babel/types': 7.26.0
 
   '@babel/traverse@7.23.9':
     dependencies:
@@ -12906,6 +13287,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@7.25.9':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/generator': 7.26.2
+      '@babel/parser': 7.26.2
+      '@babel/template': 7.25.9
+      '@babel/types': 7.26.0
+      debug: 4.3.7
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/types@7.24.0':
     dependencies:
       '@babel/helper-string-parser': 7.23.4
@@ -12923,6 +13316,11 @@ snapshots:
       '@babel/helper-string-parser': 7.24.8
       '@babel/helper-validator-identifier': 7.24.7
       to-fast-properties: 2.0.0
+
+  '@babel/types@7.26.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
 
   '@bcoe/v8-coverage@0.2.3': {}
 
@@ -13102,10 +13500,10 @@ snapshots:
       '@codecov/bundler-plugin-core': 0.0.1-beta.6
       rollup: 3.29.4
 
-  '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.21.2)':
+  '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.26.0)':
     dependencies:
       '@codecov/bundler-plugin-core': 0.0.1-beta.6
-      rollup: 4.21.2
+      rollup: 4.26.0
 
   '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.9.6)':
     dependencies:
@@ -13631,15 +14029,15 @@ snapshots:
 
   '@fastify/busboy@2.1.1': {}
 
-  '@floating-ui/core@1.6.0':
+  '@floating-ui/core@1.6.8':
     dependencies:
-      '@floating-ui/utils': 0.2.1
+      '@floating-ui/utils': 0.2.8
 
   '@floating-ui/dom@1.1.1':
     dependencies:
-      '@floating-ui/core': 1.6.0
+      '@floating-ui/core': 1.6.8
 
-  '@floating-ui/utils@0.2.1': {}
+  '@floating-ui/utils@0.2.8': {}
 
   '@fontsource/fira-mono@4.5.10': {}
 
@@ -13663,15 +14061,15 @@ snapshots:
 
   '@iconify/types@2.0.0': {}
 
-  '@iconify/utils@2.1.23':
+  '@iconify/utils@2.1.33':
     dependencies:
-      '@antfu/install-pkg': 0.1.1
+      '@antfu/install-pkg': 0.4.1
       '@antfu/utils': 0.7.10
       '@iconify/types': 2.0.0
-      debug: 4.3.6
+      debug: 4.3.7
       kolorist: 1.8.0
       local-pkg: 0.5.0
-      mlly: 1.7.1
+      mlly: 1.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -14090,45 +14488,45 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@1.2.0(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))':
+  '@nuxt/devtools-kit@1.2.0(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.26.0)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))':
     dependencies:
-      '@nuxt/kit': 3.11.2(rollup@4.21.2)
-      '@nuxt/schema': 3.11.2(rollup@4.21.2)
+      '@nuxt/kit': 3.11.2(rollup@4.26.0)
+      '@nuxt/schema': 3.11.2(rollup@4.26.0)
       execa: 7.2.0
-      nuxt: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      nuxt: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.26.0)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
       vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  '@nuxt/devtools-kit@1.4.1(magicast@0.3.4)(rollup@3.29.4)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))':
+  '@nuxt/devtools-kit@1.4.1(magicast@0.3.4)(rollup@3.29.4)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))':
     dependencies:
       '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@3.29.4)
       '@nuxt/schema': 3.13.0(rollup@3.29.4)
       execa: 7.2.0
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
     transitivePeerDependencies:
       - magicast
       - rollup
       - supports-color
 
-  '@nuxt/devtools-kit@1.4.1(magicast@0.3.4)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))':
+  '@nuxt/devtools-kit@1.4.1(magicast@0.3.4)(rollup@4.21.2)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))':
     dependencies:
       '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.21.2)
       '@nuxt/schema': 3.13.0(rollup@4.21.2)
       execa: 7.2.0
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
     transitivePeerDependencies:
       - magicast
       - rollup
       - supports-color
 
-  '@nuxt/devtools-kit@1.4.1(magicast@0.3.4)(rollup@4.21.2)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))':
+  '@nuxt/devtools-kit@1.4.1(magicast@0.3.4)(rollup@4.26.0)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))':
     dependencies:
-      '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.21.2)
-      '@nuxt/schema': 3.13.0(rollup@4.21.2)
+      '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.26.0)
+      '@nuxt/schema': 3.13.0(rollup@4.26.0)
       execa: 7.2.0
-      vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
     transitivePeerDependencies:
       - magicast
       - rollup
@@ -14160,13 +14558,13 @@ snapshots:
       rc9: 2.1.2
       semver: 7.6.3
 
-  '@nuxt/devtools@1.2.0(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.21.2)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))':
+  '@nuxt/devtools@1.2.0(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3)))(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.26.0)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.26.0)(unocss@0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))':
     dependencies:
       '@antfu/utils': 0.7.7
-      '@nuxt/devtools-kit': 1.2.0(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      '@nuxt/devtools-kit': 1.2.0(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.26.0)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
       '@nuxt/devtools-wizard': 1.2.0
-      '@nuxt/kit': 3.11.2(rollup@4.21.2)
-      '@vue/devtools-applet': 7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
+      '@nuxt/kit': 3.11.2(rollup@4.26.0)
+      '@vue/devtools-applet': 7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
       '@vue/devtools-core': 7.0.27(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
       '@vue/devtools-kit': 7.0.27(vue@3.4.24(typescript@5.3.3))
       birpc: 0.2.17
@@ -14184,7 +14582,7 @@ snapshots:
       launch-editor: 2.6.1
       local-pkg: 0.5.0
       magicast: 0.3.4
-      nuxt: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      nuxt: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.26.0)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
       nypm: 0.3.8
       ohash: 1.1.3
       pacote: 18.0.0
@@ -14196,9 +14594,9 @@ snapshots:
       semver: 7.6.0
       simple-git: 3.24.0
       sirv: 2.0.4
-      unimport: 3.7.1(rollup@4.21.2)
+      unimport: 3.7.1(rollup@4.26.0)
       vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
-      vite-plugin-inspect: 0.8.4(@nuxt/kit@3.11.2(rollup@4.21.2))(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      vite-plugin-inspect: 0.8.4(@nuxt/kit@3.11.2(rollup@4.26.0))(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
       vite-plugin-vue-inspector: 4.0.2(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
       which: 3.0.1
       ws: 8.16.0
@@ -14225,13 +14623,13 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@nuxt/devtools@1.4.1(rollup@3.29.4)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))':
+  '@nuxt/devtools@1.4.1(rollup@3.29.4)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))':
     dependencies:
       '@antfu/utils': 0.7.10
-      '@nuxt/devtools-kit': 1.4.1(magicast@0.3.4)(rollup@3.29.4)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      '@nuxt/devtools-kit': 1.4.1(magicast@0.3.4)(rollup@3.29.4)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       '@nuxt/devtools-wizard': 1.4.1
       '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@3.29.4)
-      '@vue/devtools-core': 7.3.3(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      '@vue/devtools-core': 7.3.3(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       '@vue/devtools-kit': 7.3.3
       birpc: 0.2.17
       consola: 3.2.3
@@ -14260,9 +14658,9 @@ snapshots:
       sirv: 2.0.4
       tinyglobby: 0.2.5
       unimport: 3.11.1(rollup@3.29.4)
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
-      vite-plugin-inspect: 0.8.7(@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@3.29.4))(rollup@3.29.4)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
-      vite-plugin-vue-inspector: 5.2.0(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
+      vite-plugin-inspect: 0.8.7(@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@3.29.4))(rollup@3.29.4)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
+      vite-plugin-vue-inspector: 5.2.0(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       which: 3.0.1
       ws: 8.18.0
     transitivePeerDependencies:
@@ -14271,13 +14669,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@nuxt/devtools@1.4.1(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))':
+  '@nuxt/devtools@1.4.1(rollup@4.21.2)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))':
     dependencies:
       '@antfu/utils': 0.7.10
-      '@nuxt/devtools-kit': 1.4.1(magicast@0.3.4)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      '@nuxt/devtools-kit': 1.4.1(magicast@0.3.4)(rollup@4.21.2)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
       '@nuxt/devtools-wizard': 1.4.1
       '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.21.2)
-      '@vue/devtools-core': 7.3.3(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      '@vue/devtools-core': 7.3.3(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
       '@vue/devtools-kit': 7.3.3
       birpc: 0.2.17
       consola: 3.2.3
@@ -14306,9 +14704,9 @@ snapshots:
       sirv: 2.0.4
       tinyglobby: 0.2.5
       unimport: 3.11.1(rollup@4.21.2)
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
-      vite-plugin-inspect: 0.8.7(@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@4.21.2))(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
-      vite-plugin-vue-inspector: 5.2.0(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
+      vite-plugin-inspect: 0.8.7(@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@4.21.2))(rollup@4.21.2)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
+      vite-plugin-vue-inspector: 5.2.0(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
       which: 3.0.1
       ws: 8.18.0
     transitivePeerDependencies:
@@ -14317,13 +14715,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@nuxt/devtools@1.4.1(rollup@4.21.2)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))':
+  '@nuxt/devtools@1.4.1(rollup@4.26.0)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))':
     dependencies:
       '@antfu/utils': 0.7.10
-      '@nuxt/devtools-kit': 1.4.1(magicast@0.3.4)(rollup@4.21.2)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+      '@nuxt/devtools-kit': 1.4.1(magicast@0.3.4)(rollup@4.26.0)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       '@nuxt/devtools-wizard': 1.4.1
-      '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.21.2)
-      '@vue/devtools-core': 7.3.3(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+      '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.26.0)
+      '@vue/devtools-core': 7.3.3(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       '@vue/devtools-kit': 7.3.3
       birpc: 0.2.17
       consola: 3.2.3
@@ -14351,10 +14749,10 @@ snapshots:
       simple-git: 3.26.0
       sirv: 2.0.4
       tinyglobby: 0.2.5
-      unimport: 3.11.1(rollup@4.21.2)
-      vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
-      vite-plugin-inspect: 0.8.7(@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@4.21.2))(rollup@4.21.2)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
-      vite-plugin-vue-inspector: 5.2.0(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+      unimport: 3.11.1(rollup@4.26.0)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
+      vite-plugin-inspect: 0.8.7(@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@4.26.0))(rollup@4.26.0)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
+      vite-plugin-vue-inspector: 5.2.0(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       which: 3.0.1
       ws: 8.18.0
     transitivePeerDependencies:
@@ -14411,6 +14809,30 @@ snapshots:
       - rollup
       - supports-color
 
+  '@nuxt/kit@3.11.2(rollup@4.26.0)':
+    dependencies:
+      '@nuxt/schema': 3.11.2(rollup@4.26.0)
+      c12: 1.10.0
+      consola: 3.2.3
+      defu: 6.1.4
+      globby: 14.0.1
+      hash-sum: 2.0.0
+      ignore: 5.3.1
+      jiti: 1.21.0
+      knitwork: 1.1.0
+      mlly: 1.6.1
+      pathe: 1.1.2
+      pkg-types: 1.1.0
+      scule: 1.3.0
+      semver: 7.6.0
+      ufo: 1.5.3
+      unctx: 2.3.1
+      unimport: 3.7.1(rollup@4.26.0)
+      untyped: 1.4.2
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+
   '@nuxt/kit@3.12.4(magicast@0.3.4)(rollup@3.29.4)':
     dependencies:
       '@nuxt/schema': 3.12.4(rollup@3.29.4)
@@ -14459,6 +14881,33 @@ snapshots:
       ufo: 1.5.4
       unctx: 2.3.1
       unimport: 3.11.1(rollup@4.21.2)
+      untyped: 1.4.2
+    transitivePeerDependencies:
+      - magicast
+      - rollup
+      - supports-color
+
+  '@nuxt/kit@3.12.4(magicast@0.3.4)(rollup@4.26.0)':
+    dependencies:
+      '@nuxt/schema': 3.12.4(rollup@4.26.0)
+      c12: 1.11.2(magicast@0.3.4)
+      consola: 3.2.3
+      defu: 6.1.4
+      destr: 2.0.3
+      globby: 14.0.2
+      hash-sum: 2.0.0
+      ignore: 5.3.1
+      jiti: 1.21.6
+      klona: 2.0.6
+      knitwork: 1.1.0
+      mlly: 1.7.1
+      pathe: 1.1.2
+      pkg-types: 1.2.0
+      scule: 1.3.0
+      semver: 7.6.3
+      ufo: 1.5.4
+      unctx: 2.3.1
+      unimport: 3.11.1(rollup@4.26.0)
       untyped: 1.4.2
     transitivePeerDependencies:
       - magicast
@@ -14519,6 +14968,33 @@ snapshots:
       - rollup
       - supports-color
 
+  '@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@4.26.0)':
+    dependencies:
+      '@nuxt/schema': 3.13.0(rollup@4.26.0)
+      c12: 1.11.2(magicast@0.3.4)
+      consola: 3.2.3
+      defu: 6.1.4
+      destr: 2.0.3
+      globby: 14.0.2
+      hash-sum: 2.0.0
+      ignore: 5.3.2
+      jiti: 1.21.6
+      klona: 2.0.6
+      knitwork: 1.1.0
+      mlly: 1.7.1
+      pathe: 1.1.2
+      pkg-types: 1.2.0
+      scule: 1.3.0
+      semver: 7.6.3
+      ufo: 1.5.4
+      unctx: 2.3.1
+      unimport: 3.11.1(rollup@4.26.0)
+      untyped: 1.4.2
+    transitivePeerDependencies:
+      - magicast
+      - rollup
+      - supports-color
+
   '@nuxt/schema@3.11.2(rollup@3.29.4)':
     dependencies:
       '@nuxt/ui-templates': 1.3.3
@@ -14548,6 +15024,23 @@ snapshots:
       std-env: 3.7.0
       ufo: 1.5.3
       unimport: 3.7.1(rollup@4.21.2)
+      untyped: 1.4.2
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+
+  '@nuxt/schema@3.11.2(rollup@4.26.0)':
+    dependencies:
+      '@nuxt/ui-templates': 1.3.3
+      consola: 3.2.3
+      defu: 6.1.4
+      hookable: 5.5.3
+      pathe: 1.1.2
+      pkg-types: 1.1.0
+      scule: 1.3.0
+      std-env: 3.7.0
+      ufo: 1.5.3
+      unimport: 3.7.1(rollup@4.26.0)
       untyped: 1.4.2
     transitivePeerDependencies:
       - rollup
@@ -14589,6 +15082,24 @@ snapshots:
       - rollup
       - supports-color
 
+  '@nuxt/schema@3.12.4(rollup@4.26.0)':
+    dependencies:
+      compatx: 0.1.8
+      consola: 3.2.3
+      defu: 6.1.4
+      hookable: 5.5.3
+      pathe: 1.1.2
+      pkg-types: 1.2.0
+      scule: 1.3.0
+      std-env: 3.7.0
+      ufo: 1.5.4
+      uncrypto: 0.1.3
+      unimport: 3.11.1(rollup@4.26.0)
+      untyped: 1.4.2
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+
   '@nuxt/schema@3.13.0(rollup@3.29.4)':
     dependencies:
       compatx: 0.1.8
@@ -14620,6 +15131,24 @@ snapshots:
       ufo: 1.5.4
       uncrypto: 0.1.3
       unimport: 3.11.1(rollup@4.21.2)
+      untyped: 1.4.2
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+
+  '@nuxt/schema@3.13.0(rollup@4.26.0)':
+    dependencies:
+      compatx: 0.1.8
+      consola: 3.2.3
+      defu: 6.1.4
+      hookable: 5.5.3
+      pathe: 1.1.2
+      pkg-types: 1.2.0
+      scule: 1.3.0
+      std-env: 3.7.0
+      ufo: 1.5.4
+      uncrypto: 0.1.3
+      unimport: 3.11.1(rollup@4.26.0)
       untyped: 1.4.2
     transitivePeerDependencies:
       - rollup
@@ -14671,14 +15200,37 @@ snapshots:
       - rollup
       - supports-color
 
+  '@nuxt/telemetry@2.5.4(rollup@4.26.0)':
+    dependencies:
+      '@nuxt/kit': 3.11.2(rollup@4.26.0)
+      ci-info: 4.0.0
+      consola: 3.2.3
+      create-require: 1.1.1
+      defu: 6.1.4
+      destr: 2.0.3
+      dotenv: 16.4.5
+      git-url-parse: 14.0.0
+      is-docker: 3.0.0
+      jiti: 1.21.0
+      mri: 1.2.0
+      nanoid: 5.0.7
+      ofetch: 1.3.4
+      parse-git-config: 3.0.0
+      pathe: 1.1.2
+      rc9: 2.1.2
+      std-env: 3.7.0
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+
   '@nuxt/ui-templates@1.3.3': {}
 
-  '@nuxt/vite-builder@3.11.2(@types/node@20.11.15)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(vue@3.4.24(typescript@5.3.3))':
+  '@nuxt/vite-builder@3.11.2(@types/node@20.11.15)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.26.0)(terser@5.27.0)(typescript@5.3.3)(vue@3.4.24(typescript@5.3.3))':
     dependencies:
-      '@nuxt/kit': 3.11.2(rollup@4.21.2)
-      '@rollup/plugin-replace': 5.0.7(rollup@4.21.2)
-      '@vitejs/plugin-vue': 5.0.4(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
-      '@vitejs/plugin-vue-jsx': 3.1.0(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
+      '@nuxt/kit': 3.11.2(rollup@4.26.0)
+      '@rollup/plugin-replace': 5.0.7(rollup@4.26.0)
+      '@vitejs/plugin-vue': 5.0.4(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
+      '@vitejs/plugin-vue-jsx': 3.1.0(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
       autoprefixer: 10.4.19(postcss@8.4.38)
       clear: 0.1.0
       consola: 3.2.3
@@ -14699,15 +15251,15 @@ snapshots:
       perfect-debounce: 1.0.0
       pkg-types: 1.1.0
       postcss: 8.4.38
-      rollup-plugin-visualizer: 5.12.0(rollup@4.21.2)
+      rollup-plugin-visualizer: 5.12.0(rollup@4.26.0)
       std-env: 3.7.0
       strip-literal: 2.1.0
       ufo: 1.5.3
       unenv: 1.9.0
       unplugin: 1.10.1
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
       vite-node: 1.5.0(@types/node@20.11.15)(terser@5.27.0)
-      vite-plugin-checker: 0.6.4(eslint@8.56.0)(optionator@0.9.3)(typescript@5.3.3)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      vite-plugin-checker: 0.6.4(eslint@8.56.0)(optionator@0.9.3)(typescript@5.3.3)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       vue: 3.4.24(typescript@5.3.3)
       vue-bundle-renderer: 2.0.0
     transitivePeerDependencies:
@@ -14735,8 +15287,8 @@ snapshots:
     dependencies:
       '@nuxt/kit': 3.12.4(magicast@0.3.4)(rollup@3.29.4)
       '@rollup/plugin-replace': 5.0.7(rollup@3.29.4)
-      '@vitejs/plugin-vue': 5.1.3(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.5.0(typescript@5.4.5))
-      '@vitejs/plugin-vue-jsx': 4.0.1(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.5.0(typescript@5.4.5))
+      '@vitejs/plugin-vue': 5.1.3(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))(vue@3.5.0(typescript@5.4.5))
+      '@vitejs/plugin-vue-jsx': 4.0.1(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))(vue@3.5.0(typescript@5.4.5))
       autoprefixer: 10.4.19(postcss@8.4.44)
       clear: 0.1.0
       consola: 3.2.3
@@ -14762,9 +15314,9 @@ snapshots:
       ufo: 1.5.4
       unenv: 1.10.0
       unplugin: 1.12.3
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
       vite-node: 2.0.5(@types/node@20.11.15)(terser@5.27.0)
-      vite-plugin-checker: 0.7.2(eslint@8.56.0)(optionator@0.9.3)(typescript@5.4.5)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      vite-plugin-checker: 0.7.2(eslint@8.56.0)(optionator@0.9.3)(typescript@5.4.5)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       vue: 3.5.0(typescript@5.4.5)
       vue-bundle-renderer: 2.1.0
     transitivePeerDependencies:
@@ -14794,8 +15346,8 @@ snapshots:
     dependencies:
       '@nuxt/kit': 3.12.4(magicast@0.3.4)(rollup@4.21.2)
       '@rollup/plugin-replace': 5.0.7(rollup@4.21.2)
-      '@vitejs/plugin-vue': 5.1.3(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))(vue@3.5.0(typescript@5.4.5))
-      '@vitejs/plugin-vue-jsx': 4.0.1(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))(vue@3.5.0(typescript@5.4.5))
+      '@vitejs/plugin-vue': 5.1.3(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))(vue@3.5.0(typescript@5.4.5))
+      '@vitejs/plugin-vue-jsx': 4.0.1(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))(vue@3.5.0(typescript@5.4.5))
       autoprefixer: 10.4.19(postcss@8.4.44)
       clear: 0.1.0
       consola: 3.2.3
@@ -14821,9 +15373,68 @@ snapshots:
       ufo: 1.5.4
       unenv: 1.10.0
       unplugin: 1.12.3
-      vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
       vite-node: 2.0.5(@types/node@20.12.12)(terser@5.27.0)
-      vite-plugin-checker: 0.7.2(eslint@8.56.0)(optionator@0.9.3)(typescript@5.4.5)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+      vite-plugin-checker: 0.7.2(eslint@8.56.0)(optionator@0.9.3)(typescript@5.4.5)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
+      vue: 3.5.0(typescript@5.4.5)
+      vue-bundle-renderer: 2.1.0
+    transitivePeerDependencies:
+      - '@biomejs/biome'
+      - '@types/node'
+      - eslint
+      - less
+      - lightningcss
+      - magicast
+      - meow
+      - optionator
+      - rollup
+      - sass
+      - sass-embedded
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - typescript
+      - uWebSockets.js
+      - vls
+      - vti
+      - vue-tsc
+
+  '@nuxt/vite-builder@3.12.4(@types/node@20.12.12)(eslint@8.56.0)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.26.0)(terser@5.27.0)(typescript@5.4.5)(vue@3.5.0(typescript@5.4.5))':
+    dependencies:
+      '@nuxt/kit': 3.12.4(magicast@0.3.4)(rollup@4.26.0)
+      '@rollup/plugin-replace': 5.0.7(rollup@4.26.0)
+      '@vitejs/plugin-vue': 5.1.3(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))(vue@3.5.0(typescript@5.4.5))
+      '@vitejs/plugin-vue-jsx': 4.0.1(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))(vue@3.5.0(typescript@5.4.5))
+      autoprefixer: 10.4.19(postcss@8.4.44)
+      clear: 0.1.0
+      consola: 3.2.3
+      cssnano: 7.0.5(postcss@8.4.44)
+      defu: 6.1.4
+      esbuild: 0.23.1
+      escape-string-regexp: 5.0.0
+      estree-walker: 3.0.3
+      externality: 1.0.2
+      get-port-please: 3.1.2
+      h3: 1.12.0
+      knitwork: 1.1.0
+      magic-string: 0.30.11
+      mlly: 1.7.1
+      ohash: 1.1.3
+      pathe: 1.1.2
+      perfect-debounce: 1.0.0
+      pkg-types: 1.2.0
+      postcss: 8.4.44
+      rollup-plugin-visualizer: 5.12.0(rollup@4.26.0)
+      std-env: 3.7.0
+      strip-literal: 2.1.0
+      ufo: 1.5.4
+      unenv: 1.10.0
+      unplugin: 1.12.3
+      vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
+      vite-node: 2.0.5(@types/node@20.12.12)(terser@5.27.0)
+      vite-plugin-checker: 0.7.2(eslint@8.56.0)(optionator@0.9.3)(typescript@5.4.5)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
       vue: 3.5.0(typescript@5.4.5)
       vue-bundle-renderer: 2.1.0
     transitivePeerDependencies:
@@ -15015,7 +15626,7 @@ snapshots:
 
   '@polka/url@1.0.0-next.25': {}
 
-  '@remix-run/dev@2.9.2(@remix-run/react@2.9.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5))(@remix-run/serve@2.9.2(typescript@5.4.5))(@types/node@20.11.15)(terser@5.27.0)(ts-node@10.9.2(@types/node@20.11.15)(typescript@5.4.5))(typescript@5.4.5)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))':
+  '@remix-run/dev@2.9.2(@remix-run/react@2.9.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5))(@remix-run/serve@2.9.2(typescript@5.4.5))(@types/node@20.11.15)(terser@5.27.0)(ts-node@10.9.2(@types/node@20.11.15)(typescript@5.4.5))(typescript@5.4.5)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))':
     dependencies:
       '@babel/core': 7.24.4
       '@babel/generator': 7.24.4
@@ -15074,7 +15685,7 @@ snapshots:
     optionalDependencies:
       '@remix-run/serve': 2.9.2(typescript@5.4.5)
       typescript: 5.4.5
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -15374,12 +15985,12 @@ snapshots:
     optionalDependencies:
       rollup: 4.9.6
 
-  '@rollup/plugin-replace@5.0.5(rollup@4.21.2)':
+  '@rollup/plugin-replace@5.0.5(rollup@4.26.0)':
     dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      '@rollup/pluginutils': 5.1.0(rollup@4.26.0)
       magic-string: 0.30.10
     optionalDependencies:
-      rollup: 4.21.2
+      rollup: 4.26.0
 
   '@rollup/plugin-replace@5.0.5(rollup@4.9.6)':
     dependencies:
@@ -15401,6 +16012,13 @@ snapshots:
       magic-string: 0.30.11
     optionalDependencies:
       rollup: 4.21.2
+
+  '@rollup/plugin-replace@5.0.7(rollup@4.26.0)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.26.0)
+      magic-string: 0.30.11
+    optionalDependencies:
+      rollup: 4.26.0
 
   '@rollup/plugin-terser@0.4.4(rollup@4.21.2)':
     dependencies:
@@ -15455,6 +16073,14 @@ snapshots:
     optionalDependencies:
       rollup: 4.21.2
 
+  '@rollup/pluginutils@5.1.0(rollup@4.26.0)':
+    dependencies:
+      '@types/estree': 1.0.5
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+    optionalDependencies:
+      rollup: 4.26.0
+
   '@rollup/pluginutils@5.1.0(rollup@4.9.6)':
     dependencies:
       '@types/estree': 1.0.5
@@ -15463,10 +16089,21 @@ snapshots:
     optionalDependencies:
       rollup: 4.9.6
 
+  '@rollup/pluginutils@5.1.3(rollup@4.26.0)':
+    dependencies:
+      '@types/estree': 1.0.6
+      estree-walker: 2.0.2
+      picomatch: 4.0.2
+    optionalDependencies:
+      rollup: 4.26.0
+
   '@rollup/rollup-android-arm-eabi@4.16.2':
     optional: true
 
   '@rollup/rollup-android-arm-eabi@4.21.2':
+    optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.26.0':
     optional: true
 
   '@rollup/rollup-android-arm-eabi@4.9.6':
@@ -15478,6 +16115,9 @@ snapshots:
   '@rollup/rollup-android-arm64@4.21.2':
     optional: true
 
+  '@rollup/rollup-android-arm64@4.26.0':
+    optional: true
+
   '@rollup/rollup-android-arm64@4.9.6':
     optional: true
 
@@ -15485,6 +16125,9 @@ snapshots:
     optional: true
 
   '@rollup/rollup-darwin-arm64@4.21.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.26.0':
     optional: true
 
   '@rollup/rollup-darwin-arm64@4.9.6':
@@ -15496,13 +16139,25 @@ snapshots:
   '@rollup/rollup-darwin-x64@4.21.2':
     optional: true
 
+  '@rollup/rollup-darwin-x64@4.26.0':
+    optional: true
+
   '@rollup/rollup-darwin-x64@4.9.6':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.26.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.26.0':
     optional: true
 
   '@rollup/rollup-linux-arm-gnueabihf@4.16.2':
     optional: true
 
   '@rollup/rollup-linux-arm-gnueabihf@4.21.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.26.0':
     optional: true
 
   '@rollup/rollup-linux-arm-gnueabihf@4.9.6':
@@ -15514,10 +16169,16 @@ snapshots:
   '@rollup/rollup-linux-arm-musleabihf@4.21.2':
     optional: true
 
+  '@rollup/rollup-linux-arm-musleabihf@4.26.0':
+    optional: true
+
   '@rollup/rollup-linux-arm64-gnu@4.16.2':
     optional: true
 
   '@rollup/rollup-linux-arm64-gnu@4.21.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.26.0':
     optional: true
 
   '@rollup/rollup-linux-arm64-gnu@4.9.6':
@@ -15529,6 +16190,9 @@ snapshots:
   '@rollup/rollup-linux-arm64-musl@4.21.2':
     optional: true
 
+  '@rollup/rollup-linux-arm64-musl@4.26.0':
+    optional: true
+
   '@rollup/rollup-linux-arm64-musl@4.9.6':
     optional: true
 
@@ -15538,10 +16202,16 @@ snapshots:
   '@rollup/rollup-linux-powerpc64le-gnu@4.21.2':
     optional: true
 
+  '@rollup/rollup-linux-powerpc64le-gnu@4.26.0':
+    optional: true
+
   '@rollup/rollup-linux-riscv64-gnu@4.16.2':
     optional: true
 
   '@rollup/rollup-linux-riscv64-gnu@4.21.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.26.0':
     optional: true
 
   '@rollup/rollup-linux-riscv64-gnu@4.9.6':
@@ -15553,10 +16223,16 @@ snapshots:
   '@rollup/rollup-linux-s390x-gnu@4.21.2':
     optional: true
 
+  '@rollup/rollup-linux-s390x-gnu@4.26.0':
+    optional: true
+
   '@rollup/rollup-linux-x64-gnu@4.16.2':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.21.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.26.0':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.9.6':
@@ -15568,6 +16244,9 @@ snapshots:
   '@rollup/rollup-linux-x64-musl@4.21.2':
     optional: true
 
+  '@rollup/rollup-linux-x64-musl@4.26.0':
+    optional: true
+
   '@rollup/rollup-linux-x64-musl@4.9.6':
     optional: true
 
@@ -15575,6 +16254,9 @@ snapshots:
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.21.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.26.0':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.9.6':
@@ -15586,6 +16268,9 @@ snapshots:
   '@rollup/rollup-win32-ia32-msvc@4.21.2':
     optional: true
 
+  '@rollup/rollup-win32-ia32-msvc@4.26.0':
+    optional: true
+
   '@rollup/rollup-win32-ia32-msvc@4.9.6':
     optional: true
 
@@ -15593,6 +16278,9 @@ snapshots:
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.21.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.26.0':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.9.6':
@@ -15650,7 +16338,7 @@ snapshots:
     dependencies:
       solid-js: 1.8.19
 
-  '@solidjs/start@1.0.6(rollup@3.29.4)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.11.15)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))':
+  '@solidjs/start@1.0.6(rollup@3.29.4)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.11.15)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))':
     dependencies:
       '@vinxi/plugin-directives': 0.4.1(vinxi@0.4.1(@types/node@20.11.15)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))
       '@vinxi/server-components': 0.4.1(vinxi@0.4.1(@types/node@20.11.15)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))
@@ -15665,8 +16353,8 @@ snapshots:
       shikiji: 0.9.19
       source-map-js: 1.2.0
       terracotta: 1.0.5(solid-js@1.8.19)
-      vite-plugin-inspect: 0.7.42(rollup@3.29.4)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
-      vite-plugin-solid: 2.10.2(solid-js@1.8.19)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      vite-plugin-inspect: 0.7.42(rollup@3.29.4)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
+      vite-plugin-solid: 2.10.2(solid-js@1.8.19)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
     transitivePeerDependencies:
       - '@nuxt/kit'
       - '@testing-library/jest-dom'
@@ -15676,7 +16364,7 @@ snapshots:
       - vinxi
       - vite
 
-  '@solidjs/start@1.0.6(rollup@4.21.2)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))':
+  '@solidjs/start@1.0.6(rollup@4.21.2)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))':
     dependencies:
       '@vinxi/plugin-directives': 0.4.1(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))
       '@vinxi/server-components': 0.4.1(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))
@@ -15691,7 +16379,59 @@ snapshots:
       shikiji: 0.9.19
       source-map-js: 1.2.0
       terracotta: 1.0.5(solid-js@1.8.19)
-      vite-plugin-inspect: 0.7.42(rollup@4.21.2)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+      vite-plugin-inspect: 0.7.42(rollup@4.21.2)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
+      vite-plugin-solid: 2.10.2(solid-js@1.8.19)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
+    transitivePeerDependencies:
+      - '@nuxt/kit'
+      - '@testing-library/jest-dom'
+      - rollup
+      - solid-js
+      - supports-color
+      - vinxi
+      - vite
+
+  '@solidjs/start@1.0.6(rollup@4.26.0)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))':
+    dependencies:
+      '@vinxi/plugin-directives': 0.4.1(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))
+      '@vinxi/server-components': 0.4.1(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))
+      '@vinxi/server-functions': 0.4.1(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))
+      defu: 6.1.4
+      error-stack-parser: 2.1.4
+      glob: 10.3.10
+      html-to-image: 1.11.11
+      radix3: 1.1.2
+      seroval: 1.1.0
+      seroval-plugins: 1.1.0(seroval@1.1.0)
+      shikiji: 0.9.19
+      source-map-js: 1.2.0
+      terracotta: 1.0.5(solid-js@1.8.19)
+      vite-plugin-inspect: 0.7.42(rollup@4.26.0)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
+      vite-plugin-solid: 2.10.2(solid-js@1.8.19)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
+    transitivePeerDependencies:
+      - '@nuxt/kit'
+      - '@testing-library/jest-dom'
+      - rollup
+      - solid-js
+      - supports-color
+      - vinxi
+      - vite
+
+  '@solidjs/start@1.0.6(rollup@4.26.0)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))':
+    dependencies:
+      '@vinxi/plugin-directives': 0.4.1(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))
+      '@vinxi/server-components': 0.4.1(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))
+      '@vinxi/server-functions': 0.4.1(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))
+      defu: 6.1.4
+      error-stack-parser: 2.1.4
+      glob: 10.3.10
+      html-to-image: 1.11.11
+      radix3: 1.1.2
+      seroval: 1.1.0
+      seroval-plugins: 1.1.0(seroval@1.1.0)
+      shikiji: 0.9.19
+      source-map-js: 1.2.0
+      terracotta: 1.0.5(solid-js@1.8.19)
+      vite-plugin-inspect: 0.7.42(rollup@4.26.0)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
       vite-plugin-solid: 2.10.2(solid-js@1.8.19)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -15707,9 +16447,9 @@ snapshots:
       '@sveltejs/kit': 2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
       import-meta-resolve: 4.1.0
 
-  '@sveltejs/kit@2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))':
+  '@sveltejs/kit@2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.2.15)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.0.0
@@ -15723,7 +16463,7 @@ snapshots:
       sirv: 2.0.4
       svelte: 4.2.15
       tiny-glob: 0.2.9
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
 
   '@sveltejs/kit@2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))':
     dependencies:
@@ -15761,6 +16501,15 @@ snapshots:
       tiny-glob: 0.2.9
       vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
 
+  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.2.15)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
+      debug: 4.3.4
+      svelte: 4.2.15
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
@@ -15776,6 +16525,20 @@ snapshots:
       debug: 4.3.4
       svelte: 4.2.15
       vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
+      debug: 4.3.4
+      deepmerge: 4.3.1
+      kleur: 4.1.5
+      magic-string: 0.30.10
+      svelte: 4.2.15
+      svelte-hmr: 0.16.0(svelte@4.2.15)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
+      vitefu: 0.2.5(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -15839,7 +16602,7 @@ snapshots:
 
   '@types/acorn@4.0.6':
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -15891,6 +16654,8 @@ snapshots:
       '@types/estree': 1.0.5
 
   '@types/estree@1.0.5': {}
+
+  '@types/estree@1.0.6': {}
 
   '@types/hast@2.3.10':
     dependencies:
@@ -16208,20 +16973,20 @@ snapshots:
       unhead: 1.9.7
       vue: 3.4.24(typescript@5.3.3)
 
-  '@unocss/astro@0.59.4(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))':
+  '@unocss/astro@0.59.4(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))':
     dependencies:
       '@unocss/core': 0.59.4
       '@unocss/reset': 0.59.4
-      '@unocss/vite': 0.59.4(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      '@unocss/vite': 0.59.4(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
     optionalDependencies:
       vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
     transitivePeerDependencies:
       - rollup
 
-  '@unocss/cli@0.59.4(rollup@4.21.2)':
+  '@unocss/cli@0.59.4(rollup@4.26.0)':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      '@rollup/pluginutils': 5.1.3(rollup@4.26.0)
       '@unocss/config': 0.59.4
       '@unocss/core': 0.59.4
       '@unocss/preset-uno': 0.59.4
@@ -16230,7 +16995,7 @@ snapshots:
       colorette: 2.0.20
       consola: 3.2.3
       fast-glob: 3.3.2
-      magic-string: 0.30.11
+      magic-string: 0.30.12
       pathe: 1.1.2
       perfect-debounce: 1.0.0
     transitivePeerDependencies:
@@ -16261,7 +17026,7 @@ snapshots:
       '@unocss/rule-utils': 0.59.4
       css-tree: 2.3.1
       fast-glob: 3.3.2
-      magic-string: 0.30.11
+      magic-string: 0.30.12
       postcss: 8.4.38
 
   '@unocss/preset-attributify@0.59.4':
@@ -16270,9 +17035,9 @@ snapshots:
 
   '@unocss/preset-icons@0.59.4':
     dependencies:
-      '@iconify/utils': 2.1.23
+      '@iconify/utils': 2.1.33
       '@unocss/core': 0.59.4
-      ofetch: 1.3.4
+      ofetch: 1.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -16301,7 +17066,7 @@ snapshots:
   '@unocss/preset-web-fonts@0.59.4':
     dependencies:
       '@unocss/core': 0.59.4
-      ofetch: 1.3.4
+      ofetch: 1.4.1
 
   '@unocss/preset-wind@0.59.4':
     dependencies:
@@ -16314,15 +17079,15 @@ snapshots:
   '@unocss/rule-utils@0.59.4':
     dependencies:
       '@unocss/core': 0.59.4
-      magic-string: 0.30.11
+      magic-string: 0.30.12
 
   '@unocss/scope@0.59.4': {}
 
   '@unocss/transformer-attributify-jsx-babel@0.59.4':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/plugin-syntax-jsx': 7.24.1(@babel/core@7.25.2)
-      '@babel/preset-typescript': 7.24.1(@babel/core@7.25.2)
+      '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.25.2)
+      '@babel/preset-typescript': 7.26.0(@babel/core@7.25.2)
       '@unocss/core': 0.59.4
     transitivePeerDependencies:
       - supports-color
@@ -16345,10 +17110,10 @@ snapshots:
     dependencies:
       '@unocss/core': 0.59.4
 
-  '@unocss/vite@0.59.4(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))':
+  '@unocss/vite@0.59.4(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      '@rollup/pluginutils': 5.1.3(rollup@4.26.0)
       '@unocss/config': 0.59.4
       '@unocss/core': 0.59.4
       '@unocss/inspector': 0.59.4
@@ -16356,7 +17121,7 @@ snapshots:
       '@unocss/transformer-directives': 0.59.4
       chokidar: 3.6.0
       fast-glob: 3.3.2
-      magic-string: 0.30.11
+      magic-string: 0.30.12
       vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
     transitivePeerDependencies:
       - rollup
@@ -16396,7 +17161,7 @@ snapshots:
       lodash: 4.17.21
       mlly: 1.6.1
       outdent: 0.8.0
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
       vite-node: 1.5.0(@types/node@20.11.15)(terser@5.27.0)
     transitivePeerDependencies:
       - '@types/node'
@@ -16423,7 +17188,7 @@ snapshots:
       lodash: 4.17.21
       mlly: 1.6.1
       outdent: 0.8.0
-      vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
       vite-node: 1.5.0(@types/node@20.12.12)(terser@5.27.0)
     transitivePeerDependencies:
       - '@types/node'
@@ -16578,49 +17343,49 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@3.1.0(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))':
+  '@vitejs/plugin-vue-jsx@3.1.0(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))':
     dependencies:
       '@babel/core': 7.24.4
       '@babel/plugin-transform-typescript': 7.24.4(@babel/core@7.24.4)
       '@vue/babel-plugin-jsx': 1.2.2(@babel/core@7.24.4)
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
       vue: 3.4.24(typescript@5.3.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@4.0.1(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.5.0(typescript@5.4.5))':
+  '@vitejs/plugin-vue-jsx@4.0.1(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))(vue@3.5.0(typescript@5.4.5))':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/plugin-transform-typescript': 7.25.2(@babel/core@7.25.2)
       '@vue/babel-plugin-jsx': 1.2.2(@babel/core@7.25.2)
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
       vue: 3.5.0(typescript@5.4.5)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@4.0.1(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))(vue@3.5.0(typescript@5.4.5))':
+  '@vitejs/plugin-vue-jsx@4.0.1(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))(vue@3.5.0(typescript@5.4.5))':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/plugin-transform-typescript': 7.25.2(@babel/core@7.25.2)
       '@vue/babel-plugin-jsx': 1.2.2(@babel/core@7.25.2)
-      vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
       vue: 3.5.0(typescript@5.4.5)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.0.4(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))':
+  '@vitejs/plugin-vue@5.0.4(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))':
     dependencies:
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
       vue: 3.4.24(typescript@5.3.3)
 
-  '@vitejs/plugin-vue@5.1.3(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.5.0(typescript@5.4.5))':
+  '@vitejs/plugin-vue@5.1.3(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))(vue@3.5.0(typescript@5.4.5))':
     dependencies:
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
       vue: 3.5.0(typescript@5.4.5)
 
-  '@vitejs/plugin-vue@5.1.3(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))(vue@3.5.0(typescript@5.4.5))':
+  '@vitejs/plugin-vue@5.1.3(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))(vue@3.5.0(typescript@5.4.5))':
     dependencies:
-      vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
       vue: 3.5.0(typescript@5.4.5)
 
   '@vitest/coverage-v8@1.5.0(vitest@1.5.0(@types/node@20.10.0)(terser@5.27.0))':
@@ -16709,10 +17474,10 @@ snapshots:
       loupe: 2.3.7
       pretty-format: 29.7.0
 
-  '@vue-macros/common@1.10.2(rollup@4.21.2)(vue@3.4.24(typescript@5.3.3))':
+  '@vue-macros/common@1.10.2(rollup@4.26.0)(vue@3.4.24(typescript@5.3.3))':
     dependencies:
       '@babel/types': 7.24.0
-      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      '@rollup/pluginutils': 5.1.0(rollup@4.26.0)
       '@vue/compiler-sfc': 3.4.24
       ast-kit: 0.12.1
       local-pkg: 0.5.0
@@ -16739,6 +17504,19 @@ snapshots:
     dependencies:
       '@babel/types': 7.25.6
       '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      '@vue/compiler-sfc': 3.5.0
+      ast-kit: 1.1.0
+      local-pkg: 0.5.0
+      magic-string-ast: 0.6.2
+    optionalDependencies:
+      vue: 3.5.0(typescript@5.4.5)
+    transitivePeerDependencies:
+      - rollup
+
+  '@vue-macros/common@1.12.2(rollup@4.26.0)(vue@3.5.0(typescript@5.4.5))':
+    dependencies:
+      '@babel/types': 7.25.6
+      '@rollup/pluginutils': 5.1.0(rollup@4.26.0)
       '@vue/compiler-sfc': 3.5.0
       ast-kit: 1.1.0
       local-pkg: 0.5.0
@@ -16826,7 +17604,7 @@ snapshots:
       '@vue/shared': 3.5.0
       entities: 4.5.0
       estree-walker: 2.0.2
-      source-map-js: 1.2.0
+      source-map-js: 1.2.1
 
   '@vue/compiler-dom@3.4.21':
     dependencies:
@@ -16876,7 +17654,7 @@ snapshots:
       '@vue/shared': 3.5.0
       estree-walker: 2.0.2
       magic-string: 0.30.11
-      postcss: 8.4.44
+      postcss: 8.4.49
       source-map-js: 1.2.0
 
   '@vue/compiler-ssr@3.4.21':
@@ -16898,12 +17676,12 @@ snapshots:
 
   '@vue/devtools-api@6.6.3': {}
 
-  '@vue/devtools-applet@7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))':
+  '@vue/devtools-applet@7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))':
     dependencies:
       '@vue/devtools-core': 7.0.27(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
       '@vue/devtools-kit': 7.0.27(vue@3.4.24(typescript@5.3.3))
       '@vue/devtools-shared': 7.0.27
-      '@vue/devtools-ui': 7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vue@3.4.24(typescript@5.3.3))
+      '@vue/devtools-ui': 7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vue@3.4.24(typescript@5.3.3))
       perfect-debounce: 1.0.0
       splitpanes: 3.1.5
       vue: 3.4.24(typescript@5.3.3)
@@ -16938,25 +17716,25 @@ snapshots:
       - vite
       - vue
 
-  '@vue/devtools-core@7.3.3(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))':
+  '@vue/devtools-core@7.3.3(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))':
     dependencies:
       '@vue/devtools-kit': 7.3.3
       '@vue/devtools-shared': 7.4.0
       mitt: 3.0.1
       nanoid: 3.3.7
       pathe: 1.1.2
-      vite-hot-client: 0.2.3(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      vite-hot-client: 0.2.3(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
     transitivePeerDependencies:
       - vite
 
-  '@vue/devtools-core@7.3.3(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))':
+  '@vue/devtools-core@7.3.3(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))':
     dependencies:
       '@vue/devtools-kit': 7.3.3
       '@vue/devtools-shared': 7.4.0
       mitt: 3.0.1
       nanoid: 3.3.7
       pathe: 1.1.2
-      vite-hot-client: 0.2.3(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+      vite-hot-client: 0.2.3(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
     transitivePeerDependencies:
       - vite
 
@@ -16987,16 +17765,16 @@ snapshots:
     dependencies:
       rfdc: 1.4.1
 
-  '@vue/devtools-ui@7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vue@3.4.24(typescript@5.3.3))':
+  '@vue/devtools-ui@7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vue@3.4.24(typescript@5.3.3))':
     dependencies:
       '@unocss/reset': 0.59.4
       '@vueuse/components': 10.9.0(vue@3.4.24(typescript@5.3.3))
       '@vueuse/core': 10.9.0(vue@3.4.24(typescript@5.3.3))
       '@vueuse/integrations': 10.9.0(axios@0.25.0)(focus-trap@7.5.4)(vue@3.4.24(typescript@5.3.3))
       colord: 2.9.3
-      floating-vue: 5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3))
+      floating-vue: 5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3))
       focus-trap: 7.5.4
-      unocss: 0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      unocss: 0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
       vue: 3.4.24(typescript@5.3.3)
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -17333,6 +18111,8 @@ snapshots:
 
   acorn@8.12.1: {}
 
+  acorn@8.14.0: {}
+
   agent-base@6.0.2:
     dependencies:
       debug: 4.3.4
@@ -17516,10 +18296,10 @@ snapshots:
       '@babel/parser': 7.24.8
       pathe: 1.1.2
 
-  ast-kit@0.9.5(rollup@4.21.2):
+  ast-kit@0.9.5(rollup@4.26.0):
     dependencies:
       '@babel/parser': 7.24.8
-      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      '@rollup/pluginutils': 5.1.0(rollup@4.26.0)
       pathe: 1.1.2
     transitivePeerDependencies:
       - rollup
@@ -17535,10 +18315,10 @@ snapshots:
     dependencies:
       tslib: 2.6.2
 
-  ast-walker-scope@0.5.0(rollup@4.21.2):
+  ast-walker-scope@0.5.0(rollup@4.26.0):
     dependencies:
       '@babel/parser': 7.24.4
-      ast-kit: 0.9.5(rollup@4.21.2)
+      ast-kit: 0.9.5(rollup@4.26.0)
     transitivePeerDependencies:
       - rollup
 
@@ -18144,6 +18924,8 @@ snapshots:
 
   confbox@0.1.7: {}
 
+  confbox@0.1.8: {}
+
   connect@3.7.0:
     dependencies:
       debug: 2.6.9
@@ -18243,7 +19025,7 @@ snapshots:
   css-tree@2.2.1:
     dependencies:
       mdn-data: 2.0.28
-      source-map-js: 1.2.0
+      source-map-js: 1.2.1
 
   css-tree@2.3.1:
     dependencies:
@@ -18389,6 +19171,10 @@ snapshots:
   debug@4.3.6:
     dependencies:
       ms: 2.1.2
+
+  debug@4.3.7:
+    dependencies:
+      ms: 2.1.3
 
   decamelize-keys@1.1.1:
     dependencies:
@@ -19236,7 +20022,7 @@ snapshots:
 
   estree-util-attach-comments@2.1.1:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
 
   estree-util-build-jsx@2.2.2:
     dependencies:
@@ -19486,13 +20272,13 @@ snapshots:
 
   flatted@3.3.1: {}
 
-  floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)):
+  floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3)):
     dependencies:
       '@floating-ui/dom': 1.1.1
       vue: 3.4.24(typescript@5.3.3)
       vue-resize: 2.0.0-alpha.1(vue@3.4.24(typescript@5.3.3))
     optionalDependencies:
-      '@nuxt/kit': 3.11.2(rollup@4.21.2)
+      '@nuxt/kit': 3.11.2(rollup@4.26.0)
 
   focus-trap@7.5.4:
     dependencies:
@@ -20584,6 +21370,10 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  magic-string@0.30.12:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
+
   magic-string@0.30.5:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
@@ -20807,7 +21597,7 @@ snapshots:
 
   micromark-extension-mdx-expression@1.0.8:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       micromark-factory-mdx-expression: 1.0.9
       micromark-factory-space: 1.1.0
       micromark-util-character: 1.2.0
@@ -20819,7 +21609,7 @@ snapshots:
   micromark-extension-mdx-jsx@1.0.5:
     dependencies:
       '@types/acorn': 4.0.6
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       estree-util-is-identifier-name: 2.1.0
       micromark-factory-mdx-expression: 1.0.9
       micromark-factory-space: 1.1.0
@@ -20835,7 +21625,7 @@ snapshots:
 
   micromark-extension-mdxjs-esm@1.0.5:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       micromark-core-commonmark: 1.1.0
       micromark-util-character: 1.2.0
       micromark-util-events-to-acorn: 1.2.3
@@ -20871,7 +21661,7 @@ snapshots:
 
   micromark-factory-mdx-expression@1.0.9:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       micromark-util-character: 1.2.0
       micromark-util-events-to-acorn: 1.2.3
       micromark-util-symbol: 1.1.0
@@ -20935,7 +21725,7 @@ snapshots:
   micromark-util-events-to-acorn@1.2.3:
     dependencies:
       '@types/acorn': 4.0.6
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       '@types/unist': 2.0.10
       estree-util-visit: 1.2.1
       micromark-util-symbol: 1.1.0
@@ -21150,6 +21940,13 @@ snapshots:
       acorn: 8.12.1
       pathe: 1.1.2
       pkg-types: 1.2.0
+      ufo: 1.5.4
+
+  mlly@1.7.3:
+    dependencies:
+      acorn: 8.14.0
+      pathe: 1.1.2
+      pkg-types: 1.2.1
       ufo: 1.5.4
 
   modern-ahocorasick@1.0.1: {}
@@ -21681,15 +22478,15 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
+  nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.26.0)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.2.0(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.21.2)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
-      '@nuxt/kit': 3.11.2(rollup@4.21.2)
-      '@nuxt/schema': 3.11.2(rollup@4.21.2)
-      '@nuxt/telemetry': 2.5.4(rollup@4.21.2)
+      '@nuxt/devtools': 1.2.0(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3)))(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.26.0))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.26.0)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.26.0)(unocss@0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
+      '@nuxt/kit': 3.11.2(rollup@4.26.0)
+      '@nuxt/schema': 3.11.2(rollup@4.26.0)
+      '@nuxt/telemetry': 2.5.4(rollup@4.26.0)
       '@nuxt/ui-templates': 1.3.3
-      '@nuxt/vite-builder': 3.11.2(@types/node@20.11.15)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(vue@3.4.24(typescript@5.3.3))
+      '@nuxt/vite-builder': 3.11.2(@types/node@20.11.15)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.26.0)(terser@5.27.0)(typescript@5.3.3)(vue@3.4.24(typescript@5.3.3))
       '@unhead/dom': 1.9.7
       '@unhead/ssr': 1.9.7
       '@unhead/vue': 1.9.7(vue@3.4.24(typescript@5.3.3))
@@ -21730,9 +22527,9 @@ snapshots:
       uncrypto: 0.1.3
       unctx: 2.3.1
       unenv: 1.9.0
-      unimport: 3.7.1(rollup@4.21.2)
+      unimport: 3.7.1(rollup@4.26.0)
       unplugin: 1.10.1
-      unplugin-vue-router: 0.7.0(rollup@4.21.2)(vue-router@4.3.2(vue@3.4.24(typescript@5.3.3)))(vue@3.4.24(typescript@5.3.3))
+      unplugin-vue-router: 0.7.0(rollup@4.26.0)(vue-router@4.3.2(vue@3.4.24(typescript@5.3.3)))(vue@3.4.24(typescript@5.3.3))
       unstorage: 1.10.2(ioredis@5.4.1)
       untyped: 1.4.2
       vue: 3.4.24(typescript@5.3.3)
@@ -21798,10 +22595,10 @@ snapshots:
       - vue-tsc
       - xml2js
 
-  nuxt@3.12.4(@parcel/watcher@2.4.1)(@types/node@20.11.15)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@3.29.4)(terser@5.27.0)(typescript@5.4.5)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
+  nuxt@3.12.4(@parcel/watcher@2.4.1)(@types/node@20.11.15)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@3.29.4)(terser@5.27.0)(typescript@5.4.5)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.4.1(rollup@3.29.4)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      '@nuxt/devtools': 1.4.1(rollup@3.29.4)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       '@nuxt/kit': 3.12.4(magicast@0.3.4)(rollup@3.29.4)
       '@nuxt/schema': 3.12.4(rollup@3.29.4)
       '@nuxt/telemetry': 2.5.4(rollup@3.29.4)
@@ -21905,10 +22702,10 @@ snapshots:
       - vue-tsc
       - xml2js
 
-  nuxt@3.12.4(@parcel/watcher@2.4.1)(@types/node@20.12.12)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.4.5)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
+  nuxt@3.12.4(@parcel/watcher@2.4.1)(@types/node@20.12.12)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.4.5)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0)):
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.4.1(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      '@nuxt/devtools': 1.4.1(rollup@4.21.2)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
       '@nuxt/kit': 3.12.4(magicast@0.3.4)(rollup@4.21.2)
       '@nuxt/schema': 3.12.4(rollup@4.21.2)
       '@nuxt/telemetry': 2.5.4(rollup@4.21.2)
@@ -22012,14 +22809,14 @@ snapshots:
       - vue-tsc
       - xml2js
 
-  nuxt@3.12.4(@parcel/watcher@2.4.1)(@types/node@20.12.12)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.4.5)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)):
+  nuxt@3.12.4(@parcel/watcher@2.4.1)(@types/node@20.12.12)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.26.0)(terser@5.27.0)(typescript@5.4.5)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.4.1(rollup@4.21.2)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
-      '@nuxt/kit': 3.12.4(magicast@0.3.4)(rollup@4.21.2)
-      '@nuxt/schema': 3.12.4(rollup@4.21.2)
-      '@nuxt/telemetry': 2.5.4(rollup@4.21.2)
-      '@nuxt/vite-builder': 3.12.4(@types/node@20.12.12)(eslint@8.56.0)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.4.5)(vue@3.5.0(typescript@5.4.5))
+      '@nuxt/devtools': 1.4.1(rollup@4.26.0)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
+      '@nuxt/kit': 3.12.4(magicast@0.3.4)(rollup@4.26.0)
+      '@nuxt/schema': 3.12.4(rollup@4.26.0)
+      '@nuxt/telemetry': 2.5.4(rollup@4.26.0)
+      '@nuxt/vite-builder': 3.12.4(@types/node@20.12.12)(eslint@8.56.0)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.26.0)(terser@5.27.0)(typescript@5.4.5)(vue@3.5.0(typescript@5.4.5))
       '@unhead/dom': 1.10.4
       '@unhead/ssr': 1.10.4
       '@unhead/vue': 1.10.4(vue@3.5.0(typescript@5.4.5))
@@ -22064,9 +22861,9 @@ snapshots:
       uncrypto: 0.1.3
       unctx: 2.3.1
       unenv: 1.10.0
-      unimport: 3.11.1(rollup@4.21.2)
+      unimport: 3.11.1(rollup@4.26.0)
       unplugin: 1.12.3
-      unplugin-vue-router: 0.10.7(rollup@4.21.2)(vue-router@4.4.3(vue@3.5.0(typescript@5.4.5)))(vue@3.5.0(typescript@5.4.5))
+      unplugin-vue-router: 0.10.7(rollup@4.26.0)(vue-router@4.4.3(vue@3.5.0(typescript@5.4.5)))(vue@3.5.0(typescript@5.4.5))
       unstorage: 1.10.2(ioredis@5.4.1)
       untyped: 1.4.2
       vue: 3.5.0(typescript@5.4.5)
@@ -22196,6 +22993,12 @@ snapshots:
       node-fetch-native: 1.6.4
       ufo: 1.5.3
 
+  ofetch@1.4.1:
+    dependencies:
+      destr: 2.0.3
+      node-fetch-native: 1.6.4
+      ufo: 1.5.4
+
   ohash@1.1.3: {}
 
   on-finished@2.3.0:
@@ -22318,6 +23121,8 @@ snapshots:
       aggregate-error: 3.1.0
 
   p-try@2.2.0: {}
+
+  package-manager-detector@0.2.2: {}
 
   pacote@18.0.0:
     dependencies:
@@ -22446,6 +23251,8 @@ snapshots:
 
   picocolors@1.0.1: {}
 
+  picocolors@1.1.1: {}
+
   picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
@@ -22476,6 +23283,12 @@ snapshots:
     dependencies:
       confbox: 0.1.7
       mlly: 1.7.1
+      pathe: 1.1.2
+
+  pkg-types@1.2.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.7.3
       pathe: 1.1.2
 
   postcss-calc@10.0.2(postcss@8.4.44):
@@ -22583,12 +23396,12 @@ snapshots:
       postcss: 8.4.38
       ts-node: 10.9.2(@types/node@20.12.12)(typescript@5.4.5)
 
-  postcss-load-config@4.0.2(postcss@8.4.44)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.3.3)):
+  postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.3.3)):
     dependencies:
       lilconfig: 3.1.1
       yaml: 2.3.4
     optionalDependencies:
-      postcss: 8.4.44
+      postcss: 8.4.49
       ts-node: 10.9.2(@types/node@20.12.12)(typescript@5.3.3)
     optional: true
 
@@ -22882,6 +23695,12 @@ snapshots:
       nanoid: 3.3.7
       picocolors: 1.0.1
       source-map-js: 1.2.0
+
+  postcss@8.4.49:
+    dependencies:
+      nanoid: 3.3.7
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   preferred-pm@3.1.2:
     dependencies:
@@ -23336,6 +24155,15 @@ snapshots:
     optionalDependencies:
       rollup: 4.21.2
 
+  rollup-plugin-visualizer@5.12.0(rollup@4.26.0):
+    dependencies:
+      open: 8.4.2
+      picomatch: 2.3.1
+      source-map: 0.7.4
+      yargs: 17.7.2
+    optionalDependencies:
+      rollup: 4.26.0
+
   rollup-route-manifest@1.0.0(rollup@3.29.4):
     dependencies:
       rollup: 3.29.4
@@ -23387,6 +24215,30 @@ snapshots:
       '@rollup/rollup-win32-arm64-msvc': 4.21.2
       '@rollup/rollup-win32-ia32-msvc': 4.21.2
       '@rollup/rollup-win32-x64-msvc': 4.21.2
+      fsevents: 2.3.3
+
+  rollup@4.26.0:
+    dependencies:
+      '@types/estree': 1.0.6
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.26.0
+      '@rollup/rollup-android-arm64': 4.26.0
+      '@rollup/rollup-darwin-arm64': 4.26.0
+      '@rollup/rollup-darwin-x64': 4.26.0
+      '@rollup/rollup-freebsd-arm64': 4.26.0
+      '@rollup/rollup-freebsd-x64': 4.26.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.26.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.26.0
+      '@rollup/rollup-linux-arm64-gnu': 4.26.0
+      '@rollup/rollup-linux-arm64-musl': 4.26.0
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.26.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.26.0
+      '@rollup/rollup-linux-s390x-gnu': 4.26.0
+      '@rollup/rollup-linux-x64-gnu': 4.26.0
+      '@rollup/rollup-linux-x64-musl': 4.26.0
+      '@rollup/rollup-win32-arm64-msvc': 4.26.0
+      '@rollup/rollup-win32-ia32-msvc': 4.26.0
+      '@rollup/rollup-win32-x64-msvc': 4.26.0
       fsevents: 2.3.3
 
   rollup@4.9.6:
@@ -23760,7 +24612,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  solid-start@0.3.11(@solidjs/meta@0.29.4(solid-js@1.8.19))(@solidjs/router@0.14.1(solid-js@1.8.19))(solid-js@1.8.19)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
+  solid-start@0.3.11(@solidjs/meta@0.29.4(solid-js@1.8.19))(@solidjs/router@0.14.1(solid-js@1.8.19))(solid-js@1.8.19)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
       '@babel/core': 7.24.4
       '@babel/generator': 7.24.4
@@ -23795,9 +24647,9 @@ snapshots:
       solid-js: 1.8.19
       terser: 5.27.0
       undici: 5.28.4
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
-      vite-plugin-inspect: 0.7.42(rollup@3.29.4)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
-      vite-plugin-solid: 2.10.2(solid-js@1.8.19)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
+      vite-plugin-inspect: 0.7.42(rollup@3.29.4)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
+      vite-plugin-solid: 2.10.2(solid-js@1.8.19)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
       wait-on: 6.0.1(debug@4.3.4)
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -23816,6 +24668,8 @@ snapshots:
       sander: 0.5.1
 
   source-map-js@1.2.0: {}
+
+  source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
     dependencies:
@@ -24057,7 +24911,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@3.7.0(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.44)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.3.3)))(postcss@8.4.44)(svelte@4.2.15):
+  svelte-check@3.7.0(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.3.3)))(postcss@8.4.49)(svelte@4.2.15):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 3.6.0
@@ -24066,7 +24920,7 @@ snapshots:
       picocolors: 1.0.0
       sade: 1.8.1
       svelte: 4.2.15
-      svelte-preprocess: 5.1.4(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.44)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.3.3)))(postcss@8.4.44)(svelte@4.2.15)(typescript@5.4.5)
+      svelte-preprocess: 5.1.4(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.3.3)))(postcss@8.4.49)(svelte@4.2.15)(typescript@5.4.5)
       typescript: 5.4.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -24083,7 +24937,7 @@ snapshots:
     dependencies:
       svelte: 4.2.15
 
-  svelte-preprocess@5.1.4(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.44)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.3.3)))(postcss@8.4.44)(svelte@4.2.15)(typescript@5.4.5):
+  svelte-preprocess@5.1.4(@babel/core@7.25.2)(postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.3.3)))(postcss@8.4.49)(svelte@4.2.15)(typescript@5.4.5):
     dependencies:
       '@types/pug': 2.0.10
       detect-indent: 6.1.0
@@ -24093,8 +24947,8 @@ snapshots:
       svelte: 4.2.15
     optionalDependencies:
       '@babel/core': 7.25.2
-      postcss: 8.4.44
-      postcss-load-config: 4.0.2(postcss@8.4.44)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.3.3))
+      postcss: 8.4.49
+      postcss-load-config: 4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.3.3))
       typescript: 5.4.5
 
   svelte@4.2.15:
@@ -24124,7 +24978,7 @@ snapshots:
       css-tree: 2.3.1
       css-what: 6.1.0
       csso: 5.0.5
-      picocolors: 1.0.1
+      picocolors: 1.1.1
 
   svgo@3.3.2:
     dependencies:
@@ -24134,7 +24988,7 @@ snapshots:
       css-tree: 2.3.1
       css-what: 6.1.0
       csso: 5.0.5
-      picocolors: 1.0.1
+      picocolors: 1.1.1
 
   synckit@0.8.8:
     dependencies:
@@ -24328,6 +25182,8 @@ snapshots:
   tiny-invariant@1.3.3: {}
 
   tinybench@2.7.0: {}
+
+  tinyexec@0.3.1: {}
 
   tinyglobby@0.2.5:
     dependencies:
@@ -24775,6 +25631,24 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
+  unimport@3.11.1(rollup@4.26.0):
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.26.0)
+      acorn: 8.12.1
+      escape-string-regexp: 5.0.0
+      estree-walker: 3.0.3
+      fast-glob: 3.3.2
+      local-pkg: 0.5.0
+      magic-string: 0.30.11
+      mlly: 1.7.1
+      pathe: 1.1.2
+      pkg-types: 1.2.0
+      scule: 1.3.0
+      strip-literal: 2.1.0
+      unplugin: 1.12.3
+    transitivePeerDependencies:
+      - rollup
+
   unimport@3.7.1(rollup@3.29.4):
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
@@ -24796,6 +25670,24 @@ snapshots:
   unimport@3.7.1(rollup@4.21.2):
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      acorn: 8.11.3
+      escape-string-regexp: 5.0.0
+      estree-walker: 3.0.3
+      fast-glob: 3.3.2
+      local-pkg: 0.5.0
+      magic-string: 0.30.11
+      mlly: 1.6.1
+      pathe: 1.1.2
+      pkg-types: 1.1.0
+      scule: 1.3.0
+      strip-literal: 1.3.0
+      unplugin: 1.10.1
+    transitivePeerDependencies:
+      - rollup
+
+  unimport@3.7.1(rollup@4.26.0):
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.26.0)
       acorn: 8.11.3
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
@@ -24859,10 +25751,10 @@ snapshots:
 
   universalify@2.0.0: {}
 
-  unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
+  unocss@0.59.4(postcss@8.4.38)(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
-      '@unocss/astro': 0.59.4(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
-      '@unocss/cli': 0.59.4(rollup@4.21.2)
+      '@unocss/astro': 0.59.4(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      '@unocss/cli': 0.59.4(rollup@4.26.0)
       '@unocss/core': 0.59.4
       '@unocss/extractor-arbitrary-variants': 0.59.4
       '@unocss/postcss': 0.59.4(postcss@8.4.38)
@@ -24880,7 +25772,7 @@ snapshots:
       '@unocss/transformer-compile-class': 0.59.4
       '@unocss/transformer-directives': 0.59.4
       '@unocss/transformer-variant-group': 0.59.4
-      '@unocss/vite': 0.59.4(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      '@unocss/vite': 0.59.4(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
     optionalDependencies:
       vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
     transitivePeerDependencies:
@@ -24934,12 +25826,34 @@ snapshots:
       - rollup
       - vue
 
-  unplugin-vue-router@0.7.0(rollup@4.21.2)(vue-router@4.3.2(vue@3.4.24(typescript@5.3.3)))(vue@3.4.24(typescript@5.3.3)):
+  unplugin-vue-router@0.10.7(rollup@4.26.0)(vue-router@4.4.3(vue@3.5.0(typescript@5.4.5)))(vue@3.5.0(typescript@5.4.5)):
+    dependencies:
+      '@babel/types': 7.25.6
+      '@rollup/pluginutils': 5.1.0(rollup@4.26.0)
+      '@vue-macros/common': 1.12.2(rollup@4.26.0)(vue@3.5.0(typescript@5.4.5))
+      ast-walker-scope: 0.6.2
+      chokidar: 3.6.0
+      fast-glob: 3.3.2
+      json5: 2.2.3
+      local-pkg: 0.5.0
+      magic-string: 0.30.11
+      mlly: 1.7.1
+      pathe: 1.1.2
+      scule: 1.3.0
+      unplugin: 1.12.3
+      yaml: 2.5.0
+    optionalDependencies:
+      vue-router: 4.4.3(vue@3.5.0(typescript@5.4.5))
+    transitivePeerDependencies:
+      - rollup
+      - vue
+
+  unplugin-vue-router@0.7.0(rollup@4.26.0)(vue-router@4.3.2(vue@3.4.24(typescript@5.3.3)))(vue@3.4.24(typescript@5.3.3)):
     dependencies:
       '@babel/types': 7.24.0
-      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
-      '@vue-macros/common': 1.10.2(rollup@4.21.2)(vue@3.4.24(typescript@5.3.3))
-      ast-walker-scope: 0.5.0(rollup@4.21.2)
+      '@rollup/pluginutils': 5.1.0(rollup@4.26.0)
+      '@vue-macros/common': 1.10.2(rollup@4.26.0)(vue@3.4.24(typescript@5.3.3))
+      ast-walker-scope: 0.5.0(rollup@4.26.0)
       chokidar: 3.6.0
       fast-glob: 3.3.2
       json5: 2.2.3
@@ -25133,7 +26047,7 @@ snapshots:
       unctx: 2.3.1
       unenv: 1.9.0
       unstorage: 1.10.2(ioredis@5.4.1)
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
       zod: 3.22.4
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -25200,7 +26114,7 @@ snapshots:
       unctx: 2.3.1
       unenv: 1.9.0
       unstorage: 1.10.2(ioredis@5.4.1)
-      vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
       zod: 3.22.4
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -25233,13 +26147,17 @@ snapshots:
       - uWebSockets.js
       - xml2js
 
+  vite-hot-client@0.2.3(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)):
+    dependencies:
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
+
+  vite-hot-client@0.2.3(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0)):
+    dependencies:
+      vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
+
   vite-hot-client@0.2.3(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
       vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
-
-  vite-hot-client@0.2.3(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)):
-    dependencies:
-      vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
 
   vite-node@1.5.0(@types/node@20.10.0)(terser@5.27.0):
     dependencies:
@@ -25247,7 +26165,7 @@ snapshots:
       debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.4.3(@types/node@20.10.0)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.10.0)(terser@5.27.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -25265,7 +26183,7 @@ snapshots:
       debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -25283,7 +26201,7 @@ snapshots:
       debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -25301,7 +26219,7 @@ snapshots:
       debug: 4.3.6
       pathe: 1.1.2
       tinyrainbow: 1.2.0
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -25319,7 +26237,7 @@ snapshots:
       debug: 4.3.6
       pathe: 1.1.2
       tinyrainbow: 1.2.0
-      vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -25331,7 +26249,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-checker@0.6.4(eslint@8.56.0)(optionator@0.9.3)(typescript@5.3.3)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
+  vite-plugin-checker@0.6.4(eslint@8.56.0)(optionator@0.9.3)(typescript@5.3.3)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
       '@babel/code-frame': 7.24.2
       ansi-escapes: 4.3.2
@@ -25344,7 +26262,7 @@ snapshots:
       semver: 7.6.3
       strip-ansi: 6.0.1
       tiny-invariant: 1.3.3
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
       vscode-languageclient: 7.0.0
       vscode-languageserver: 7.0.0
       vscode-languageserver-textdocument: 1.0.11
@@ -25354,7 +26272,7 @@ snapshots:
       optionator: 0.9.3
       typescript: 5.3.3
 
-  vite-plugin-checker@0.7.2(eslint@8.56.0)(optionator@0.9.3)(typescript@5.4.5)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
+  vite-plugin-checker@0.7.2(eslint@8.56.0)(optionator@0.9.3)(typescript@5.4.5)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
       '@babel/code-frame': 7.24.7
       ansi-escapes: 4.3.2
@@ -25366,7 +26284,7 @@ snapshots:
       npm-run-path: 4.0.1
       strip-ansi: 6.0.1
       tiny-invariant: 1.3.3
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
       vscode-languageclient: 7.0.0
       vscode-languageserver: 7.0.0
       vscode-languageserver-textdocument: 1.0.11
@@ -25376,7 +26294,7 @@ snapshots:
       optionator: 0.9.3
       typescript: 5.4.5
 
-  vite-plugin-checker@0.7.2(eslint@8.56.0)(optionator@0.9.3)(typescript@5.4.5)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)):
+  vite-plugin-checker@0.7.2(eslint@8.56.0)(optionator@0.9.3)(typescript@5.4.5)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0)):
     dependencies:
       '@babel/code-frame': 7.24.7
       ansi-escapes: 4.3.2
@@ -25388,7 +26306,7 @@ snapshots:
       npm-run-path: 4.0.1
       strip-ansi: 6.0.1
       tiny-invariant: 1.3.3
-      vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
       vscode-languageclient: 7.0.0
       vscode-languageserver: 7.0.0
       vscode-languageserver-textdocument: 1.0.11
@@ -25398,7 +26316,7 @@ snapshots:
       optionator: 0.9.3
       typescript: 5.4.5
 
-  vite-plugin-inspect@0.7.42(rollup@3.29.4)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
+  vite-plugin-inspect@0.7.42(rollup@3.29.4)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
       '@antfu/utils': 0.7.7
       '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
@@ -25408,15 +26326,45 @@ snapshots:
       open: 9.1.0
       picocolors: 1.0.0
       sirv: 2.0.4
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@0.7.42(rollup@4.21.2)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)):
+  vite-plugin-inspect@0.7.42(rollup@4.21.2)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0)):
     dependencies:
       '@antfu/utils': 0.7.7
       '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      debug: 4.3.4
+      error-stack-parser-es: 0.1.1
+      fs-extra: 11.2.0
+      open: 9.1.0
+      picocolors: 1.0.0
+      sirv: 2.0.4
+      vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+
+  vite-plugin-inspect@0.7.42(rollup@4.26.0)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0)):
+    dependencies:
+      '@antfu/utils': 0.7.7
+      '@rollup/pluginutils': 5.1.0(rollup@4.26.0)
+      debug: 4.3.4
+      error-stack-parser-es: 0.1.1
+      fs-extra: 11.2.0
+      open: 9.1.0
+      picocolors: 1.0.0
+      sirv: 2.0.4
+      vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+
+  vite-plugin-inspect@0.7.42(rollup@4.26.0)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)):
+    dependencies:
+      '@antfu/utils': 0.7.7
+      '@rollup/pluginutils': 5.1.0(rollup@4.26.0)
       debug: 4.3.4
       error-stack-parser-es: 0.1.1
       fs-extra: 11.2.0
@@ -25428,10 +26376,10 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@0.8.4(@nuxt/kit@3.11.2(rollup@4.21.2))(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
+  vite-plugin-inspect@0.8.4(@nuxt/kit@3.11.2(rollup@4.26.0))(rollup@4.26.0)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
       '@antfu/utils': 0.7.7
-      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      '@rollup/pluginutils': 5.1.0(rollup@4.26.0)
       debug: 4.3.4
       error-stack-parser-es: 0.1.1
       fs-extra: 11.2.0
@@ -25441,12 +26389,12 @@ snapshots:
       sirv: 2.0.4
       vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
     optionalDependencies:
-      '@nuxt/kit': 3.11.2(rollup@4.21.2)
+      '@nuxt/kit': 3.11.2(rollup@4.26.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@0.8.7(@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@3.29.4))(rollup@3.29.4)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
+  vite-plugin-inspect@0.8.7(@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@3.29.4))(rollup@3.29.4)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
@@ -25457,14 +26405,14 @@ snapshots:
       perfect-debounce: 1.0.0
       picocolors: 1.0.1
       sirv: 2.0.4
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
     optionalDependencies:
       '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@3.29.4)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@0.8.7(@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@4.21.2))(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
+  vite-plugin-inspect@0.8.7(@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@4.21.2))(rollup@4.21.2)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0)):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
@@ -25475,17 +26423,17 @@ snapshots:
       perfect-debounce: 1.0.0
       picocolors: 1.0.1
       sirv: 2.0.4
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
     optionalDependencies:
       '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.21.2)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@0.8.7(@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@4.21.2))(rollup@4.21.2)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)):
+  vite-plugin-inspect@0.8.7(@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@4.26.0))(rollup@4.26.0)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
       '@antfu/utils': 0.7.10
-      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      '@rollup/pluginutils': 5.1.0(rollup@4.26.0)
       debug: 4.3.6
       error-stack-parser-es: 0.1.5
       fs-extra: 11.2.0
@@ -25493,14 +26441,14 @@ snapshots:
       perfect-debounce: 1.0.0
       picocolors: 1.0.1
       sirv: 2.0.4
-      vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
     optionalDependencies:
-      '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.21.2)
+      '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.26.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  vite-plugin-solid@2.10.2(solid-js@1.8.19)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
+  vite-plugin-solid@2.10.2(solid-js@1.8.19)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
       '@babel/core': 7.24.4
       '@types/babel__core': 7.20.5
@@ -25508,8 +26456,21 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.8.19
       solid-refresh: 0.6.3(solid-js@1.8.19)
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
-      vitefu: 0.2.5(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
+      vitefu: 0.2.5(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0))
+    transitivePeerDependencies:
+      - supports-color
+
+  vite-plugin-solid@2.10.2(solid-js@1.8.19)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0)):
+    dependencies:
+      '@babel/core': 7.24.4
+      '@types/babel__core': 7.20.5
+      babel-preset-solid: 1.8.19(@babel/core@7.24.4)
+      merge-anything: 5.1.7
+      solid-js: 1.8.19
+      solid-refresh: 0.6.3(solid-js@1.8.19)
+      vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
+      vitefu: 0.2.5(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -25541,7 +26502,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-inspector@5.2.0(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
+  vite-plugin-vue-inspector@5.2.0(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
       '@babel/core': 7.24.4
       '@babel/plugin-proposal-decorators': 7.24.1(@babel/core@7.24.4)
@@ -25552,11 +26513,11 @@ snapshots:
       '@vue/compiler-dom': 3.4.24
       kolorist: 1.8.0
       magic-string: 0.30.11
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-inspector@5.2.0(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)):
+  vite-plugin-vue-inspector@5.2.0(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0)):
     dependencies:
       '@babel/core': 7.24.4
       '@babel/plugin-proposal-decorators': 7.24.1(@babel/core@7.24.4)
@@ -25567,17 +26528,28 @@ snapshots:
       '@vue/compiler-dom': 3.4.24
       kolorist: 1.8.0
       magic-string: 0.30.11
-      vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
     transitivePeerDependencies:
       - supports-color
 
-  vite-tsconfig-paths@4.3.2(typescript@5.3.3)(vite@5.4.3(@types/node@20.10.0)(terser@5.27.0)):
+  vite-tsconfig-paths@4.3.2(typescript@5.3.3)(vite@5.4.11(@types/node@20.10.0)(terser@5.27.0)):
     dependencies:
       debug: 4.3.4
       globrex: 0.1.2
       tsconfck: 3.0.3(typescript@5.3.3)
     optionalDependencies:
-      vite: 5.4.3(@types/node@20.10.0)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.10.0)(terser@5.27.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  vite-tsconfig-paths@4.3.2(typescript@5.3.3)(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)):
+    dependencies:
+      debug: 4.3.4
+      globrex: 0.1.2
+      tsconfck: 3.0.3(typescript@5.3.3)
+    optionalDependencies:
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -25589,6 +26561,17 @@ snapshots:
       tsconfck: 3.0.3(typescript@5.3.3)
     optionalDependencies:
       vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  vite-tsconfig-paths@4.3.2(typescript@5.4.5)(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0)):
+    dependencies:
+      debug: 4.3.4
+      globrex: 0.1.2
+      tsconfck: 3.0.3(typescript@5.4.5)
+    optionalDependencies:
+      vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -25624,13 +26607,33 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.27.0
 
-  vite@5.4.3(@types/node@20.10.0)(terser@5.27.0):
+  vite@5.4.11(@types/node@20.10.0)(terser@5.27.0):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.4.44
-      rollup: 4.21.2
+      postcss: 8.4.49
+      rollup: 4.26.0
     optionalDependencies:
       '@types/node': 20.10.0
+      fsevents: 2.3.3
+      terser: 5.27.0
+
+  vite@5.4.11(@types/node@20.11.15)(terser@5.27.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.4.49
+      rollup: 4.26.0
+    optionalDependencies:
+      '@types/node': 20.11.15
+      fsevents: 2.3.3
+      terser: 5.27.0
+
+  vite@5.4.11(@types/node@20.12.12)(terser@5.27.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.4.49
+      rollup: 4.26.0
+    optionalDependencies:
+      '@types/node': 20.12.12
       fsevents: 2.3.3
       terser: 5.27.0
 
@@ -25653,6 +26656,14 @@ snapshots:
       '@types/node': 20.12.12
       fsevents: 2.3.3
       terser: 5.27.0
+
+  vitefu@0.2.5(vite@5.4.11(@types/node@20.11.15)(terser@5.27.0)):
+    optionalDependencies:
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
+
+  vitefu@0.2.5(vite@5.4.11(@types/node@20.12.12)(terser@5.27.0)):
+    optionalDependencies:
+      vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
 
   vitefu@0.2.5(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
     optionalDependencies:
@@ -25681,7 +26692,7 @@ snapshots:
       strip-literal: 2.1.0
       tinybench: 2.7.0
       tinypool: 0.8.4
-      vite: 5.4.3(@types/node@20.10.0)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.10.0)(terser@5.27.0)
       vite-node: 1.5.0(@types/node@20.10.0)(terser@5.27.0)
       why-is-node-running: 2.2.2
     optionalDependencies:
@@ -25715,7 +26726,7 @@ snapshots:
       strip-literal: 2.1.0
       tinybench: 2.7.0
       tinypool: 0.8.4
-      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.11.15)(terser@5.27.0)
       vite-node: 1.5.0(@types/node@20.11.15)(terser@5.27.0)
       why-is-node-running: 2.2.2
     optionalDependencies:
@@ -25749,7 +26760,7 @@ snapshots:
       strip-literal: 2.1.0
       tinybench: 2.7.0
       tinypool: 0.8.4
-      vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+      vite: 5.4.11(@types/node@20.12.12)(terser@5.27.0)
       vite-node: 1.5.0(@types/node@20.12.12)(terser@5.27.0)
       why-is-node-running: 2.2.2
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,11 +57,11 @@ importers:
         specifier: ^5.3.3
         version: 5.3.3
       vite:
-        specifier: ^5.2.10
-        version: 5.2.10(@types/node@20.11.15)(terser@5.27.0)
+        specifier: ^5.3.6
+        version: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.3.3)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+        version: 4.3.2(typescript@5.3.3)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
       vitest:
         specifier: ^1.5.0
         version: 1.5.0(@types/node@20.11.15)(terser@5.27.0)
@@ -232,7 +232,7 @@ importers:
         specifier: ^5.3.3
         version: 5.4.5
       vite:
-        specifier: ^5.2.10
+        specifier: ^5.2.14
         version: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
 
   examples/remix:
@@ -261,7 +261,7 @@ importers:
         version: link:../../packages/remix-vite-plugin
       '@remix-run/dev':
         specifier: ^2.9.2
-        version: 2.9.2(@remix-run/react@2.9.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5))(@remix-run/serve@2.9.2(typescript@5.4.5))(@types/node@20.12.12)(terser@5.27.0)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))(typescript@5.4.5)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))
+        version: 2.9.2(@remix-run/react@2.9.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5))(@remix-run/serve@2.9.2(typescript@5.4.5))(@types/node@20.12.12)(terser@5.27.0)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))(typescript@5.4.5)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
       '@types/react':
         specifier: ^18.2.20
         version: 18.3.3
@@ -305,11 +305,11 @@ importers:
         specifier: ^5.1.6
         version: 5.4.5
       vite:
-        specifier: ^5.1.0
-        version: 5.2.10(@types/node@20.12.12)(terser@5.27.0)
+        specifier: ^5.1.8
+        version: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
       vite-tsconfig-paths:
         specifier: ^4.2.1
-        version: 4.3.2(typescript@5.4.5)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))
+        version: 4.3.2(typescript@5.4.5)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
 
   examples/rollup:
     dependencies:
@@ -373,13 +373,13 @@ importers:
         version: 1.0.0
       '@sveltejs/adapter-auto':
         specifier: ^3.0.0
-        version: 3.2.0(@sveltejs/kit@2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0)))
+        version: 3.2.0(@sveltejs/kit@2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)))
       '@sveltejs/kit':
         specifier: ^2.5.25
-        version: 2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))
+        version: 2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.0.0
-        version: 3.1.0(svelte@4.2.15)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))
+        version: 3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
       svelte:
         specifier: ^4.2.7
         version: 4.2.15
@@ -393,8 +393,8 @@ importers:
         specifier: ^5.0.0
         version: 5.3.3
       vite:
-        specifier: ^5.0.3
-        version: 5.2.10(@types/node@20.12.12)(terser@5.27.0)
+        specifier: ^5.1.8
+        version: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
 
   examples/tokenless:
     dependencies:
@@ -422,7 +422,7 @@ importers:
         version: 6.20.0(eslint@8.56.0)(typescript@5.4.5)
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.2.1(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))
+        version: 4.2.1(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
@@ -439,8 +439,8 @@ importers:
         specifier: ^5.3.3
         version: 5.4.5
       vite:
-        specifier: ^5.2.10
-        version: 5.2.10(@types/node@20.12.12)(terser@5.27.0)
+        specifier: ^5.2.14
+        version: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
 
   examples/vite:
     dependencies:
@@ -468,7 +468,7 @@ importers:
         version: 6.20.0(eslint@8.56.0)(typescript@5.3.3)
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.2.1(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))
+        version: 4.2.1(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
@@ -485,8 +485,8 @@ importers:
         specifier: ^5.3.3
         version: 5.3.3
       vite:
-        specifier: ^5.2.10
-        version: 5.2.10(@types/node@20.12.12)(terser@5.27.0)
+        specifier: ^5.2.14
+        version: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
 
   examples/webpack:
     dependencies:
@@ -616,8 +616,8 @@ importers:
         specifier: ^5.0.2
         version: 5.4.5
       vite:
-        specifier: npm:vite@4.5.3
-        version: 4.5.3(@types/node@20.12.12)(terser@5.27.0)
+        specifier: ^5.2.14
+        version: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
 
   integration-tests/test-apps/nextjs:
     dependencies:
@@ -651,7 +651,7 @@ importers:
     dependencies:
       nuxt:
         specifier: ^3.12.4
-        version: 3.12.4(@parcel/watcher@2.4.1)(@types/node@20.12.12)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.4.5)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+        version: 3.12.4(@parcel/watcher@2.4.1)(@types/node@20.12.12)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.4.5)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
       vue:
         specifier: ^3.4.21
         version: 3.4.24(typescript@5.4.5)
@@ -689,7 +689,7 @@ importers:
         version: link:../../../packages/remix-vite-plugin
       '@remix-run/dev':
         specifier: ^2.9.2
-        version: 2.9.2(@remix-run/react@2.9.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5))(@remix-run/serve@2.9.2(typescript@5.4.5))(@types/node@20.12.12)(terser@5.27.0)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))(typescript@5.4.5)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))
+        version: 2.9.2(@remix-run/react@2.9.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5))(@remix-run/serve@2.9.2(typescript@5.4.5))(@types/node@20.12.12)(terser@5.27.0)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))(typescript@5.4.5)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
       '@types/react':
         specifier: ^18.2.20
         version: 18.3.3
@@ -733,11 +733,11 @@ importers:
         specifier: ^5.1.6
         version: 5.4.5
       vite:
-        specifier: ^5.1.0
-        version: 5.2.10(@types/node@20.12.12)(terser@5.27.0)
+        specifier: ^5.1.8
+        version: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
       vite-tsconfig-paths:
         specifier: ^4.2.1
-        version: 4.3.2(typescript@5.4.5)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))
+        version: 4.3.2(typescript@5.4.5)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
 
   integration-tests/test-apps/solidstart:
     dependencies:
@@ -773,19 +773,19 @@ importers:
         version: 1.0.0
       '@sveltejs/adapter-auto':
         specifier: ^3.0.0
-        version: 3.2.0(@sveltejs/kit@2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0)))
+        version: 3.2.0(@sveltejs/kit@2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)))
       '@sveltejs/kit':
         specifier: ^2.5.25
-        version: 2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))
+        version: 2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.0.0
-        version: 3.1.0(svelte@4.2.15)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))
+        version: 3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
       svelte:
         specifier: ^4.2.7
         version: 4.2.15
       vite:
-        specifier: ^5.0.3
-        version: 5.2.10(@types/node@20.12.12)(terser@5.27.0)
+        specifier: ^5.1.8
+        version: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
 
   packages/bundle-analyzer:
     dependencies:
@@ -830,7 +830,7 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(typescript@5.4.5)
       vite:
-        specifier: ^5.2.10
+        specifier: ^5.2.14
         version: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
       vite-tsconfig-paths:
         specifier: ^4.3.2
@@ -971,7 +971,7 @@ importers:
         version: 3.11.2(rollup@4.21.2)
       nuxt:
         specifier: 3.x
-        version: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+        version: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
       unplugin:
         specifier: ^1.10.1
         version: 1.10.1
@@ -1004,11 +1004,11 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(typescript@5.3.3)
       vite:
-        specifier: ^5.2.10
-        version: 5.2.10(@types/node@20.11.15)(terser@5.27.0)
+        specifier: ^5.2.14
+        version: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.3.3)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+        version: 4.3.2(typescript@5.3.3)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
       vitest:
         specifier: ^1.5.0
         version: 1.5.0(@types/node@20.11.15)(terser@5.27.0)
@@ -1056,11 +1056,11 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(typescript@5.4.5)
       vite:
-        specifier: ^5.2.10
-        version: 5.2.10(@types/node@20.12.12)(terser@5.27.0)
+        specifier: ^5.2.14
+        version: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.4.5)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))
+        version: 4.3.2(typescript@5.4.5)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
       vitest:
         specifier: ^1.5.0
         version: 1.5.0(@types/node@20.12.12)(terser@5.27.0)
@@ -1121,7 +1121,7 @@ importers:
         version: link:../vite-plugin
       '@solidjs/start':
         specifier: 1.x
-        version: 1.0.6(rollup@4.21.2)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))
+        version: 1.0.6(rollup@4.21.2)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
       unplugin:
         specifier: ^1.10.1
         version: 1.10.1
@@ -1154,11 +1154,11 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(typescript@5.4.5)
       vite:
-        specifier: ^5.2.10
-        version: 5.2.10(@types/node@20.12.12)(terser@5.27.0)
+        specifier: ^5.2.14
+        version: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.4.5)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))
+        version: 4.3.2(typescript@5.4.5)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
       vitest:
         specifier: ^1.5.0
         version: 1.5.0(@types/node@20.12.12)(terser@5.27.0)
@@ -1173,7 +1173,7 @@ importers:
         version: link:../vite-plugin
       '@sveltejs/kit':
         specifier: 2.x
-        version: 2.5.7(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(svelte@4.2.15)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+        version: 2.5.7(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
       svelte:
         specifier: 4.x
         version: 4.2.15
@@ -1209,11 +1209,11 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(typescript@5.3.3)
       vite:
-        specifier: ^5.2.10
-        version: 5.2.10(@types/node@20.11.15)(terser@5.27.0)
+        specifier: ^5.2.14
+        version: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.3.3)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+        version: 4.3.2(typescript@5.3.3)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
       vitest:
         specifier: ^1.5.0
         version: 1.5.0(@types/node@20.11.15)(terser@5.27.0)
@@ -1255,11 +1255,11 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(typescript@5.3.3)
       vite:
-        specifier: ^5.2.10
-        version: 5.2.10(@types/node@20.11.15)(terser@5.27.0)
+        specifier: ^5.2.14
+        version: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 4.3.2(typescript@5.3.3)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+        version: 4.3.2(typescript@5.3.3)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
       vitest:
         specifier: ^1.5.0
         version: 1.5.0(@types/node@20.11.15)(terser@5.27.0)
@@ -14090,13 +14090,13 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@1.2.0(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))':
+  '@nuxt/devtools-kit@1.2.0(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))':
     dependencies:
       '@nuxt/kit': 3.11.2(rollup@4.21.2)
       '@nuxt/schema': 3.11.2(rollup@4.21.2)
       execa: 7.2.0
-      nuxt: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
-      vite: 5.2.10(@types/node@20.11.15)(terser@5.27.0)
+      nuxt: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -14112,12 +14112,12 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/devtools-kit@1.4.1(magicast@0.3.4)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))':
+  '@nuxt/devtools-kit@1.4.1(magicast@0.3.4)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))':
     dependencies:
       '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.21.2)
       '@nuxt/schema': 3.13.0(rollup@4.21.2)
       execa: 7.2.0
-      vite: 5.2.10(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
     transitivePeerDependencies:
       - magicast
       - rollup
@@ -14160,14 +14160,14 @@ snapshots:
       rc9: 2.1.2
       semver: 7.6.3
 
-  '@nuxt/devtools@1.2.0(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.21.2)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))':
+  '@nuxt/devtools@1.2.0(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.21.2)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))':
     dependencies:
       '@antfu/utils': 0.7.7
-      '@nuxt/devtools-kit': 1.2.0(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+      '@nuxt/devtools-kit': 1.2.0(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
       '@nuxt/devtools-wizard': 1.2.0
       '@nuxt/kit': 3.11.2(rollup@4.21.2)
-      '@vue/devtools-applet': 7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
-      '@vue/devtools-core': 7.0.27(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
+      '@vue/devtools-applet': 7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
+      '@vue/devtools-core': 7.0.27(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
       '@vue/devtools-kit': 7.0.27(vue@3.4.24(typescript@5.3.3))
       birpc: 0.2.17
       consola: 3.2.3
@@ -14184,7 +14184,7 @@ snapshots:
       launch-editor: 2.6.1
       local-pkg: 0.5.0
       magicast: 0.3.4
-      nuxt: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+      nuxt: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
       nypm: 0.3.8
       ohash: 1.1.3
       pacote: 18.0.0
@@ -14197,9 +14197,9 @@ snapshots:
       simple-git: 3.24.0
       sirv: 2.0.4
       unimport: 3.7.1(rollup@4.21.2)
-      vite: 5.2.10(@types/node@20.11.15)(terser@5.27.0)
-      vite-plugin-inspect: 0.8.4(@nuxt/kit@3.11.2(rollup@4.21.2))(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
-      vite-plugin-vue-inspector: 4.0.2(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+      vite-plugin-inspect: 0.8.4(@nuxt/kit@3.11.2(rollup@4.21.2))(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      vite-plugin-vue-inspector: 4.0.2(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
       which: 3.0.1
       ws: 8.16.0
     transitivePeerDependencies:
@@ -14271,13 +14271,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@nuxt/devtools@1.4.1(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))':
+  '@nuxt/devtools@1.4.1(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))':
     dependencies:
       '@antfu/utils': 0.7.10
-      '@nuxt/devtools-kit': 1.4.1(magicast@0.3.4)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+      '@nuxt/devtools-kit': 1.4.1(magicast@0.3.4)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
       '@nuxt/devtools-wizard': 1.4.1
       '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.21.2)
-      '@vue/devtools-core': 7.3.3(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+      '@vue/devtools-core': 7.3.3(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
       '@vue/devtools-kit': 7.3.3
       birpc: 0.2.17
       consola: 3.2.3
@@ -14306,9 +14306,9 @@ snapshots:
       sirv: 2.0.4
       tinyglobby: 0.2.5
       unimport: 3.11.1(rollup@4.21.2)
-      vite: 5.2.10(@types/node@20.11.15)(terser@5.27.0)
-      vite-plugin-inspect: 0.8.7(@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@4.21.2))(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
-      vite-plugin-vue-inspector: 5.2.0(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
+      vite-plugin-inspect: 0.8.7(@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@4.21.2))(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+      vite-plugin-vue-inspector: 5.2.0(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
       which: 3.0.1
       ws: 8.18.0
     transitivePeerDependencies:
@@ -15091,7 +15091,7 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  '@remix-run/dev@2.9.2(@remix-run/react@2.9.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5))(@remix-run/serve@2.9.2(typescript@5.4.5))(@types/node@20.12.12)(terser@5.27.0)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))(typescript@5.4.5)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))':
+  '@remix-run/dev@2.9.2(@remix-run/react@2.9.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.4.5))(@remix-run/serve@2.9.2(typescript@5.4.5))(@types/node@20.12.12)(terser@5.27.0)(ts-node@10.9.2(@types/node@20.12.12)(typescript@5.4.5))(typescript@5.4.5)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))':
     dependencies:
       '@babel/core': 7.24.4
       '@babel/generator': 7.24.4
@@ -15150,7 +15150,7 @@ snapshots:
     optionalDependencies:
       '@remix-run/serve': 2.9.2(typescript@5.4.5)
       typescript: 5.4.5
-      vite: 5.2.10(@types/node@20.12.12)(terser@5.27.0)
+      vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -15676,32 +15676,6 @@ snapshots:
       - vinxi
       - vite
 
-  '@solidjs/start@1.0.6(rollup@4.21.2)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))':
-    dependencies:
-      '@vinxi/plugin-directives': 0.4.1(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))
-      '@vinxi/server-components': 0.4.1(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))
-      '@vinxi/server-functions': 0.4.1(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))
-      defu: 6.1.4
-      error-stack-parser: 2.1.4
-      glob: 10.3.10
-      html-to-image: 1.11.11
-      radix3: 1.1.2
-      seroval: 1.1.0
-      seroval-plugins: 1.1.0(seroval@1.1.0)
-      shikiji: 0.9.19
-      source-map-js: 1.2.0
-      terracotta: 1.0.5(solid-js@1.8.19)
-      vite-plugin-inspect: 0.7.42(rollup@4.21.2)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))
-      vite-plugin-solid: 2.10.2(solid-js@1.8.19)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))
-    transitivePeerDependencies:
-      - '@nuxt/kit'
-      - '@testing-library/jest-dom'
-      - rollup
-      - solid-js
-      - supports-color
-      - vinxi
-      - vite
-
   '@solidjs/start@1.0.6(rollup@4.21.2)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))':
     dependencies:
       '@vinxi/plugin-directives': 0.4.1(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))
@@ -15728,28 +15702,10 @@ snapshots:
       - vinxi
       - vite
 
-  '@sveltejs/adapter-auto@3.2.0(@sveltejs/kit@2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0)))':
+  '@sveltejs/adapter-auto@3.2.0(@sveltejs/kit@2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)))':
     dependencies:
-      '@sveltejs/kit': 2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))
+      '@sveltejs/kit': 2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
       import-meta-resolve: 4.1.0
-
-  '@sveltejs/kit@2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))':
-    dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.2.15)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))
-      '@types/cookie': 0.6.0
-      cookie: 0.6.0
-      devalue: 5.0.0
-      esm-env: 1.0.0
-      import-meta-resolve: 4.1.0
-      kleur: 4.1.5
-      magic-string: 0.30.11
-      mrmime: 2.0.0
-      sade: 1.8.1
-      set-cookie-parser: 2.6.0
-      sirv: 2.0.4
-      svelte: 4.2.15
-      tiny-glob: 0.2.9
-      vite: 5.2.10(@types/node@20.12.12)(terser@5.27.0)
 
   '@sveltejs/kit@2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))':
     dependencies:
@@ -15769,9 +15725,27 @@ snapshots:
       tiny-glob: 0.2.9
       vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
 
-  '@sveltejs/kit@2.5.7(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(svelte@4.2.15)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))':
+  '@sveltejs/kit@2.5.25(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.2.15)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+      '@types/cookie': 0.6.0
+      cookie: 0.6.0
+      devalue: 5.0.0
+      esm-env: 1.0.0
+      import-meta-resolve: 4.1.0
+      kleur: 4.1.5
+      magic-string: 0.30.11
+      mrmime: 2.0.0
+      sade: 1.8.1
+      set-cookie-parser: 2.6.0
+      sirv: 2.0.4
+      svelte: 4.2.15
+      tiny-glob: 0.2.9
+      vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+
+  '@sveltejs/kit@2.5.7(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.0.0
@@ -15785,25 +15759,7 @@ snapshots:
       sirv: 2.0.4
       svelte: 4.2.15
       tiny-glob: 0.2.9
-      vite: 5.2.10(@types/node@20.11.15)(terser@5.27.0)
-
-  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(svelte@4.2.15)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))':
-    dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.2.15)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
-      debug: 4.3.4
-      svelte: 4.2.15
-      vite: 5.2.10(@types/node@20.11.15)(terser@5.27.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))':
-    dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.2.15)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))
-      debug: 4.3.4
-      svelte: 4.2.15
-      vite: 5.2.10(@types/node@20.12.12)(terser@5.27.0)
-    transitivePeerDependencies:
-      - supports-color
+      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
 
   '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))':
     dependencies:
@@ -15814,31 +15770,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(svelte@4.2.15)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+      '@sveltejs/vite-plugin-svelte': 3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
       debug: 4.3.4
-      deepmerge: 4.3.1
-      kleur: 4.1.5
-      magic-string: 0.30.10
       svelte: 4.2.15
-      svelte-hmr: 0.16.0(svelte@4.2.15)
-      vite: 5.2.10(@types/node@20.11.15)(terser@5.27.0)
-      vitefu: 0.2.5(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
-    transitivePeerDependencies:
-      - supports-color
-
-  '@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))':
-    dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))
-      debug: 4.3.4
-      deepmerge: 4.3.1
-      kleur: 4.1.5
-      magic-string: 0.30.10
-      svelte: 4.2.15
-      svelte-hmr: 0.16.0(svelte@4.2.15)
-      vite: 5.2.10(@types/node@20.12.12)(terser@5.27.0)
-      vitefu: 0.2.5(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))
+      vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -15853,6 +15790,20 @@ snapshots:
       svelte-hmr: 0.16.0(svelte@4.2.15)
       vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
       vitefu: 0.2.5(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.0(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)))(svelte@4.2.15)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+      debug: 4.3.4
+      deepmerge: 4.3.1
+      kleur: 4.1.5
+      magic-string: 0.30.10
+      svelte: 4.2.15
+      svelte-hmr: 0.16.0(svelte@4.2.15)
+      vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
+      vitefu: 0.2.5(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -16257,13 +16208,13 @@ snapshots:
       unhead: 1.9.7
       vue: 3.4.24(typescript@5.3.3)
 
-  '@unocss/astro@0.59.4(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))':
+  '@unocss/astro@0.59.4(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))':
     dependencies:
       '@unocss/core': 0.59.4
       '@unocss/reset': 0.59.4
-      '@unocss/vite': 0.59.4(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+      '@unocss/vite': 0.59.4(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
     optionalDependencies:
-      vite: 5.2.10(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
     transitivePeerDependencies:
       - rollup
 
@@ -16394,7 +16345,7 @@ snapshots:
     dependencies:
       '@unocss/core': 0.59.4
 
-  '@unocss/vite@0.59.4(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))':
+  '@unocss/vite@0.59.4(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
@@ -16406,7 +16357,7 @@ snapshots:
       chokidar: 3.6.0
       fast-glob: 3.3.2
       magic-string: 0.30.11
-      vite: 5.2.10(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
     transitivePeerDependencies:
       - rollup
 
@@ -16615,17 +16566,6 @@ snapshots:
       magicast: 0.2.11
       recast: 0.23.9
       vinxi: 0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0)
-
-  '@vitejs/plugin-react@4.2.1(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))':
-    dependencies:
-      '@babel/core': 7.23.9
-      '@babel/plugin-transform-react-jsx-self': 7.23.3(@babel/core@7.23.9)
-      '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.23.9)
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.14.0
-      vite: 5.2.10(@types/node@20.12.12)(terser@5.27.0)
-    transitivePeerDependencies:
-      - supports-color
 
   '@vitejs/plugin-react@4.2.1(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))':
     dependencies:
@@ -16958,12 +16898,12 @@ snapshots:
 
   '@vue/devtools-api@6.6.3': {}
 
-  '@vue/devtools-applet@7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))':
+  '@vue/devtools-applet@7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))':
     dependencies:
-      '@vue/devtools-core': 7.0.27(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
+      '@vue/devtools-core': 7.0.27(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
       '@vue/devtools-kit': 7.0.27(vue@3.4.24(typescript@5.3.3))
       '@vue/devtools-shared': 7.0.27
-      '@vue/devtools-ui': 7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vue@3.4.24(typescript@5.3.3))
+      '@vue/devtools-ui': 7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vue@3.4.24(typescript@5.3.3))
       perfect-debounce: 1.0.0
       splitpanes: 3.1.5
       vue: 3.4.24(typescript@5.3.3)
@@ -16986,28 +16926,17 @@ snapshots:
       - unocss
       - vite
 
-  '@vue/devtools-core@7.0.27(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))':
+  '@vue/devtools-core@7.0.27(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))':
     dependencies:
       '@vue/devtools-kit': 7.0.27(vue@3.4.24(typescript@5.3.3))
       '@vue/devtools-shared': 7.0.27
       mitt: 3.0.1
       nanoid: 3.3.7
       pathe: 1.1.2
-      vite-hot-client: 0.2.3(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+      vite-hot-client: 0.2.3(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
     transitivePeerDependencies:
       - vite
       - vue
-
-  '@vue/devtools-core@7.3.3(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))':
-    dependencies:
-      '@vue/devtools-kit': 7.3.3
-      '@vue/devtools-shared': 7.4.0
-      mitt: 3.0.1
-      nanoid: 3.3.7
-      pathe: 1.1.2
-      vite-hot-client: 0.2.3(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
-    transitivePeerDependencies:
-      - vite
 
   '@vue/devtools-core@7.3.3(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))':
     dependencies:
@@ -17058,7 +16987,7 @@ snapshots:
     dependencies:
       rfdc: 1.4.1
 
-  '@vue/devtools-ui@7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vue@3.4.24(typescript@5.3.3))':
+  '@vue/devtools-ui@7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vue@3.4.24(typescript@5.3.3))':
     dependencies:
       '@unocss/reset': 0.59.4
       '@vueuse/components': 10.9.0(vue@3.4.24(typescript@5.3.3))
@@ -17067,7 +16996,7 @@ snapshots:
       colord: 2.9.3
       floating-vue: 5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3))
       focus-trap: 7.5.4
-      unocss: 0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+      unocss: 0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
       vue: 3.4.24(typescript@5.3.3)
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -21752,10 +21681,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)):
+  nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.2.0(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.21.2)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
+      '@nuxt/devtools': 1.2.0(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.21.2)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)))(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
       '@nuxt/kit': 3.11.2(rollup@4.21.2)
       '@nuxt/schema': 3.11.2(rollup@4.21.2)
       '@nuxt/telemetry': 2.5.4(rollup@4.21.2)
@@ -21976,10 +21905,10 @@ snapshots:
       - vue-tsc
       - xml2js
 
-  nuxt@3.12.4(@parcel/watcher@2.4.1)(@types/node@20.12.12)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.4.5)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)):
+  nuxt@3.12.4(@parcel/watcher@2.4.1)(@types/node@20.12.12)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.4.5)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.4.1(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+      '@nuxt/devtools': 1.4.1(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
       '@nuxt/kit': 3.12.4(magicast@0.3.4)(rollup@4.21.2)
       '@nuxt/schema': 3.12.4(rollup@4.21.2)
       '@nuxt/telemetry': 2.5.4(rollup@4.21.2)
@@ -24930,9 +24859,9 @@ snapshots:
 
   universalify@2.0.0: {}
 
-  unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)):
+  unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
-      '@unocss/astro': 0.59.4(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+      '@unocss/astro': 0.59.4(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
       '@unocss/cli': 0.59.4(rollup@4.21.2)
       '@unocss/core': 0.59.4
       '@unocss/extractor-arbitrary-variants': 0.59.4
@@ -24951,9 +24880,9 @@ snapshots:
       '@unocss/transformer-compile-class': 0.59.4
       '@unocss/transformer-directives': 0.59.4
       '@unocss/transformer-variant-group': 0.59.4
-      '@unocss/vite': 0.59.4(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+      '@unocss/vite': 0.59.4(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))
     optionalDependencies:
-      vite: 5.2.10(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
     transitivePeerDependencies:
       - postcss
       - rollup
@@ -25304,10 +25233,6 @@ snapshots:
       - uWebSockets.js
       - xml2js
 
-  vite-hot-client@0.2.3(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)):
-    dependencies:
-      vite: 5.2.10(@types/node@20.11.15)(terser@5.27.0)
-
   vite-hot-client@0.2.3(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
       vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
@@ -25488,21 +25413,6 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@0.7.42(rollup@4.21.2)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0)):
-    dependencies:
-      '@antfu/utils': 0.7.7
-      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
-      debug: 4.3.4
-      error-stack-parser-es: 0.1.1
-      fs-extra: 11.2.0
-      open: 9.1.0
-      picocolors: 1.0.0
-      sirv: 2.0.4
-      vite: 5.2.10(@types/node@20.12.12)(terser@5.27.0)
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-
   vite-plugin-inspect@0.7.42(rollup@4.21.2)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)):
     dependencies:
       '@antfu/utils': 0.7.7
@@ -25518,7 +25428,7 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@0.8.4(@nuxt/kit@3.11.2(rollup@4.21.2))(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)):
+  vite-plugin-inspect@0.8.4(@nuxt/kit@3.11.2(rollup@4.21.2))(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
       '@antfu/utils': 0.7.7
       '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
@@ -25529,7 +25439,7 @@ snapshots:
       perfect-debounce: 1.0.0
       picocolors: 1.0.1
       sirv: 2.0.4
-      vite: 5.2.10(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
     optionalDependencies:
       '@nuxt/kit': 3.11.2(rollup@4.21.2)
     transitivePeerDependencies:
@@ -25554,7 +25464,7 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@0.8.7(@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@4.21.2))(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)):
+  vite-plugin-inspect@0.8.7(@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@4.21.2))(rollup@4.21.2)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
@@ -25565,7 +25475,7 @@ snapshots:
       perfect-debounce: 1.0.0
       picocolors: 1.0.1
       sirv: 2.0.4
-      vite: 5.2.10(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
     optionalDependencies:
       '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.21.2)
     transitivePeerDependencies:
@@ -25588,19 +25498,6 @@ snapshots:
       '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.21.2)
     transitivePeerDependencies:
       - rollup
-      - supports-color
-
-  vite-plugin-solid@2.10.2(solid-js@1.8.19)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0)):
-    dependencies:
-      '@babel/core': 7.24.4
-      '@types/babel__core': 7.20.5
-      babel-preset-solid: 1.8.19(@babel/core@7.24.4)
-      merge-anything: 5.1.7
-      solid-js: 1.8.19
-      solid-refresh: 0.6.3(solid-js@1.8.19)
-      vite: 5.2.10(@types/node@20.12.12)(terser@5.27.0)
-      vitefu: 0.2.5(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))
-    transitivePeerDependencies:
       - supports-color
 
   vite-plugin-solid@2.10.2(solid-js@1.8.19)(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
@@ -25629,7 +25526,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-inspector@4.0.2(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)):
+  vite-plugin-vue-inspector@4.0.2(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
       '@babel/core': 7.24.4
       '@babel/plugin-proposal-decorators': 7.24.1(@babel/core@7.24.4)
@@ -25640,22 +25537,7 @@ snapshots:
       '@vue/compiler-dom': 3.4.24
       kolorist: 1.8.0
       magic-string: 0.30.11
-      vite: 5.2.10(@types/node@20.11.15)(terser@5.27.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  vite-plugin-vue-inspector@5.2.0(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)):
-    dependencies:
-      '@babel/core': 7.24.4
-      '@babel/plugin-proposal-decorators': 7.24.1(@babel/core@7.24.4)
-      '@babel/plugin-syntax-import-attributes': 7.24.7(@babel/core@7.24.4)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.24.4)
-      '@babel/plugin-transform-typescript': 7.24.4(@babel/core@7.24.4)
-      '@vue/babel-plugin-jsx': 1.2.2(@babel/core@7.24.4)
-      '@vue/compiler-dom': 3.4.24
-      kolorist: 1.8.0
-      magic-string: 0.30.11
-      vite: 5.2.10(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -25689,17 +25571,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-tsconfig-paths@4.3.2(typescript@5.3.3)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)):
-    dependencies:
-      debug: 4.3.4
-      globrex: 0.1.2
-      tsconfck: 3.0.3(typescript@5.3.3)
-    optionalDependencies:
-      vite: 5.2.10(@types/node@20.11.15)(terser@5.27.0)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   vite-tsconfig-paths@4.3.2(typescript@5.3.3)(vite@5.4.3(@types/node@20.10.0)(terser@5.27.0)):
     dependencies:
       debug: 4.3.4
@@ -25718,17 +25589,6 @@ snapshots:
       tsconfck: 3.0.3(typescript@5.3.3)
     optionalDependencies:
       vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
-  vite-tsconfig-paths@4.3.2(typescript@5.4.5)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0)):
-    dependencies:
-      debug: 4.3.4
-      globrex: 0.1.2
-      tsconfck: 3.0.3(typescript@5.4.5)
-    optionalDependencies:
-      vite: 5.2.10(@types/node@20.12.12)(terser@5.27.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -25754,26 +25614,6 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.27.0
 
-  vite@4.5.3(@types/node@20.12.12)(terser@5.27.0):
-    dependencies:
-      esbuild: 0.18.20
-      postcss: 8.4.44
-      rollup: 3.29.4
-    optionalDependencies:
-      '@types/node': 20.12.12
-      fsevents: 2.3.3
-      terser: 5.27.0
-
-  vite@5.2.10(@types/node@20.10.0)(terser@5.27.0):
-    dependencies:
-      esbuild: 0.20.2
-      postcss: 8.4.38
-      rollup: 4.16.2
-    optionalDependencies:
-      '@types/node': 20.10.0
-      fsevents: 2.3.3
-      terser: 5.27.0
-
   vite@5.2.10(@types/node@20.11.15)(terser@5.27.0):
     dependencies:
       esbuild: 0.20.2
@@ -25781,16 +25621,6 @@ snapshots:
       rollup: 4.16.2
     optionalDependencies:
       '@types/node': 20.11.15
-      fsevents: 2.3.3
-      terser: 5.27.0
-
-  vite@5.2.10(@types/node@20.12.12)(terser@5.27.0):
-    dependencies:
-      esbuild: 0.20.2
-      postcss: 8.4.38
-      rollup: 4.16.2
-    optionalDependencies:
-      '@types/node': 20.12.12
       fsevents: 2.3.3
       terser: 5.27.0
 
@@ -25824,14 +25654,6 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.27.0
 
-  vitefu@0.2.5(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)):
-    optionalDependencies:
-      vite: 5.2.10(@types/node@20.11.15)(terser@5.27.0)
-
-  vitefu@0.2.5(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0)):
-    optionalDependencies:
-      vite: 5.2.10(@types/node@20.12.12)(terser@5.27.0)
-
   vitefu@0.2.5(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0)):
     optionalDependencies:
       vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
@@ -25859,7 +25681,7 @@ snapshots:
       strip-literal: 2.1.0
       tinybench: 2.7.0
       tinypool: 0.8.4
-      vite: 5.2.10(@types/node@20.10.0)(terser@5.27.0)
+      vite: 5.4.3(@types/node@20.10.0)(terser@5.27.0)
       vite-node: 1.5.0(@types/node@20.10.0)(terser@5.27.0)
       why-is-node-running: 2.2.2
     optionalDependencies:
@@ -25893,7 +25715,7 @@ snapshots:
       strip-literal: 2.1.0
       tinybench: 2.7.0
       tinypool: 0.8.4
-      vite: 5.2.10(@types/node@20.11.15)(terser@5.27.0)
+      vite: 5.4.3(@types/node@20.11.15)(terser@5.27.0)
       vite-node: 1.5.0(@types/node@20.11.15)(terser@5.27.0)
       why-is-node-running: 2.2.2
     optionalDependencies:
@@ -25927,7 +25749,7 @@ snapshots:
       strip-literal: 2.1.0
       tinybench: 2.7.0
       tinypool: 0.8.4
-      vite: 5.2.10(@types/node@20.12.12)(terser@5.27.0)
+      vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
       vite-node: 1.5.0(@types/node@20.12.12)(terser@5.27.0)
       why-is-node-running: 2.2.2
     optionalDependencies:


### PR DESCRIPTION
Upgrade vite versions to resolve vulnerability. Resolved versions:
* 5.4.11
* 5.3.6
* 5.2.14
* 5.1.8
* 4.5.4

Closes https://github.com/codecov/internal-issues/issues/934
Closes https://github.com/codecov/internal-issues/issues/932
