### PR TITLE
chore: Resolve rollup vuln

### DIFF
--- a/.changeset/brave-bikes-wait.md
+++ b/.changeset/brave-bikes-wait.md
@@ -1,0 +1,14 @@
+---
+"@codecov/rollup-plugin": patch
+"@codecov/bundle-analyzer": patch
+"@codecov/bundler-plugin-core": patch
+"@codecov/nextjs-webpack-plugin": patch
+"@codecov/nuxt-plugin": patch
+"@codecov/remix-vite-plugin": patch
+"@codecov/solidstart-plugin": patch
+"@codecov/sveltekit-plugin": patch
+"@codecov/vite-plugin": patch
+"@codecov/webpack-plugin": patch
+---
+
+Bump rollup versions

--- a/examples/bundle-analyzer-cli/package.json
+++ b/examples/bundle-analyzer-cli/package.json
@@ -26,7 +26,7 @@
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "npm-run-all": "^4.1.5",
-    "rollup": "^4.9.6",
+    "rollup": "^4.22.4",
     "serve": "^14.2.1"
   },
   "volta": {

--- a/examples/oidc/package.json
+++ b/examples/oidc/package.json
@@ -23,7 +23,7 @@
     "eslint": "^8.56.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "rollup": "^4.9.6",
+    "rollup": "^4.22.4",
     "typescript": "^5.3.3",
     "vite": "^5.2.10"
   },

--- a/examples/rollup/package.json
+++ b/examples/rollup/package.json
@@ -17,7 +17,7 @@
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "npm-run-all": "^4.1.5",
-    "rollup": "^4.9.6",
+    "rollup": "^4.22.4",
     "serve": "^14.2.1"
   },
   "volta": {

--- a/examples/tokenless/package.json
+++ b/examples/tokenless/package.json
@@ -23,7 +23,7 @@
     "eslint": "^8.56.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "rollup": "^4.9.6",
+    "rollup": "^4.22.4",
     "typescript": "^5.3.3",
     "vite": "^5.2.10"
   },

--- a/examples/vite/package.json
+++ b/examples/vite/package.json
@@ -23,7 +23,7 @@
     "eslint": "^8.56.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "rollup": "^4.9.6",
+    "rollup": "^4.22.4",
     "typescript": "^5.3.3",
     "vite": "^5.2.10"
   },

--- a/integration-tests/fixtures/generate-bundle-stats/nuxt/__snapshots__/nuxt-plugin.test.ts.snap
+++ b/integration-tests/fixtures/generate-bundle-stats/nuxt/__snapshots__/nuxt-plugin.test.ts.snap
@@ -7,7 +7,7 @@ exports[`Generating nuxt stats 3 {"format":"amd","expected":"amd"} matches the s
   "bundleName": StringContaining "test-nuxt-v3-client-amd",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -28,7 +28,7 @@ exports[`Generating nuxt stats 3 {"format":"amd","expected":"amd"} matches the s
   "bundleName": StringContaining "test-nuxt-v3-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -49,7 +49,7 @@ exports[`Generating nuxt stats 3 {"format":"cjs","expected":"cjs"} matches the s
   "bundleName": StringContaining "test-nuxt-v3-client-cjs",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -70,7 +70,7 @@ exports[`Generating nuxt stats 3 {"format":"cjs","expected":"cjs"} matches the s
   "bundleName": StringContaining "test-nuxt-v3-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -91,7 +91,7 @@ exports[`Generating nuxt stats 3 {"format":"es","expected":"esm"} matches the sn
   "bundleName": StringContaining "test-nuxt-v3-client-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -112,7 +112,7 @@ exports[`Generating nuxt stats 3 {"format":"es","expected":"esm"} matches the sn
   "bundleName": StringContaining "test-nuxt-v3-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -133,7 +133,7 @@ exports[`Generating nuxt stats 3 {"format":"esm","expected":"esm"} matches the s
   "bundleName": StringContaining "test-nuxt-v3-client-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -154,7 +154,7 @@ exports[`Generating nuxt stats 3 {"format":"esm","expected":"esm"} matches the s
   "bundleName": StringContaining "test-nuxt-v3-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -175,7 +175,7 @@ exports[`Generating nuxt stats 3 {"format":"module","expected":"esm"} matches th
   "bundleName": StringContaining "test-nuxt-v3-client-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -196,7 +196,7 @@ exports[`Generating nuxt stats 3 {"format":"module","expected":"esm"} matches th
   "bundleName": StringContaining "test-nuxt-v3-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -217,7 +217,7 @@ exports[`Generating nuxt stats 3 {"format":"iife","expected":"iife"} matches the
   "bundleName": StringContaining "test-nuxt-v3-client-iife",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -238,7 +238,7 @@ exports[`Generating nuxt stats 3 {"format":"iife","expected":"iife"} matches the
   "bundleName": StringContaining "test-nuxt-v3-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -259,7 +259,7 @@ exports[`Generating nuxt stats 3 {"format":"umd","expected":"umd"} matches the s
   "bundleName": StringContaining "test-nuxt-v3-client-umd",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -280,7 +280,7 @@ exports[`Generating nuxt stats 3 {"format":"umd","expected":"umd"} matches the s
   "bundleName": StringContaining "test-nuxt-v3-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -301,7 +301,7 @@ exports[`Generating nuxt stats 3 {"format":"system","expected":"system"} matches
   "bundleName": StringContaining "test-nuxt-v3-client-system",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -322,7 +322,7 @@ exports[`Generating nuxt stats 3 {"format":"system","expected":"system"} matches
   "bundleName": StringContaining "test-nuxt-v3-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -343,7 +343,7 @@ exports[`Generating nuxt stats 3 {"format":"systemjs","expected":"system"} match
   "bundleName": StringContaining "test-nuxt-v3-client-system",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -364,7 +364,7 @@ exports[`Generating nuxt stats 3 {"format":"systemjs","expected":"system"} match
   "bundleName": StringContaining "test-nuxt-v3-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,

--- a/integration-tests/fixtures/generate-bundle-stats/remix/__snapshots__/remix-plugin.test.ts.snap
+++ b/integration-tests/fixtures/generate-bundle-stats/remix/__snapshots__/remix-plugin.test.ts.snap
@@ -7,7 +7,7 @@ exports[`Generating remix stats 2 {"format":"amd","expected":"amd"} matches the 
   "bundleName": StringContaining "test-remix-v2-client-amd",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -28,7 +28,7 @@ exports[`Generating remix stats 2 {"format":"amd","expected":"amd"} matches the 
   "bundleName": StringContaining "test-remix-v2-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -49,7 +49,7 @@ exports[`Generating remix stats 2 {"format":"cjs","expected":"cjs"} matches the 
   "bundleName": StringContaining "test-remix-v2-client-cjs",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -70,7 +70,7 @@ exports[`Generating remix stats 2 {"format":"cjs","expected":"cjs"} matches the 
   "bundleName": StringContaining "test-remix-v2-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -91,7 +91,7 @@ exports[`Generating remix stats 2 {"format":"es","expected":"esm"} matches the s
   "bundleName": StringContaining "test-remix-v2-client-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -112,7 +112,7 @@ exports[`Generating remix stats 2 {"format":"es","expected":"esm"} matches the s
   "bundleName": StringContaining "test-remix-v2-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -133,7 +133,7 @@ exports[`Generating remix stats 2 {"format":"esm","expected":"esm"} matches the 
   "bundleName": StringContaining "test-remix-v2-client-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -154,7 +154,7 @@ exports[`Generating remix stats 2 {"format":"esm","expected":"esm"} matches the 
   "bundleName": StringContaining "test-remix-v2-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -175,7 +175,7 @@ exports[`Generating remix stats 2 {"format":"module","expected":"esm"} matches t
   "bundleName": StringContaining "test-remix-v2-client-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -196,7 +196,7 @@ exports[`Generating remix stats 2 {"format":"module","expected":"esm"} matches t
   "bundleName": StringContaining "test-remix-v2-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,

--- a/integration-tests/fixtures/generate-bundle-stats/rollup/__snapshots__/rollup-plugin.test.ts.snap
+++ b/integration-tests/fixtures/generate-bundle-stats/rollup/__snapshots__/rollup-plugin.test.ts.snap
@@ -1237,7 +1237,7 @@ exports[`Generating rollup stats 4 {"format":"umd","expected":"umd"} matches the
   "assets": [
     {
       "gzipSize": 98845,
-      "name": "main-ymXr0nql.js",
+      "name": "main-DXhL8JQx.js",
       "normalized": "main-*.js",
       "size": 577167,
     },
@@ -1252,7 +1252,7 @@ exports[`Generating rollup stats 4 {"format":"umd","expected":"umd"} matches the
     {
       "entry": true,
       "files": [
-        "main-ymXr0nql.js",
+        "main-DXhL8JQx.js",
       ],
       "id": "main",
       "initial": false,

--- a/integration-tests/fixtures/generate-bundle-stats/rollup/__snapshots__/rollup-plugin.test.ts.snap
+++ b/integration-tests/fixtures/generate-bundle-stats/rollup/__snapshots__/rollup-plugin.test.ts.snap
@@ -784,7 +784,7 @@ exports[`Generating rollup stats 4 {"format":"amd","expected":"amd"} matches the
   "bundleName": StringContaining "test-rollup-v4-amd",
   "bundler": {
     "name": "rollup",
-    "version": "4.9.6",
+    "version": "4.22.4",
   },
   "chunks": [
     {
@@ -861,7 +861,7 @@ exports[`Generating rollup stats 4 {"format":"cjs","expected":"cjs"} matches the
   "bundleName": StringContaining "test-rollup-v4-cjs",
   "bundler": {
     "name": "rollup",
-    "version": "4.9.6",
+    "version": "4.22.4",
   },
   "chunks": [
     {
@@ -938,7 +938,7 @@ exports[`Generating rollup stats 4 {"format":"es","expected":"esm"} matches the 
   "bundleName": StringContaining "test-rollup-v4-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.9.6",
+    "version": "4.22.4",
   },
   "chunks": [
     {
@@ -1015,7 +1015,7 @@ exports[`Generating rollup stats 4 {"format":"esm","expected":"esm"} matches the
   "bundleName": StringContaining "test-rollup-v4-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.9.6",
+    "version": "4.22.4",
   },
   "chunks": [
     {
@@ -1092,7 +1092,7 @@ exports[`Generating rollup stats 4 {"format":"module","expected":"esm"} matches 
   "bundleName": StringContaining "test-rollup-v4-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.9.6",
+    "version": "4.22.4",
   },
   "chunks": [
     {
@@ -1169,7 +1169,7 @@ exports[`Generating rollup stats 4 {"format":"iife","expected":"iife"} matches t
   "bundleName": StringContaining "test-rollup-v4-iife",
   "bundler": {
     "name": "rollup",
-    "version": "4.9.6",
+    "version": "4.22.4",
   },
   "chunks": [
     {
@@ -1246,7 +1246,7 @@ exports[`Generating rollup stats 4 {"format":"umd","expected":"umd"} matches the
   "bundleName": StringContaining "test-rollup-v4-umd",
   "bundler": {
     "name": "rollup",
-    "version": "4.9.6",
+    "version": "4.22.4",
   },
   "chunks": [
     {
@@ -1323,7 +1323,7 @@ exports[`Generating rollup stats 4 {"format":"system","expected":"system"} match
   "bundleName": StringContaining "test-rollup-v4-system",
   "bundler": {
     "name": "rollup",
-    "version": "4.9.6",
+    "version": "4.22.4",
   },
   "chunks": [
     {
@@ -1400,7 +1400,7 @@ exports[`Generating rollup stats 4 {"format":"systemjs","expected":"system"} mat
   "bundleName": StringContaining "test-rollup-v4-system",
   "bundler": {
     "name": "rollup",
-    "version": "4.9.6",
+    "version": "4.22.4",
   },
   "chunks": [
     {
@@ -1477,7 +1477,7 @@ exports[`Generating rollup stats 4 source maps are enabled does not include any 
   "bundleName": StringNotContaining ".map",
   "bundler": {
     "name": "rollup",
-    "version": "4.9.6",
+    "version": "4.22.4",
   },
   "chunks": [
     {

--- a/integration-tests/fixtures/generate-bundle-stats/rollup/__snapshots__/rollup-plugin.test.ts.snap
+++ b/integration-tests/fixtures/generate-bundle-stats/rollup/__snapshots__/rollup-plugin.test.ts.snap
@@ -775,7 +775,7 @@ exports[`Generating rollup stats 4 {"format":"amd","expected":"amd"} matches the
   "assets": [
     {
       "gzipSize": 98808,
-      "name": "main-H2_1FSsQ.js",
+      "name": "main-Bz9ahex4.js",
       "normalized": "main-*.js",
       "size": 577073,
     },
@@ -790,7 +790,7 @@ exports[`Generating rollup stats 4 {"format":"amd","expected":"amd"} matches the
     {
       "entry": true,
       "files": [
-        "main-H2_1FSsQ.js",
+        "main-Bz9ahex4.js",
       ],
       "id": "main",
       "initial": false,
@@ -852,7 +852,7 @@ exports[`Generating rollup stats 4 {"format":"cjs","expected":"cjs"} matches the
   "assets": [
     {
       "gzipSize": 98252,
-      "name": "main-MVbZZknk.js",
+      "name": "main-xb59kfqA.js",
       "normalized": "main-*.js",
       "size": 560888,
     },
@@ -867,7 +867,7 @@ exports[`Generating rollup stats 4 {"format":"cjs","expected":"cjs"} matches the
     {
       "entry": true,
       "files": [
-        "main-MVbZZknk.js",
+        "main-xb59kfqA.js",
       ],
       "id": "main",
       "initial": false,
@@ -929,7 +929,7 @@ exports[`Generating rollup stats 4 {"format":"es","expected":"esm"} matches the 
   "assets": [
     {
       "gzipSize": 98243,
-      "name": "main-v-vWaFyT.js",
+      "name": "main-DTMU6eC0.js",
       "normalized": "main-*.js",
       "size": 560873,
     },
@@ -944,7 +944,7 @@ exports[`Generating rollup stats 4 {"format":"es","expected":"esm"} matches the 
     {
       "entry": true,
       "files": [
-        "main-v-vWaFyT.js",
+        "main-DTMU6eC0.js",
       ],
       "id": "main",
       "initial": false,
@@ -1006,7 +1006,7 @@ exports[`Generating rollup stats 4 {"format":"esm","expected":"esm"} matches the
   "assets": [
     {
       "gzipSize": 98243,
-      "name": "main-v-vWaFyT.js",
+      "name": "main-DTMU6eC0.js",
       "normalized": "main-*.js",
       "size": 560873,
     },
@@ -1021,7 +1021,7 @@ exports[`Generating rollup stats 4 {"format":"esm","expected":"esm"} matches the
     {
       "entry": true,
       "files": [
-        "main-v-vWaFyT.js",
+        "main-DTMU6eC0.js",
       ],
       "id": "main",
       "initial": false,
@@ -1083,7 +1083,7 @@ exports[`Generating rollup stats 4 {"format":"module","expected":"esm"} matches 
   "assets": [
     {
       "gzipSize": 98243,
-      "name": "main-v-vWaFyT.js",
+      "name": "main-DTMU6eC0.js",
       "normalized": "main-*.js",
       "size": 560873,
     },
@@ -1098,7 +1098,7 @@ exports[`Generating rollup stats 4 {"format":"module","expected":"esm"} matches 
     {
       "entry": true,
       "files": [
-        "main-v-vWaFyT.js",
+        "main-DTMU6eC0.js",
       ],
       "id": "main",
       "initial": false,
@@ -1160,7 +1160,7 @@ exports[`Generating rollup stats 4 {"format":"iife","expected":"iife"} matches t
   "assets": [
     {
       "gzipSize": 98804,
-      "name": "main-ChwnvxRF.js",
+      "name": "main-B7VbaLUG.js",
       "normalized": "main-*.js",
       "size": 577068,
     },
@@ -1175,7 +1175,7 @@ exports[`Generating rollup stats 4 {"format":"iife","expected":"iife"} matches t
     {
       "entry": true,
       "files": [
-        "main-ChwnvxRF.js",
+        "main-B7VbaLUG.js",
       ],
       "id": "main",
       "initial": false,
@@ -1314,7 +1314,7 @@ exports[`Generating rollup stats 4 {"format":"system","expected":"system"} match
   "assets": [
     {
       "gzipSize": 99908,
-      "name": "main-VyFuBFOR.js",
+      "name": "main-DwblAVj_.js",
       "normalized": "main-*.js",
       "size": 609446,
     },
@@ -1329,7 +1329,7 @@ exports[`Generating rollup stats 4 {"format":"system","expected":"system"} match
     {
       "entry": true,
       "files": [
-        "main-VyFuBFOR.js",
+        "main-DwblAVj_.js",
       ],
       "id": "main",
       "initial": false,
@@ -1391,7 +1391,7 @@ exports[`Generating rollup stats 4 {"format":"systemjs","expected":"system"} mat
   "assets": [
     {
       "gzipSize": 99908,
-      "name": "main-VyFuBFOR.js",
+      "name": "main-DwblAVj_.js",
       "normalized": "main-*.js",
       "size": 609446,
     },
@@ -1406,7 +1406,7 @@ exports[`Generating rollup stats 4 {"format":"systemjs","expected":"system"} mat
     {
       "entry": true,
       "files": [
-        "main-VyFuBFOR.js",
+        "main-DwblAVj_.js",
       ],
       "id": "main",
       "initial": false,
@@ -1468,7 +1468,7 @@ exports[`Generating rollup stats 4 source maps are enabled does not include any 
   "assets": [
     {
       "gzipSize": 98277,
-      "name": "main-v-vWaFyT.js",
+      "name": "main-DTMU6eC0.js",
       "normalized": "main-*.js",
       "size": 560915,
     },
@@ -1483,7 +1483,7 @@ exports[`Generating rollup stats 4 source maps are enabled does not include any 
     {
       "entry": true,
       "files": [
-        "main-v-vWaFyT.js",
+        "main-DTMU6eC0.js",
       ],
       "id": "main",
       "initial": false,

--- a/integration-tests/fixtures/generate-bundle-stats/sveltekit/__snapshots__/sveltekit-plugin.test.ts.snap
+++ b/integration-tests/fixtures/generate-bundle-stats/sveltekit/__snapshots__/sveltekit-plugin.test.ts.snap
@@ -7,7 +7,7 @@ exports[`Generating sveltekit stats 2 {"format":"es","expected":"esm"} matches t
   "bundleName": StringContaining "test-sveltekit-v2-client-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -28,7 +28,7 @@ exports[`Generating sveltekit stats 2 {"format":"es","expected":"esm"} matches t
   "bundleName": StringContaining "test-sveltekit-v2-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -49,7 +49,7 @@ exports[`Generating sveltekit stats 2 {"format":"esm","expected":"esm"} matches 
   "bundleName": StringContaining "test-sveltekit-v2-client-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -70,7 +70,7 @@ exports[`Generating sveltekit stats 2 {"format":"esm","expected":"esm"} matches 
   "bundleName": StringContaining "test-sveltekit-v2-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -91,7 +91,7 @@ exports[`Generating sveltekit stats 2 {"format":"module","expected":"esm"} match
   "bundleName": StringContaining "test-sveltekit-v2-client-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,
@@ -112,7 +112,7 @@ exports[`Generating sveltekit stats 2 {"format":"module","expected":"esm"} match
   "bundleName": StringContaining "test-sveltekit-v2-server-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": ExpectArrayContaining {},
   "duration": Any<Number>,

--- a/integration-tests/fixtures/generate-bundle-stats/vite/__snapshots__/vite-plugin.test.ts.snap
+++ b/integration-tests/fixtures/generate-bundle-stats/vite/__snapshots__/vite-plugin.test.ts.snap
@@ -924,7 +924,7 @@ exports[`Generating vite stats v5 {"format":"amd","expected":"amd"} matches the 
   "bundleName": StringContaining "test-vite-v5-amd",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": [
     {
@@ -1015,7 +1015,7 @@ exports[`Generating vite stats v5 {"format":"cjs","expected":"cjs"} matches the 
   "bundleName": StringContaining "test-vite-v5-cjs",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": [
     {
@@ -1106,7 +1106,7 @@ exports[`Generating vite stats v5 {"format":"es","expected":"esm"} matches the s
   "bundleName": StringContaining "test-vite-v5-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": [
     {
@@ -1197,7 +1197,7 @@ exports[`Generating vite stats v5 {"format":"esm","expected":"esm"} matches the 
   "bundleName": StringContaining "test-vite-v5-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": [
     {
@@ -1288,7 +1288,7 @@ exports[`Generating vite stats v5 {"format":"module","expected":"esm"} matches t
   "bundleName": StringContaining "test-vite-v5-esm",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": [
     {
@@ -1379,7 +1379,7 @@ exports[`Generating vite stats v5 {"format":"iife","expected":"iife"} matches th
   "bundleName": StringContaining "test-vite-v5-iife",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": [
     {
@@ -1470,7 +1470,7 @@ exports[`Generating vite stats v5 {"format":"umd","expected":"umd"} matches the 
   "bundleName": StringContaining "test-vite-v5-umd",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": [
     {
@@ -1561,7 +1561,7 @@ exports[`Generating vite stats v5 {"format":"system","expected":"system"} matche
   "bundleName": StringContaining "test-vite-v5-system",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": [
     {
@@ -1652,7 +1652,7 @@ exports[`Generating vite stats v5 {"format":"systemjs","expected":"system"} matc
   "bundleName": StringContaining "test-vite-v5-system",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": [
     {
@@ -1743,7 +1743,7 @@ exports[`Generating vite stats v5 source maps are enabled does not include any s
   "bundleName": StringNotContaining ".map",
   "bundler": {
     "name": "rollup",
-    "version": "4.21.2",
+    "version": "4.22.4",
   },
   "chunks": [
     {

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -52,7 +52,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rollupV3": "npm:rollup@3.29.4",
-    "rollupV4": "npm:rollup@4.9.6",
+    "rollupV4": "npm:rollup@4.22.4",
     "ts-node": "^10.9.2",
     "viteV4": "npm:vite@4.5.3",
     "viteV5": "npm:vite@5.2.14",

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -51,7 +51,7 @@
     "nuxt": "3.12.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "rollupV3": "npm:rollup@3.29.4",
+    "rollupV3": "npm:rollup@3.29.5",
     "rollupV4": "npm:rollup@4.22.4",
     "ts-node": "^10.9.2",
     "viteV4": "npm:vite@4.5.3",

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -54,7 +54,7 @@
     "@vitest/coverage-v8": "^1.5.0",
     "codecovProdRollupPlugin": "npm:@codecov/rollup-plugin@0.0.1-beta.5",
     "msw": "^2.1.5",
-    "rollup": "4.9.6",
+    "rollup": "4.22.4",
     "ts-node": "^10.9.2",
     "typedoc": "^0.25.12",
     "typescript": "^5.3.3",
@@ -63,7 +63,7 @@
     "vitest": "^1.5.0"
   },
   "peerDependencies": {
-    "rollup": "3.x || 4.x"
+    "rollup": ">=4.22.4 <5.0.0"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -63,7 +63,7 @@
     "vitest": "^1.5.0"
   },
   "peerDependencies": {
-    "rollup": ">=4.22.4 <5.0.0"
+    "rollup": ">=3.29.5 <4.0.0 || >=4.22.4 <5.0.0"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -63,7 +63,7 @@
     "vitest": "^1.5.0"
   },
   "peerDependencies": {
-    "rollup": ">=3.29.5 <4.0.0 || >=4.22.4 <5.0.0"
+    "rollup": "3.x || 4.x"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/rollup-plugin/vitest.config.ts
+++ b/packages/rollup-plugin/vitest.config.ts
@@ -7,7 +7,6 @@ const packageJson = await import("./package.json");
 export default defineProject({
   ...config,
   plugins: [
-    // @ts-expect-error - using rollup plugin
     {
       ...replace({
         preventAssignment: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -583,8 +583,8 @@ importers:
         specifier: npm:rollup@3.29.4
         version: rollup@3.29.4
       rollupV4:
-        specifier: npm:rollup@4.9.6
-        version: rollup@4.9.6
+        specifier: npm:rollup@4.22.4
+        version: rollup@4.22.4
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@20.11.15)(typescript@5.4.5)
@@ -801,7 +801,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.7(rollup@3.29.4)
+        version: 5.0.7(rollup@4.22.4)
       '@types/micromatch':
         specifier: ^4.0.9
         version: 4.0.9
@@ -816,7 +816,7 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.12.12)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@3.29.4)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.22.4)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.4.5)
@@ -874,7 +874,7 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.11.15)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.22.4)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@3.29.4)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.3.3)
@@ -4198,11 +4198,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm-eabi@4.9.6':
-    resolution: {integrity: sha512-MVNXSSYN6QXOulbHpLMKYi60ppyO13W9my1qogeiAqtjb2yR4LSmfU2+POvDkLzhjYLXz9Rf9+9a3zFHW1Lecg==}
-    cpu: [arm]
-    os: [android]
-
   '@rollup/rollup-android-arm64@4.21.2':
     resolution: {integrity: sha512-xGU5ZQmPlsjQS6tzTTGwMsnKUtu0WVbl0hYpTPauvbRAnmIvpInhJtgjj3mcuJpEiuUw4v1s4BimkdfDWlh7gA==}
     cpu: [arm64]
@@ -4210,11 +4205,6 @@ packages:
 
   '@rollup/rollup-android-arm64@4.22.4':
     resolution: {integrity: sha512-VXoK5UMrgECLYaMuGuVTOx5kcuap1Jm8g/M83RnCHBKOqvPPmROFJGQaZhGccnsFtfXQ3XYa4/jMCJvZnbJBdA==}
-    cpu: [arm64]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.9.6':
-    resolution: {integrity: sha512-T14aNLpqJ5wzKNf5jEDpv5zgyIqcpn1MlwCrUXLrwoADr2RkWA0vOWP4XxbO9aiO3dvMCQICZdKeDrFl7UMClw==}
     cpu: [arm64]
     os: [android]
 
@@ -4228,11 +4218,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-arm64@4.9.6':
-    resolution: {integrity: sha512-CqNNAyhRkTbo8VVZ5R85X73H3R5NX9ONnKbXuHisGWC0qRbTTxnF1U4V9NafzJbgGM0sHZpdO83pLPzq8uOZFw==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rollup/rollup-darwin-x64@4.21.2':
     resolution: {integrity: sha512-ZbRaUvw2iN/y37x6dY50D8m2BnDbBjlnMPotDi/qITMJ4sIxNY33HArjikDyakhSv0+ybdUxhWxE6kTI4oX26w==}
     cpu: [x64]
@@ -4243,11 +4228,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.9.6':
-    resolution: {integrity: sha512-zRDtdJuRvA1dc9Mp6BWYqAsU5oeLixdfUvkTHuiYOHwqYuQ4YgSmi6+/lPvSsqc/I0Omw3DdICx4Tfacdzmhog==}
-    cpu: [x64]
-    os: [darwin]
-
   '@rollup/rollup-linux-arm-gnueabihf@4.21.2':
     resolution: {integrity: sha512-ztRJJMiE8nnU1YFcdbd9BcH6bGWG1z+jP+IPW2oDUAPxPjo9dverIOyXz76m6IPA6udEL12reYeLojzW2cYL7w==}
     cpu: [arm]
@@ -4255,11 +4235,6 @@ packages:
 
   '@rollup/rollup-linux-arm-gnueabihf@4.22.4':
     resolution: {integrity: sha512-j63YtCIRAzbO+gC2L9dWXRh5BFetsv0j0va0Wi9epXDgU/XUi5dJKo4USTttVyK7fGw2nPWK0PbAvyliz50SCQ==}
-    cpu: [arm]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm-gnueabihf@4.9.6':
-    resolution: {integrity: sha512-oNk8YXDDnNyG4qlNb6is1ojTOGL/tRhbbKeE/YuccItzerEZT68Z9gHrY3ROh7axDc974+zYAPxK5SH0j/G+QQ==}
     cpu: [arm]
     os: [linux]
 
@@ -4283,11 +4258,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.9.6':
-    resolution: {integrity: sha512-Z3O60yxPtuCYobrtzjo0wlmvDdx2qZfeAWTyfOjEDqd08kthDKexLpV97KfAeUXPosENKd8uyJMRDfFMxcYkDQ==}
-    cpu: [arm64]
-    os: [linux]
-
   '@rollup/rollup-linux-arm64-musl@4.21.2':
     resolution: {integrity: sha512-48pD/fJkTiHAZTnZwR0VzHrao70/4MlzJrq0ZsILjLW/Ab/1XlVUStYyGt7tdyIiVSlGZbnliqmult/QGA2O2w==}
     cpu: [arm64]
@@ -4295,11 +4265,6 @@ packages:
 
   '@rollup/rollup-linux-arm64-musl@4.22.4':
     resolution: {integrity: sha512-Gl0AxBtDg8uoAn5CCqQDMqAx22Wx22pjDOjBdmG0VIWX3qUBHzYmOKh8KXHL4UpogfJ14G4wk16EQogF+v8hmA==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm64-musl@4.9.6':
-    resolution: {integrity: sha512-gpiG0qQJNdYEVad+1iAsGAbgAnZ8j07FapmnIAQgODKcOTjLEWM9sRb+MbQyVsYCnA0Im6M6QIq6ax7liws6eQ==}
     cpu: [arm64]
     os: [linux]
 
@@ -4323,11 +4288,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.9.6':
-    resolution: {integrity: sha512-+uCOcvVmFUYvVDr27aiyun9WgZk0tXe7ThuzoUTAukZJOwS5MrGbmSlNOhx1j80GdpqbOty05XqSl5w4dQvcOA==}
-    cpu: [riscv64]
-    os: [linux]
-
   '@rollup/rollup-linux-s390x-gnu@4.21.2':
     resolution: {integrity: sha512-PMxkrWS9z38bCr3rWvDFVGD6sFeZJw4iQlhrup7ReGmfn7Oukrr/zweLhYX6v2/8J6Cep9IEA/SmjXjCmSbrMQ==}
     cpu: [s390x]
@@ -4348,11 +4308,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.9.6':
-    resolution: {integrity: sha512-HUNqM32dGzfBKuaDUBqFB7tP6VMN74eLZ33Q9Y1TBqRDn+qDonkAUyKWwF9BR9unV7QUzffLnz9GrnKvMqC/fw==}
-    cpu: [x64]
-    os: [linux]
-
   '@rollup/rollup-linux-x64-musl@4.21.2':
     resolution: {integrity: sha512-7twFizNXudESmC9oneLGIUmoHiiLppz/Xs5uJQ4ShvE6234K0VB1/aJYU3f/4g7PhssLGKBVCC37uRkkOi8wjg==}
     cpu: [x64]
@@ -4360,11 +4315,6 @@ packages:
 
   '@rollup/rollup-linux-x64-musl@4.22.4':
     resolution: {integrity: sha512-UV6FZMUgePDZrFjrNGIWzDo/vABebuXBhJEqrHxrGiU6HikPy0Z3LfdtciIttEUQfuDdCn8fqh7wiFJjCNwO+g==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rollup/rollup-linux-x64-musl@4.9.6':
-    resolution: {integrity: sha512-ch7M+9Tr5R4FK40FHQk8VnML0Szi2KRujUgHXd/HjuH9ifH72GUmw6lStZBo3c3GB82vHa0ZoUfjfcM7JiiMrQ==}
     cpu: [x64]
     os: [linux]
 
@@ -4378,11 +4328,6 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-arm64-msvc@4.9.6':
-    resolution: {integrity: sha512-VD6qnR99dhmTQ1mJhIzXsRcTBvTjbfbGGwKAHcu+52cVl15AC/kplkhxzW/uT0Xl62Y/meBKDZvoJSJN+vTeGA==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rollup/rollup-win32-ia32-msvc@4.21.2':
     resolution: {integrity: sha512-5rA4vjlqgrpbFVVHX3qkrCo/fZTj1q0Xxpg+Z7yIo3J2AilW7t2+n6Q8Jrx+4MrYpAnjttTYF8rr7bP46BPzRw==}
     cpu: [ia32]
@@ -4393,11 +4338,6 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.9.6':
-    resolution: {integrity: sha512-J9AFDq/xiRI58eR2NIDfyVmTYGyIZmRcvcAoJ48oDld/NTR8wyiPUu2X/v1navJ+N/FGg68LEbX3Ejd6l8B7MQ==}
-    cpu: [ia32]
-    os: [win32]
-
   '@rollup/rollup-win32-x64-msvc@4.21.2':
     resolution: {integrity: sha512-6UUxd0+SKomjdzuAcp+HAmxw1FlGBnl1v2yEPSabtx4lBfdXHDVsW7+lQkgz9cNFJGY3AWR7+V8P5BqkD9L9nA==}
     cpu: [x64]
@@ -4405,11 +4345,6 @@ packages:
 
   '@rollup/rollup-win32-x64-msvc@4.22.4':
     resolution: {integrity: sha512-j8pPKp53/lq9lMXN57S8cFz0MynJk8OWNuUnXct/9KCpKU7DgU3bYMJhwWmcqC0UU29p8Lr0/7KEVcaM6bf47Q==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.9.6':
-    resolution: {integrity: sha512-jqzNLhNDvIZOrt69Ce4UjGRpXJBzhUBzawMwnaDAwyHriki3XollsewxWzOzz+4yOFDkuJHtTsZFwMxhYJWmLQ==}
     cpu: [x64]
     os: [win32]
 
@@ -9828,11 +9763,6 @@ packages:
 
   rollup@4.22.4:
     resolution: {integrity: sha512-vD8HJ5raRcWOyymsR6Z3o6+RzfEPCnVLMFJ6vRslO1jt4LO6dUo5Qnpg7y4RkZFM2DMe3WUirkI5c16onjrc6A==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
-
-  rollup@4.9.6:
-    resolution: {integrity: sha512-05lzkCS2uASX0CiLFybYfVkwNbKZG5NFQ6Go0VWyogFTXXbR039UVsegViTntkk4OglHBdF54ccApXRRuXRbsg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -15389,16 +15319,10 @@ snapshots:
   '@rollup/rollup-android-arm-eabi@4.22.4':
     optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.9.6':
-    optional: true
-
   '@rollup/rollup-android-arm64@4.21.2':
     optional: true
 
   '@rollup/rollup-android-arm64@4.22.4':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.9.6':
     optional: true
 
   '@rollup/rollup-darwin-arm64@4.21.2':
@@ -15407,25 +15331,16 @@ snapshots:
   '@rollup/rollup-darwin-arm64@4.22.4':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.9.6':
-    optional: true
-
   '@rollup/rollup-darwin-x64@4.21.2':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.22.4':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.9.6':
-    optional: true
-
   '@rollup/rollup-linux-arm-gnueabihf@4.21.2':
     optional: true
 
   '@rollup/rollup-linux-arm-gnueabihf@4.22.4':
-    optional: true
-
-  '@rollup/rollup-linux-arm-gnueabihf@4.9.6':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.21.2':
@@ -15440,16 +15355,10 @@ snapshots:
   '@rollup/rollup-linux-arm64-gnu@4.22.4':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.9.6':
-    optional: true
-
   '@rollup/rollup-linux-arm64-musl@4.21.2':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.22.4':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.9.6':
     optional: true
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.21.2':
@@ -15464,9 +15373,6 @@ snapshots:
   '@rollup/rollup-linux-riscv64-gnu@4.22.4':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.9.6':
-    optional: true
-
   '@rollup/rollup-linux-s390x-gnu@4.21.2':
     optional: true
 
@@ -15479,16 +15385,10 @@ snapshots:
   '@rollup/rollup-linux-x64-gnu@4.22.4':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.9.6':
-    optional: true
-
   '@rollup/rollup-linux-x64-musl@4.21.2':
     optional: true
 
   '@rollup/rollup-linux-x64-musl@4.22.4':
-    optional: true
-
-  '@rollup/rollup-linux-x64-musl@4.9.6':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.21.2':
@@ -15497,25 +15397,16 @@ snapshots:
   '@rollup/rollup-win32-arm64-msvc@4.22.4':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.9.6':
-    optional: true
-
   '@rollup/rollup-win32-ia32-msvc@4.21.2':
     optional: true
 
   '@rollup/rollup-win32-ia32-msvc@4.22.4':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.9.6':
-    optional: true
-
   '@rollup/rollup-win32-x64-msvc@4.21.2':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.22.4':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.9.6':
     optional: true
 
   '@rushstack/eslint-patch@1.7.2': {}
@@ -23308,25 +23199,6 @@ snapshots:
       '@rollup/rollup-win32-arm64-msvc': 4.22.4
       '@rollup/rollup-win32-ia32-msvc': 4.22.4
       '@rollup/rollup-win32-x64-msvc': 4.22.4
-      fsevents: 2.3.3
-
-  rollup@4.9.6:
-    dependencies:
-      '@types/estree': 1.0.5
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.9.6
-      '@rollup/rollup-android-arm64': 4.9.6
-      '@rollup/rollup-darwin-arm64': 4.9.6
-      '@rollup/rollup-darwin-x64': 4.9.6
-      '@rollup/rollup-linux-arm-gnueabihf': 4.9.6
-      '@rollup/rollup-linux-arm64-gnu': 4.9.6
-      '@rollup/rollup-linux-arm64-musl': 4.9.6
-      '@rollup/rollup-linux-riscv64-gnu': 4.9.6
-      '@rollup/rollup-linux-x64-gnu': 4.9.6
-      '@rollup/rollup-linux-x64-musl': 4.9.6
-      '@rollup/rollup-win32-arm64-msvc': 4.9.6
-      '@rollup/rollup-win32-ia32-msvc': 4.9.6
-      '@rollup/rollup-win32-x64-msvc': 4.9.6
       fsevents: 2.3.3
 
   route-sort@1.0.0: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -801,7 +801,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.7(rollup@4.22.4)
+        version: 5.0.7(rollup@3.29.4)
       '@types/micromatch':
         specifier: ^4.0.9
         version: 4.0.9
@@ -816,7 +816,7 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.12.12)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.22.4)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@3.29.4)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.4.5)
@@ -874,7 +874,7 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.11.15)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@3.29.4)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.22.4)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.3.3)
@@ -4188,19 +4188,9 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.21.2':
-    resolution: {integrity: sha512-fSuPrt0ZO8uXeS+xP3b+yYTCBUd05MoSp2N/MFOgjhhUhMmchXlpTQrTpI8T+YAwAQuK7MafsCOxW7VrPMrJcg==}
-    cpu: [arm]
-    os: [android]
-
   '@rollup/rollup-android-arm-eabi@4.22.4':
     resolution: {integrity: sha512-Fxamp4aEZnfPOcGA8KSNEohV8hX7zVHOemC8jVBoBUHu5zpJK/Eu3uJwt6BMgy9fkvzxDaurgj96F/NiLukF2w==}
     cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.21.2':
-    resolution: {integrity: sha512-xGU5ZQmPlsjQS6tzTTGwMsnKUtu0WVbl0hYpTPauvbRAnmIvpInhJtgjj3mcuJpEiuUw4v1s4BimkdfDWlh7gA==}
-    cpu: [arm64]
     os: [android]
 
   '@rollup/rollup-android-arm64@4.22.4':
@@ -4208,19 +4198,9 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.21.2':
-    resolution: {integrity: sha512-99AhQ3/ZMxU7jw34Sq8brzXqWH/bMnf7ZVhvLk9QU2cOepbQSVTns6qoErJmSiAvU3InRqC2RRZ5ovh1KN0d0Q==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rollup/rollup-darwin-arm64@4.22.4':
     resolution: {integrity: sha512-xMM9ORBqu81jyMKCDP+SZDhnX2QEVQzTcC6G18KlTQEzWK8r/oNZtKuZaCcHhnsa6fEeOBionoyl5JsAbE/36Q==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.21.2':
-    resolution: {integrity: sha512-ZbRaUvw2iN/y37x6dY50D8m2BnDbBjlnMPotDi/qITMJ4sIxNY33HArjikDyakhSv0+ybdUxhWxE6kTI4oX26w==}
-    cpu: [x64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.22.4':
@@ -4228,18 +4208,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.21.2':
-    resolution: {integrity: sha512-ztRJJMiE8nnU1YFcdbd9BcH6bGWG1z+jP+IPW2oDUAPxPjo9dverIOyXz76m6IPA6udEL12reYeLojzW2cYL7w==}
-    cpu: [arm]
-    os: [linux]
-
   '@rollup/rollup-linux-arm-gnueabihf@4.22.4':
     resolution: {integrity: sha512-j63YtCIRAzbO+gC2L9dWXRh5BFetsv0j0va0Wi9epXDgU/XUi5dJKo4USTttVyK7fGw2nPWK0PbAvyliz50SCQ==}
-    cpu: [arm]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm-musleabihf@4.21.2':
-    resolution: {integrity: sha512-flOcGHDZajGKYpLV0JNc0VFH361M7rnV1ee+NTeC/BQQ1/0pllYcFmxpagltANYt8FYf9+kL6RSk80Ziwyhr7w==}
     cpu: [arm]
     os: [linux]
 
@@ -4248,18 +4218,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.21.2':
-    resolution: {integrity: sha512-69CF19Kp3TdMopyteO/LJbWufOzqqXzkrv4L2sP8kfMaAQ6iwky7NoXTp7bD6/irKgknDKM0P9E/1l5XxVQAhw==}
-    cpu: [arm64]
-    os: [linux]
-
   '@rollup/rollup-linux-arm64-gnu@4.22.4':
     resolution: {integrity: sha512-AdPRoNi3NKVLolCN/Sp4F4N1d98c4SBnHMKoLuiG6RXgoZ4sllseuGioszumnPGmPM2O7qaAX/IJdeDU8f26Aw==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rollup/rollup-linux-arm64-musl@4.21.2':
-    resolution: {integrity: sha512-48pD/fJkTiHAZTnZwR0VzHrao70/4MlzJrq0ZsILjLW/Ab/1XlVUStYyGt7tdyIiVSlGZbnliqmult/QGA2O2w==}
     cpu: [arm64]
     os: [linux]
 
@@ -4268,19 +4228,9 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.21.2':
-    resolution: {integrity: sha512-cZdyuInj0ofc7mAQpKcPR2a2iu4YM4FQfuUzCVA2u4HI95lCwzjoPtdWjdpDKyHxI0UO82bLDoOaLfpZ/wviyQ==}
-    cpu: [ppc64]
-    os: [linux]
-
   '@rollup/rollup-linux-powerpc64le-gnu@4.22.4':
     resolution: {integrity: sha512-3aVCK9xfWW1oGQpTsYJJPF6bfpWfhbRnhdlyhak2ZiyFLDaayz0EP5j9V1RVLAAxlmWKTDfS9wyRyY3hvhPoOg==}
     cpu: [ppc64]
-    os: [linux]
-
-  '@rollup/rollup-linux-riscv64-gnu@4.21.2':
-    resolution: {integrity: sha512-RL56JMT6NwQ0lXIQmMIWr1SW28z4E4pOhRRNqwWZeXpRlykRIlEpSWdsgNWJbYBEWD84eocjSGDu/XxbYeCmwg==}
-    cpu: [riscv64]
     os: [linux]
 
   '@rollup/rollup-linux-riscv64-gnu@4.22.4':
@@ -4288,28 +4238,13 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.21.2':
-    resolution: {integrity: sha512-PMxkrWS9z38bCr3rWvDFVGD6sFeZJw4iQlhrup7ReGmfn7Oukrr/zweLhYX6v2/8J6Cep9IEA/SmjXjCmSbrMQ==}
-    cpu: [s390x]
-    os: [linux]
-
   '@rollup/rollup-linux-s390x-gnu@4.22.4':
     resolution: {integrity: sha512-GqFJ9wLlbB9daxhVlrTe61vJtEY99/xB3C8e4ULVsVfflcpmR6c8UZXjtkMA6FhNONhj2eA5Tk9uAVw5orEs4Q==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.21.2':
-    resolution: {integrity: sha512-B90tYAUoLhU22olrafY3JQCFLnT3NglazdwkHyxNDYF/zAxJt5fJUB/yBoWFoIQ7SQj+KLe3iL4BhOMa9fzgpw==}
-    cpu: [x64]
-    os: [linux]
-
   '@rollup/rollup-linux-x64-gnu@4.22.4':
     resolution: {integrity: sha512-87v0ol2sH9GE3cLQLNEy0K/R0pz1nvg76o8M5nhMR0+Q+BBGLnb35P0fVz4CQxHYXaAOhE8HhlkaZfsdUOlHwg==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rollup/rollup-linux-x64-musl@4.21.2':
-    resolution: {integrity: sha512-7twFizNXudESmC9oneLGIUmoHiiLppz/Xs5uJQ4ShvE6234K0VB1/aJYU3f/4g7PhssLGKBVCC37uRkkOi8wjg==}
     cpu: [x64]
     os: [linux]
 
@@ -4318,29 +4253,14 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-win32-arm64-msvc@4.21.2':
-    resolution: {integrity: sha512-9rRero0E7qTeYf6+rFh3AErTNU1VCQg2mn7CQcI44vNUWM9Ze7MSRS/9RFuSsox+vstRt97+x3sOhEey024FRQ==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rollup/rollup-win32-arm64-msvc@4.22.4':
     resolution: {integrity: sha512-BjI+NVVEGAXjGWYHz/vv0pBqfGoUH0IGZ0cICTn7kB9PyjrATSkX+8WkguNjWoj2qSr1im/+tTGRaY+4/PdcQw==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.21.2':
-    resolution: {integrity: sha512-5rA4vjlqgrpbFVVHX3qkrCo/fZTj1q0Xxpg+Z7yIo3J2AilW7t2+n6Q8Jrx+4MrYpAnjttTYF8rr7bP46BPzRw==}
-    cpu: [ia32]
-    os: [win32]
-
   '@rollup/rollup-win32-ia32-msvc@4.22.4':
     resolution: {integrity: sha512-SiWG/1TuUdPvYmzmYnmd3IEifzR61Tragkbx9D3+R8mzQqDBz8v+BvZNDlkiTtI9T15KYZhP0ehn3Dld4n9J5g==}
     cpu: [ia32]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.21.2':
-    resolution: {integrity: sha512-6UUxd0+SKomjdzuAcp+HAmxw1FlGBnl1v2yEPSabtx4lBfdXHDVsW7+lQkgz9cNFJGY3AWR7+V8P5BqkD9L9nA==}
-    cpu: [x64]
     os: [win32]
 
   '@rollup/rollup-win32-x64-msvc@4.22.4':
@@ -9754,11 +9674,6 @@ packages:
   rollup@3.29.4:
     resolution: {integrity: sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
-    hasBin: true
-
-  rollup@4.21.2:
-    resolution: {integrity: sha512-e3TapAgYf9xjdLvKQCkQTnbTKd4a6jwlpQSJJFokHGaX2IVjoEqkIIhiQfqsi0cdwlOD+tQGuOd5AJkc5RngBw==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
   rollup@4.22.4:
@@ -15313,97 +15228,49 @@ snapshots:
     optionalDependencies:
       rollup: 4.22.4
 
-  '@rollup/rollup-android-arm-eabi@4.21.2':
-    optional: true
-
   '@rollup/rollup-android-arm-eabi@4.22.4':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.21.2':
     optional: true
 
   '@rollup/rollup-android-arm64@4.22.4':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.21.2':
-    optional: true
-
   '@rollup/rollup-darwin-arm64@4.22.4':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.21.2':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.22.4':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.21.2':
-    optional: true
-
   '@rollup/rollup-linux-arm-gnueabihf@4.22.4':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.21.2':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.22.4':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.21.2':
-    optional: true
-
   '@rollup/rollup-linux-arm64-gnu@4.22.4':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.21.2':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.22.4':
     optional: true
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.21.2':
-    optional: true
-
   '@rollup/rollup-linux-powerpc64le-gnu@4.22.4':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-gnu@4.21.2':
     optional: true
 
   '@rollup/rollup-linux-riscv64-gnu@4.22.4':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.21.2':
-    optional: true
-
   '@rollup/rollup-linux-s390x-gnu@4.22.4':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.21.2':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.22.4':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.21.2':
-    optional: true
-
   '@rollup/rollup-linux-x64-musl@4.22.4':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.21.2':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.22.4':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.21.2':
-    optional: true
-
   '@rollup/rollup-win32-ia32-msvc@4.22.4':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.21.2':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.22.4':
@@ -23157,28 +23024,6 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  rollup@4.21.2:
-    dependencies:
-      '@types/estree': 1.0.5
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.21.2
-      '@rollup/rollup-android-arm64': 4.21.2
-      '@rollup/rollup-darwin-arm64': 4.21.2
-      '@rollup/rollup-darwin-x64': 4.21.2
-      '@rollup/rollup-linux-arm-gnueabihf': 4.21.2
-      '@rollup/rollup-linux-arm-musleabihf': 4.21.2
-      '@rollup/rollup-linux-arm64-gnu': 4.21.2
-      '@rollup/rollup-linux-arm64-musl': 4.21.2
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.21.2
-      '@rollup/rollup-linux-riscv64-gnu': 4.21.2
-      '@rollup/rollup-linux-s390x-gnu': 4.21.2
-      '@rollup/rollup-linux-x64-gnu': 4.21.2
-      '@rollup/rollup-linux-x64-musl': 4.21.2
-      '@rollup/rollup-win32-arm64-msvc': 4.21.2
-      '@rollup/rollup-win32-ia32-msvc': 4.21.2
-      '@rollup/rollup-win32-x64-msvc': 4.21.2
-      fsevents: 2.3.3
-
   rollup@4.22.4:
     dependencies:
       '@types/estree': 1.0.5
@@ -25404,7 +25249,7 @@ snapshots:
     dependencies:
       esbuild: 0.20.2
       postcss: 8.4.44
-      rollup: 4.21.2
+      rollup: 4.22.4
     optionalDependencies:
       '@types/node': 20.11.15
       fsevents: 2.3.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,16 +76,16 @@ importers:
         version: link:../../packages/rollup-plugin
       '@rollup/plugin-commonjs':
         specifier: ^25.0.7
-        version: 25.0.8(rollup@4.9.6)
+        version: 25.0.8(rollup@4.22.4)
       '@rollup/plugin-node-resolve':
         specifier: ^15.2.3
-        version: 15.2.3(rollup@4.9.6)
+        version: 15.2.3(rollup@4.22.4)
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
       rollup:
-        specifier: ^4.9.6
-        version: 4.9.6
+        specifier: ^4.22.4
+        version: 4.22.4
       serve:
         specifier: ^14.2.1
         version: 14.2.1
@@ -177,7 +177,7 @@ importers:
     dependencies:
       nuxt:
         specifier: ^3.12.4
-        version: 3.12.4(@parcel/watcher@2.4.1)(@types/node@20.12.12)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.4.5)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+        version: 3.12.4(@parcel/watcher@2.4.1)(@types/node@20.12.12)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.22.4)(terser@5.27.0)(typescript@5.4.5)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
       vue:
         specifier: ^3.4.21
         version: 3.4.24(typescript@5.4.5)
@@ -226,8 +226,8 @@ importers:
         specifier: ^0.4.5
         version: 0.4.5(eslint@8.56.0)
       rollup:
-        specifier: ^4.9.6
-        version: 4.9.6
+        specifier: ^4.22.4
+        version: 4.22.4
       typescript:
         specifier: ^5.3.3
         version: 5.4.5
@@ -322,16 +322,16 @@ importers:
         version: link:../../packages/rollup-plugin
       '@rollup/plugin-commonjs':
         specifier: ^25.0.7
-        version: 25.0.7(rollup@4.9.6)
+        version: 25.0.7(rollup@4.22.4)
       '@rollup/plugin-node-resolve':
         specifier: ^15.2.3
-        version: 15.2.3(rollup@4.9.6)
+        version: 15.2.3(rollup@4.22.4)
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
       rollup:
-        specifier: ^4.9.6
-        version: 4.9.6
+        specifier: ^4.22.4
+        version: 4.22.4
       serve:
         specifier: ^14.2.1
         version: 14.2.1
@@ -349,7 +349,7 @@ importers:
         version: 0.14.1(solid-js@1.8.19)
       '@solidjs/start':
         specifier: ^1.0.6
-        version: 1.0.6(rollup@4.21.2)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+        version: 1.0.6(rollup@4.22.4)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
       solid-js:
         specifier: ^1.8.18
         version: 1.8.19
@@ -433,8 +433,8 @@ importers:
         specifier: ^0.4.5
         version: 0.4.5(eslint@8.56.0)
       rollup:
-        specifier: ^4.9.6
-        version: 4.9.6
+        specifier: ^4.22.4
+        version: 4.22.4
       typescript:
         specifier: ^5.3.3
         version: 5.4.5
@@ -479,8 +479,8 @@ importers:
         specifier: ^0.4.5
         version: 0.4.5(eslint@8.56.0)
       rollup:
-        specifier: ^4.9.6
-        version: 4.9.6
+        specifier: ^4.22.4
+        version: 4.22.4
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
@@ -651,7 +651,7 @@ importers:
     dependencies:
       nuxt:
         specifier: ^3.12.4
-        version: 3.12.4(@parcel/watcher@2.4.1)(@types/node@20.12.12)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.4.5)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+        version: 3.12.4(@parcel/watcher@2.4.1)(@types/node@20.12.12)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.22.4)(terser@5.27.0)(typescript@5.4.5)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
       vue:
         specifier: ^3.4.21
         version: 3.4.24(typescript@5.4.5)
@@ -749,7 +749,7 @@ importers:
         version: 0.14.1(solid-js@1.8.19)
       '@solidjs/start':
         specifier: ^1.0.6
-        version: 1.0.6(rollup@4.21.2)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+        version: 1.0.6(rollup@4.22.4)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
       solid-js:
         specifier: ^1.8.18
         version: 1.8.19
@@ -874,7 +874,7 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.11.15)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.21.2)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.22.4)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.3.3)
@@ -920,7 +920,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.21.2)
+        version: 5.0.5(rollup@4.22.4)
       '@types/node':
         specifier: ^20.10.0
         version: 20.12.12
@@ -932,7 +932,7 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.12.12)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.21.2)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.22.4)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.4.5)
@@ -968,17 +968,17 @@ importers:
         version: link:../vite-plugin
       '@nuxt/kit':
         specifier: ^3.11.2
-        version: 3.11.2(rollup@4.21.2)
+        version: 3.11.2(rollup@4.22.4)
       nuxt:
         specifier: 3.x
-        version: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+        version: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.22.4))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.22.4)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
       unplugin:
         specifier: ^1.10.1
         version: 1.10.1
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.21.2)
+        version: 5.0.5(rollup@4.22.4)
       '@types/node':
         specifier: ^20.11.15
         version: 20.11.15
@@ -987,7 +987,7 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.11.15)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.21.2)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.22.4)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.3.3)
@@ -1030,7 +1030,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.21.2)
+        version: 5.0.5(rollup@4.22.4)
       '@types/node':
         specifier: ^20.11.15
         version: 20.12.12
@@ -1039,7 +1039,7 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.12.12)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.21.2)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.22.4)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.4.5)
@@ -1076,7 +1076,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.9.6)
+        version: 5.0.5(rollup@4.22.4)
       '@types/node':
         specifier: ^20.11.15
         version: 20.11.15
@@ -1085,13 +1085,13 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.11.15)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.9.6)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.22.4)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.3.3)
       rollup:
-        specifier: 4.9.6
-        version: 4.9.6
+        specifier: 4.22.4
+        version: 4.22.4
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@20.11.15)(typescript@5.3.3)
@@ -1121,14 +1121,14 @@ importers:
         version: link:../vite-plugin
       '@solidjs/start':
         specifier: 1.x
-        version: 1.0.6(rollup@4.21.2)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))
+        version: 1.0.6(rollup@4.22.4)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))
       unplugin:
         specifier: ^1.10.1
         version: 1.10.1
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.21.2)
+        version: 5.0.5(rollup@4.22.4)
       '@types/node':
         specifier: ^20.11.15
         version: 20.12.12
@@ -1137,7 +1137,7 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.12.12)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.21.2)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.22.4)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.4.5)
@@ -1183,7 +1183,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.21.2)
+        version: 5.0.5(rollup@4.22.4)
       '@types/node':
         specifier: ^20.11.15
         version: 20.11.15
@@ -1192,7 +1192,7 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.11.15)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.21.2)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.22.4)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.3.3)
@@ -1229,7 +1229,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.21.2)
+        version: 5.0.5(rollup@4.22.4)
       '@types/node':
         specifier: ^20.11.15
         version: 20.11.15
@@ -1238,7 +1238,7 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.11.15)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.21.2)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.22.4)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.3.3)
@@ -1275,7 +1275,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.5(rollup@4.21.2)
+        version: 5.0.5(rollup@4.22.4)
       '@types/node':
         specifier: ^20.10.0
         version: 20.10.0
@@ -1287,7 +1287,7 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.10.0)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.21.2)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.22.4)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.3.3)
@@ -4193,8 +4193,8 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm-eabi@4.21.2':
-    resolution: {integrity: sha512-fSuPrt0ZO8uXeS+xP3b+yYTCBUd05MoSp2N/MFOgjhhUhMmchXlpTQrTpI8T+YAwAQuK7MafsCOxW7VrPMrJcg==}
+  '@rollup/rollup-android-arm-eabi@4.22.4':
+    resolution: {integrity: sha512-Fxamp4aEZnfPOcGA8KSNEohV8hX7zVHOemC8jVBoBUHu5zpJK/Eu3uJwt6BMgy9fkvzxDaurgj96F/NiLukF2w==}
     cpu: [arm]
     os: [android]
 
@@ -4208,8 +4208,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.21.2':
-    resolution: {integrity: sha512-xGU5ZQmPlsjQS6tzTTGwMsnKUtu0WVbl0hYpTPauvbRAnmIvpInhJtgjj3mcuJpEiuUw4v1s4BimkdfDWlh7gA==}
+  '@rollup/rollup-android-arm64@4.22.4':
+    resolution: {integrity: sha512-VXoK5UMrgECLYaMuGuVTOx5kcuap1Jm8g/M83RnCHBKOqvPPmROFJGQaZhGccnsFtfXQ3XYa4/jMCJvZnbJBdA==}
     cpu: [arm64]
     os: [android]
 
@@ -4223,8 +4223,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-arm64@4.21.2':
-    resolution: {integrity: sha512-99AhQ3/ZMxU7jw34Sq8brzXqWH/bMnf7ZVhvLk9QU2cOepbQSVTns6qoErJmSiAvU3InRqC2RRZ5ovh1KN0d0Q==}
+  '@rollup/rollup-darwin-arm64@4.22.4':
+    resolution: {integrity: sha512-xMM9ORBqu81jyMKCDP+SZDhnX2QEVQzTcC6G18KlTQEzWK8r/oNZtKuZaCcHhnsa6fEeOBionoyl5JsAbE/36Q==}
     cpu: [arm64]
     os: [darwin]
 
@@ -4238,8 +4238,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.21.2':
-    resolution: {integrity: sha512-ZbRaUvw2iN/y37x6dY50D8m2BnDbBjlnMPotDi/qITMJ4sIxNY33HArjikDyakhSv0+ybdUxhWxE6kTI4oX26w==}
+  '@rollup/rollup-darwin-x64@4.22.4':
+    resolution: {integrity: sha512-aJJyYKQwbHuhTUrjWjxEvGnNNBCnmpHDvrb8JFDbeSH3m2XdHcxDd3jthAzvmoI8w/kSjd2y0udT+4okADsZIw==}
     cpu: [x64]
     os: [darwin]
 
@@ -4253,8 +4253,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.21.2':
-    resolution: {integrity: sha512-ztRJJMiE8nnU1YFcdbd9BcH6bGWG1z+jP+IPW2oDUAPxPjo9dverIOyXz76m6IPA6udEL12reYeLojzW2cYL7w==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.22.4':
+    resolution: {integrity: sha512-j63YtCIRAzbO+gC2L9dWXRh5BFetsv0j0va0Wi9epXDgU/XUi5dJKo4USTttVyK7fGw2nPWK0PbAvyliz50SCQ==}
     cpu: [arm]
     os: [linux]
 
@@ -4268,8 +4268,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.21.2':
-    resolution: {integrity: sha512-flOcGHDZajGKYpLV0JNc0VFH361M7rnV1ee+NTeC/BQQ1/0pllYcFmxpagltANYt8FYf9+kL6RSk80Ziwyhr7w==}
+  '@rollup/rollup-linux-arm-musleabihf@4.22.4':
+    resolution: {integrity: sha512-dJnWUgwWBX1YBRsuKKMOlXCzh2Wu1mlHzv20TpqEsfdZLb3WoJW2kIEsGwLkroYf24IrPAvOT/ZQ2OYMV6vlrg==}
     cpu: [arm]
     os: [linux]
 
@@ -4278,8 +4278,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.21.2':
-    resolution: {integrity: sha512-69CF19Kp3TdMopyteO/LJbWufOzqqXzkrv4L2sP8kfMaAQ6iwky7NoXTp7bD6/irKgknDKM0P9E/1l5XxVQAhw==}
+  '@rollup/rollup-linux-arm64-gnu@4.22.4':
+    resolution: {integrity: sha512-AdPRoNi3NKVLolCN/Sp4F4N1d98c4SBnHMKoLuiG6RXgoZ4sllseuGioszumnPGmPM2O7qaAX/IJdeDU8f26Aw==}
     cpu: [arm64]
     os: [linux]
 
@@ -4293,8 +4293,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.21.2':
-    resolution: {integrity: sha512-48pD/fJkTiHAZTnZwR0VzHrao70/4MlzJrq0ZsILjLW/Ab/1XlVUStYyGt7tdyIiVSlGZbnliqmult/QGA2O2w==}
+  '@rollup/rollup-linux-arm64-musl@4.22.4':
+    resolution: {integrity: sha512-Gl0AxBtDg8uoAn5CCqQDMqAx22Wx22pjDOjBdmG0VIWX3qUBHzYmOKh8KXHL4UpogfJ14G4wk16EQogF+v8hmA==}
     cpu: [arm64]
     os: [linux]
 
@@ -4308,8 +4308,8 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.21.2':
-    resolution: {integrity: sha512-cZdyuInj0ofc7mAQpKcPR2a2iu4YM4FQfuUzCVA2u4HI95lCwzjoPtdWjdpDKyHxI0UO82bLDoOaLfpZ/wviyQ==}
+  '@rollup/rollup-linux-powerpc64le-gnu@4.22.4':
+    resolution: {integrity: sha512-3aVCK9xfWW1oGQpTsYJJPF6bfpWfhbRnhdlyhak2ZiyFLDaayz0EP5j9V1RVLAAxlmWKTDfS9wyRyY3hvhPoOg==}
     cpu: [ppc64]
     os: [linux]
 
@@ -4318,8 +4318,8 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.21.2':
-    resolution: {integrity: sha512-RL56JMT6NwQ0lXIQmMIWr1SW28z4E4pOhRRNqwWZeXpRlykRIlEpSWdsgNWJbYBEWD84eocjSGDu/XxbYeCmwg==}
+  '@rollup/rollup-linux-riscv64-gnu@4.22.4':
+    resolution: {integrity: sha512-ePYIir6VYnhgv2C5Xe9u+ico4t8sZWXschR6fMgoPUK31yQu7hTEJb7bCqivHECwIClJfKgE7zYsh1qTP3WHUA==}
     cpu: [riscv64]
     os: [linux]
 
@@ -4333,8 +4333,8 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.21.2':
-    resolution: {integrity: sha512-PMxkrWS9z38bCr3rWvDFVGD6sFeZJw4iQlhrup7ReGmfn7Oukrr/zweLhYX6v2/8J6Cep9IEA/SmjXjCmSbrMQ==}
+  '@rollup/rollup-linux-s390x-gnu@4.22.4':
+    resolution: {integrity: sha512-GqFJ9wLlbB9daxhVlrTe61vJtEY99/xB3C8e4ULVsVfflcpmR6c8UZXjtkMA6FhNONhj2eA5Tk9uAVw5orEs4Q==}
     cpu: [s390x]
     os: [linux]
 
@@ -4343,8 +4343,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.21.2':
-    resolution: {integrity: sha512-B90tYAUoLhU22olrafY3JQCFLnT3NglazdwkHyxNDYF/zAxJt5fJUB/yBoWFoIQ7SQj+KLe3iL4BhOMa9fzgpw==}
+  '@rollup/rollup-linux-x64-gnu@4.22.4':
+    resolution: {integrity: sha512-87v0ol2sH9GE3cLQLNEy0K/R0pz1nvg76o8M5nhMR0+Q+BBGLnb35P0fVz4CQxHYXaAOhE8HhlkaZfsdUOlHwg==}
     cpu: [x64]
     os: [linux]
 
@@ -4358,8 +4358,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.21.2':
-    resolution: {integrity: sha512-7twFizNXudESmC9oneLGIUmoHiiLppz/Xs5uJQ4ShvE6234K0VB1/aJYU3f/4g7PhssLGKBVCC37uRkkOi8wjg==}
+  '@rollup/rollup-linux-x64-musl@4.22.4':
+    resolution: {integrity: sha512-UV6FZMUgePDZrFjrNGIWzDo/vABebuXBhJEqrHxrGiU6HikPy0Z3LfdtciIttEUQfuDdCn8fqh7wiFJjCNwO+g==}
     cpu: [x64]
     os: [linux]
 
@@ -4373,8 +4373,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-arm64-msvc@4.21.2':
-    resolution: {integrity: sha512-9rRero0E7qTeYf6+rFh3AErTNU1VCQg2mn7CQcI44vNUWM9Ze7MSRS/9RFuSsox+vstRt97+x3sOhEey024FRQ==}
+  '@rollup/rollup-win32-arm64-msvc@4.22.4':
+    resolution: {integrity: sha512-BjI+NVVEGAXjGWYHz/vv0pBqfGoUH0IGZ0cICTn7kB9PyjrATSkX+8WkguNjWoj2qSr1im/+tTGRaY+4/PdcQw==}
     cpu: [arm64]
     os: [win32]
 
@@ -4388,8 +4388,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.21.2':
-    resolution: {integrity: sha512-5rA4vjlqgrpbFVVHX3qkrCo/fZTj1q0Xxpg+Z7yIo3J2AilW7t2+n6Q8Jrx+4MrYpAnjttTYF8rr7bP46BPzRw==}
+  '@rollup/rollup-win32-ia32-msvc@4.22.4':
+    resolution: {integrity: sha512-SiWG/1TuUdPvYmzmYnmd3IEifzR61Tragkbx9D3+R8mzQqDBz8v+BvZNDlkiTtI9T15KYZhP0ehn3Dld4n9J5g==}
     cpu: [ia32]
     os: [win32]
 
@@ -4403,8 +4403,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.21.2':
-    resolution: {integrity: sha512-6UUxd0+SKomjdzuAcp+HAmxw1FlGBnl1v2yEPSabtx4lBfdXHDVsW7+lQkgz9cNFJGY3AWR7+V8P5BqkD9L9nA==}
+  '@rollup/rollup-win32-x64-msvc@4.22.4':
+    resolution: {integrity: sha512-j8pPKp53/lq9lMXN57S8cFz0MynJk8OWNuUnXct/9KCpKU7DgU3bYMJhwWmcqC0UU29p8Lr0/7KEVcaM6bf47Q==}
     cpu: [x64]
     os: [win32]
 
@@ -9826,8 +9826,8 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rollup@4.21.2:
-    resolution: {integrity: sha512-e3TapAgYf9xjdLvKQCkQTnbTKd4a6jwlpQSJJFokHGaX2IVjoEqkIIhiQfqsi0cdwlOD+tQGuOd5AJkc5RngBw==}
+  rollup@4.22.4:
+    resolution: {integrity: sha512-vD8HJ5raRcWOyymsR6Z3o6+RzfEPCnVLMFJ6vRslO1jt4LO6dUo5Qnpg7y4RkZFM2DMe3WUirkI5c16onjrc6A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -13102,15 +13102,10 @@ snapshots:
       '@codecov/bundler-plugin-core': 0.0.1-beta.6
       rollup: 3.29.4
 
-  '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.21.2)':
+  '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.22.4)':
     dependencies:
       '@codecov/bundler-plugin-core': 0.0.1-beta.6
-      rollup: 4.21.2
-
-  '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.9.6)':
-    dependencies:
-      '@codecov/bundler-plugin-core': 0.0.1-beta.6
-      rollup: 4.9.6
+      rollup: 4.22.4
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -14090,12 +14085,12 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@1.2.0(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))':
+  '@nuxt/devtools-kit@1.2.0(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.22.4))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.22.4)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))':
     dependencies:
-      '@nuxt/kit': 3.11.2(rollup@4.21.2)
-      '@nuxt/schema': 3.11.2(rollup@4.21.2)
+      '@nuxt/kit': 3.11.2(rollup@4.22.4)
+      '@nuxt/schema': 3.11.2(rollup@4.22.4)
       execa: 7.2.0
-      nuxt: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+      nuxt: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.22.4))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.22.4)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
       vite: 5.2.10(@types/node@20.11.15)(terser@5.27.0)
     transitivePeerDependencies:
       - rollup
@@ -14112,10 +14107,10 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/devtools-kit@1.4.1(magicast@0.3.4)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))':
+  '@nuxt/devtools-kit@1.4.1(magicast@0.3.4)(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))':
     dependencies:
-      '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.21.2)
-      '@nuxt/schema': 3.13.0(rollup@4.21.2)
+      '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.22.4)
+      '@nuxt/schema': 3.13.0(rollup@4.22.4)
       execa: 7.2.0
       vite: 5.2.10(@types/node@20.11.15)(terser@5.27.0)
     transitivePeerDependencies:
@@ -14123,10 +14118,10 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/devtools-kit@1.4.1(magicast@0.3.4)(rollup@4.21.2)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))':
+  '@nuxt/devtools-kit@1.4.1(magicast@0.3.4)(rollup@4.22.4)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))':
     dependencies:
-      '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.21.2)
-      '@nuxt/schema': 3.13.0(rollup@4.21.2)
+      '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.22.4)
+      '@nuxt/schema': 3.13.0(rollup@4.22.4)
       execa: 7.2.0
       vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
     transitivePeerDependencies:
@@ -14160,13 +14155,13 @@ snapshots:
       rc9: 2.1.2
       semver: 7.6.3
 
-  '@nuxt/devtools@1.2.0(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.21.2)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))':
+  '@nuxt/devtools@1.2.0(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.22.4))(vue@3.4.24(typescript@5.3.3)))(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.22.4))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.22.4)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.22.4)(unocss@0.59.4(postcss@8.4.38)(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))':
     dependencies:
       '@antfu/utils': 0.7.7
-      '@nuxt/devtools-kit': 1.2.0(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+      '@nuxt/devtools-kit': 1.2.0(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.22.4))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.22.4)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
       '@nuxt/devtools-wizard': 1.2.0
-      '@nuxt/kit': 3.11.2(rollup@4.21.2)
-      '@vue/devtools-applet': 7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
+      '@nuxt/kit': 3.11.2(rollup@4.22.4)
+      '@vue/devtools-applet': 7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.22.4))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
       '@vue/devtools-core': 7.0.27(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
       '@vue/devtools-kit': 7.0.27(vue@3.4.24(typescript@5.3.3))
       birpc: 0.2.17
@@ -14184,7 +14179,7 @@ snapshots:
       launch-editor: 2.6.1
       local-pkg: 0.5.0
       magicast: 0.3.4
-      nuxt: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+      nuxt: 3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.22.4))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.22.4)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
       nypm: 0.3.8
       ohash: 1.1.3
       pacote: 18.0.0
@@ -14196,9 +14191,9 @@ snapshots:
       semver: 7.6.0
       simple-git: 3.24.0
       sirv: 2.0.4
-      unimport: 3.7.1(rollup@4.21.2)
+      unimport: 3.7.1(rollup@4.22.4)
       vite: 5.2.10(@types/node@20.11.15)(terser@5.27.0)
-      vite-plugin-inspect: 0.8.4(@nuxt/kit@3.11.2(rollup@4.21.2))(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+      vite-plugin-inspect: 0.8.4(@nuxt/kit@3.11.2(rollup@4.22.4))(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
       vite-plugin-vue-inspector: 4.0.2(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
       which: 3.0.1
       ws: 8.16.0
@@ -14271,12 +14266,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@nuxt/devtools@1.4.1(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))':
+  '@nuxt/devtools@1.4.1(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))':
     dependencies:
       '@antfu/utils': 0.7.10
-      '@nuxt/devtools-kit': 1.4.1(magicast@0.3.4)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+      '@nuxt/devtools-kit': 1.4.1(magicast@0.3.4)(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
       '@nuxt/devtools-wizard': 1.4.1
-      '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.21.2)
+      '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.22.4)
       '@vue/devtools-core': 7.3.3(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
       '@vue/devtools-kit': 7.3.3
       birpc: 0.2.17
@@ -14305,9 +14300,9 @@ snapshots:
       simple-git: 3.26.0
       sirv: 2.0.4
       tinyglobby: 0.2.5
-      unimport: 3.11.1(rollup@4.21.2)
+      unimport: 3.11.1(rollup@4.22.4)
       vite: 5.2.10(@types/node@20.11.15)(terser@5.27.0)
-      vite-plugin-inspect: 0.8.7(@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@4.21.2))(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+      vite-plugin-inspect: 0.8.7(@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@4.22.4))(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
       vite-plugin-vue-inspector: 5.2.0(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
       which: 3.0.1
       ws: 8.18.0
@@ -14317,12 +14312,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@nuxt/devtools@1.4.1(rollup@4.21.2)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))':
+  '@nuxt/devtools@1.4.1(rollup@4.22.4)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))':
     dependencies:
       '@antfu/utils': 0.7.10
-      '@nuxt/devtools-kit': 1.4.1(magicast@0.3.4)(rollup@4.21.2)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+      '@nuxt/devtools-kit': 1.4.1(magicast@0.3.4)(rollup@4.22.4)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
       '@nuxt/devtools-wizard': 1.4.1
-      '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.21.2)
+      '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.22.4)
       '@vue/devtools-core': 7.3.3(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
       '@vue/devtools-kit': 7.3.3
       birpc: 0.2.17
@@ -14351,9 +14346,9 @@ snapshots:
       simple-git: 3.26.0
       sirv: 2.0.4
       tinyglobby: 0.2.5
-      unimport: 3.11.1(rollup@4.21.2)
+      unimport: 3.11.1(rollup@4.22.4)
       vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
-      vite-plugin-inspect: 0.8.7(@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@4.21.2))(rollup@4.21.2)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+      vite-plugin-inspect: 0.8.7(@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@4.22.4))(rollup@4.22.4)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
       vite-plugin-vue-inspector: 5.2.0(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
       which: 3.0.1
       ws: 8.18.0
@@ -14387,9 +14382,9 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/kit@3.11.2(rollup@4.21.2)':
+  '@nuxt/kit@3.11.2(rollup@4.22.4)':
     dependencies:
-      '@nuxt/schema': 3.11.2(rollup@4.21.2)
+      '@nuxt/schema': 3.11.2(rollup@4.22.4)
       c12: 1.10.0
       consola: 3.2.3
       defu: 6.1.4
@@ -14405,7 +14400,7 @@ snapshots:
       semver: 7.6.0
       ufo: 1.5.3
       unctx: 2.3.1
-      unimport: 3.7.1(rollup@4.21.2)
+      unimport: 3.7.1(rollup@4.22.4)
       untyped: 1.4.2
     transitivePeerDependencies:
       - rollup
@@ -14438,9 +14433,9 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/kit@3.12.4(magicast@0.3.4)(rollup@4.21.2)':
+  '@nuxt/kit@3.12.4(magicast@0.3.4)(rollup@4.22.4)':
     dependencies:
-      '@nuxt/schema': 3.12.4(rollup@4.21.2)
+      '@nuxt/schema': 3.12.4(rollup@4.22.4)
       c12: 1.11.2(magicast@0.3.4)
       consola: 3.2.3
       defu: 6.1.4
@@ -14458,7 +14453,7 @@ snapshots:
       semver: 7.6.3
       ufo: 1.5.4
       unctx: 2.3.1
-      unimport: 3.11.1(rollup@4.21.2)
+      unimport: 3.11.1(rollup@4.22.4)
       untyped: 1.4.2
     transitivePeerDependencies:
       - magicast
@@ -14492,9 +14487,9 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@4.21.2)':
+  '@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@4.22.4)':
     dependencies:
-      '@nuxt/schema': 3.13.0(rollup@4.21.2)
+      '@nuxt/schema': 3.13.0(rollup@4.22.4)
       c12: 1.11.2(magicast@0.3.4)
       consola: 3.2.3
       defu: 6.1.4
@@ -14512,7 +14507,7 @@ snapshots:
       semver: 7.6.3
       ufo: 1.5.4
       unctx: 2.3.1
-      unimport: 3.11.1(rollup@4.21.2)
+      unimport: 3.11.1(rollup@4.22.4)
       untyped: 1.4.2
     transitivePeerDependencies:
       - magicast
@@ -14536,7 +14531,7 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/schema@3.11.2(rollup@4.21.2)':
+  '@nuxt/schema@3.11.2(rollup@4.22.4)':
     dependencies:
       '@nuxt/ui-templates': 1.3.3
       consola: 3.2.3
@@ -14547,7 +14542,7 @@ snapshots:
       scule: 1.3.0
       std-env: 3.7.0
       ufo: 1.5.3
-      unimport: 3.7.1(rollup@4.21.2)
+      unimport: 3.7.1(rollup@4.22.4)
       untyped: 1.4.2
     transitivePeerDependencies:
       - rollup
@@ -14571,7 +14566,7 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/schema@3.12.4(rollup@4.21.2)':
+  '@nuxt/schema@3.12.4(rollup@4.22.4)':
     dependencies:
       compatx: 0.1.8
       consola: 3.2.3
@@ -14583,7 +14578,7 @@ snapshots:
       std-env: 3.7.0
       ufo: 1.5.4
       uncrypto: 0.1.3
-      unimport: 3.11.1(rollup@4.21.2)
+      unimport: 3.11.1(rollup@4.22.4)
       untyped: 1.4.2
     transitivePeerDependencies:
       - rollup
@@ -14607,7 +14602,7 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/schema@3.13.0(rollup@4.21.2)':
+  '@nuxt/schema@3.13.0(rollup@4.22.4)':
     dependencies:
       compatx: 0.1.8
       consola: 3.2.3
@@ -14619,7 +14614,7 @@ snapshots:
       std-env: 3.7.0
       ufo: 1.5.4
       uncrypto: 0.1.3
-      unimport: 3.11.1(rollup@4.21.2)
+      unimport: 3.11.1(rollup@4.22.4)
       untyped: 1.4.2
     transitivePeerDependencies:
       - rollup
@@ -14648,9 +14643,9 @@ snapshots:
       - rollup
       - supports-color
 
-  '@nuxt/telemetry@2.5.4(rollup@4.21.2)':
+  '@nuxt/telemetry@2.5.4(rollup@4.22.4)':
     dependencies:
-      '@nuxt/kit': 3.11.2(rollup@4.21.2)
+      '@nuxt/kit': 3.11.2(rollup@4.22.4)
       ci-info: 4.0.0
       consola: 3.2.3
       create-require: 1.1.1
@@ -14673,10 +14668,10 @@ snapshots:
 
   '@nuxt/ui-templates@1.3.3': {}
 
-  '@nuxt/vite-builder@3.11.2(@types/node@20.11.15)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(vue@3.4.24(typescript@5.3.3))':
+  '@nuxt/vite-builder@3.11.2(@types/node@20.11.15)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.22.4)(terser@5.27.0)(typescript@5.3.3)(vue@3.4.24(typescript@5.3.3))':
     dependencies:
-      '@nuxt/kit': 3.11.2(rollup@4.21.2)
-      '@rollup/plugin-replace': 5.0.7(rollup@4.21.2)
+      '@nuxt/kit': 3.11.2(rollup@4.22.4)
+      '@rollup/plugin-replace': 5.0.7(rollup@4.22.4)
       '@vitejs/plugin-vue': 5.0.4(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
       '@vitejs/plugin-vue-jsx': 3.1.0(vite@5.4.3(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
       autoprefixer: 10.4.19(postcss@8.4.38)
@@ -14699,7 +14694,7 @@ snapshots:
       perfect-debounce: 1.0.0
       pkg-types: 1.1.0
       postcss: 8.4.38
-      rollup-plugin-visualizer: 5.12.0(rollup@4.21.2)
+      rollup-plugin-visualizer: 5.12.0(rollup@4.22.4)
       std-env: 3.7.0
       strip-literal: 2.1.0
       ufo: 1.5.3
@@ -14790,10 +14785,10 @@ snapshots:
       - vti
       - vue-tsc
 
-  '@nuxt/vite-builder@3.12.4(@types/node@20.12.12)(eslint@8.56.0)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.4.5)(vue@3.5.0(typescript@5.4.5))':
+  '@nuxt/vite-builder@3.12.4(@types/node@20.12.12)(eslint@8.56.0)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.22.4)(terser@5.27.0)(typescript@5.4.5)(vue@3.5.0(typescript@5.4.5))':
     dependencies:
-      '@nuxt/kit': 3.12.4(magicast@0.3.4)(rollup@4.21.2)
-      '@rollup/plugin-replace': 5.0.7(rollup@4.21.2)
+      '@nuxt/kit': 3.12.4(magicast@0.3.4)(rollup@4.22.4)
+      '@rollup/plugin-replace': 5.0.7(rollup@4.22.4)
       '@vitejs/plugin-vue': 5.1.3(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))(vue@3.5.0(typescript@5.4.5))
       '@vitejs/plugin-vue-jsx': 4.0.1(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))(vue@3.5.0(typescript@5.4.5))
       autoprefixer: 10.4.19(postcss@8.4.44)
@@ -14815,7 +14810,7 @@ snapshots:
       perfect-debounce: 1.0.0
       pkg-types: 1.2.0
       postcss: 8.4.44
-      rollup-plugin-visualizer: 5.12.0(rollup@4.21.2)
+      rollup-plugin-visualizer: 5.12.0(rollup@4.22.4)
       std-env: 3.7.0
       strip-literal: 2.1.0
       ufo: 1.5.4
@@ -15260,11 +15255,11 @@ snapshots:
     optionalDependencies:
       rollup: 3.29.4
 
-  '@rollup/plugin-alias@5.1.0(rollup@4.21.2)':
+  '@rollup/plugin-alias@5.1.0(rollup@4.22.4)':
     dependencies:
       slash: 4.0.0
     optionalDependencies:
-      rollup: 4.21.2
+      rollup: 4.22.4
 
   '@rollup/plugin-commonjs@25.0.7(rollup@3.29.4)':
     dependencies:
@@ -15277,16 +15272,16 @@ snapshots:
     optionalDependencies:
       rollup: 3.29.4
 
-  '@rollup/plugin-commonjs@25.0.7(rollup@4.9.6)':
+  '@rollup/plugin-commonjs@25.0.7(rollup@4.22.4)':
     dependencies:
-      '@rollup/pluginutils': 5.0.5(rollup@4.9.6)
+      '@rollup/pluginutils': 5.0.5(rollup@4.22.4)
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 8.1.0
       is-reference: 1.2.1
       magic-string: 0.30.5
     optionalDependencies:
-      rollup: 4.9.6
+      rollup: 4.22.4
 
   '@rollup/plugin-commonjs@25.0.8(rollup@3.29.4)':
     dependencies:
@@ -15299,35 +15294,24 @@ snapshots:
     optionalDependencies:
       rollup: 3.29.4
 
-  '@rollup/plugin-commonjs@25.0.8(rollup@4.21.2)':
+  '@rollup/plugin-commonjs@25.0.8(rollup@4.22.4)':
     dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      '@rollup/pluginutils': 5.1.0(rollup@4.22.4)
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 8.1.0
       is-reference: 1.2.1
       magic-string: 0.30.11
     optionalDependencies:
-      rollup: 4.21.2
+      rollup: 4.22.4
 
-  '@rollup/plugin-commonjs@25.0.8(rollup@4.9.6)':
+  '@rollup/plugin-inject@5.0.5(rollup@4.22.4)':
     dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.9.6)
-      commondir: 1.0.1
-      estree-walker: 2.0.2
-      glob: 8.1.0
-      is-reference: 1.2.1
-      magic-string: 0.30.11
-    optionalDependencies:
-      rollup: 4.9.6
-
-  '@rollup/plugin-inject@5.0.5(rollup@4.21.2)':
-    dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      '@rollup/pluginutils': 5.1.0(rollup@4.22.4)
       estree-walker: 2.0.2
       magic-string: 0.30.11
     optionalDependencies:
-      rollup: 4.21.2
+      rollup: 4.22.4
 
   '@rollup/plugin-json@6.1.0(rollup@3.29.4)':
     dependencies:
@@ -15335,11 +15319,11 @@ snapshots:
     optionalDependencies:
       rollup: 3.29.4
 
-  '@rollup/plugin-json@6.1.0(rollup@4.21.2)':
+  '@rollup/plugin-json@6.1.0(rollup@4.22.4)':
     dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      '@rollup/pluginutils': 5.1.0(rollup@4.22.4)
     optionalDependencies:
-      rollup: 4.21.2
+      rollup: 4.22.4
 
   '@rollup/plugin-node-resolve@15.2.3(rollup@3.29.4)':
     dependencies:
@@ -15352,41 +15336,23 @@ snapshots:
     optionalDependencies:
       rollup: 3.29.4
 
-  '@rollup/plugin-node-resolve@15.2.3(rollup@4.21.2)':
+  '@rollup/plugin-node-resolve@15.2.3(rollup@4.22.4)':
     dependencies:
-      '@rollup/pluginutils': 5.0.5(rollup@4.21.2)
+      '@rollup/pluginutils': 5.0.5(rollup@4.22.4)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-builtin-module: 3.2.1
       is-module: 1.0.0
       resolve: 1.22.8
     optionalDependencies:
-      rollup: 4.21.2
+      rollup: 4.22.4
 
-  '@rollup/plugin-node-resolve@15.2.3(rollup@4.9.6)':
+  '@rollup/plugin-replace@5.0.5(rollup@4.22.4)':
     dependencies:
-      '@rollup/pluginutils': 5.0.5(rollup@4.9.6)
-      '@types/resolve': 1.20.2
-      deepmerge: 4.3.1
-      is-builtin-module: 3.2.1
-      is-module: 1.0.0
-      resolve: 1.22.8
-    optionalDependencies:
-      rollup: 4.9.6
-
-  '@rollup/plugin-replace@5.0.5(rollup@4.21.2)':
-    dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      '@rollup/pluginutils': 5.1.0(rollup@4.22.4)
       magic-string: 0.30.10
     optionalDependencies:
-      rollup: 4.21.2
-
-  '@rollup/plugin-replace@5.0.5(rollup@4.9.6)':
-    dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.9.6)
-      magic-string: 0.30.10
-    optionalDependencies:
-      rollup: 4.9.6
+      rollup: 4.22.4
 
   '@rollup/plugin-replace@5.0.7(rollup@3.29.4)':
     dependencies:
@@ -15395,20 +15361,20 @@ snapshots:
     optionalDependencies:
       rollup: 3.29.4
 
-  '@rollup/plugin-replace@5.0.7(rollup@4.21.2)':
+  '@rollup/plugin-replace@5.0.7(rollup@4.22.4)':
     dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      '@rollup/pluginutils': 5.1.0(rollup@4.22.4)
       magic-string: 0.30.11
     optionalDependencies:
-      rollup: 4.21.2
+      rollup: 4.22.4
 
-  '@rollup/plugin-terser@0.4.4(rollup@4.21.2)':
+  '@rollup/plugin-terser@0.4.4(rollup@4.22.4)':
     dependencies:
       serialize-javascript: 6.0.1
       smob: 1.5.0
       terser: 5.27.0
     optionalDependencies:
-      rollup: 4.21.2
+      rollup: 4.22.4
 
   '@rollup/pluginutils@4.2.1':
     dependencies:
@@ -15423,21 +15389,13 @@ snapshots:
     optionalDependencies:
       rollup: 3.29.4
 
-  '@rollup/pluginutils@5.0.5(rollup@4.21.2)':
+  '@rollup/pluginutils@5.0.5(rollup@4.22.4)':
     dependencies:
       '@types/estree': 1.0.5
       estree-walker: 2.0.2
       picomatch: 2.3.1
     optionalDependencies:
-      rollup: 4.21.2
-
-  '@rollup/pluginutils@5.0.5(rollup@4.9.6)':
-    dependencies:
-      '@types/estree': 1.0.5
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
-    optionalDependencies:
-      rollup: 4.9.6
+      rollup: 4.22.4
 
   '@rollup/pluginutils@5.1.0(rollup@3.29.4)':
     dependencies:
@@ -15447,26 +15405,18 @@ snapshots:
     optionalDependencies:
       rollup: 3.29.4
 
-  '@rollup/pluginutils@5.1.0(rollup@4.21.2)':
+  '@rollup/pluginutils@5.1.0(rollup@4.22.4)':
     dependencies:
       '@types/estree': 1.0.5
       estree-walker: 2.0.2
       picomatch: 2.3.1
     optionalDependencies:
-      rollup: 4.21.2
-
-  '@rollup/pluginutils@5.1.0(rollup@4.9.6)':
-    dependencies:
-      '@types/estree': 1.0.5
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
-    optionalDependencies:
-      rollup: 4.9.6
+      rollup: 4.22.4
 
   '@rollup/rollup-android-arm-eabi@4.16.2':
     optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.21.2':
+  '@rollup/rollup-android-arm-eabi@4.22.4':
     optional: true
 
   '@rollup/rollup-android-arm-eabi@4.9.6':
@@ -15475,7 +15425,7 @@ snapshots:
   '@rollup/rollup-android-arm64@4.16.2':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.21.2':
+  '@rollup/rollup-android-arm64@4.22.4':
     optional: true
 
   '@rollup/rollup-android-arm64@4.9.6':
@@ -15484,7 +15434,7 @@ snapshots:
   '@rollup/rollup-darwin-arm64@4.16.2':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.21.2':
+  '@rollup/rollup-darwin-arm64@4.22.4':
     optional: true
 
   '@rollup/rollup-darwin-arm64@4.9.6':
@@ -15493,7 +15443,7 @@ snapshots:
   '@rollup/rollup-darwin-x64@4.16.2':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.21.2':
+  '@rollup/rollup-darwin-x64@4.22.4':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.9.6':
@@ -15502,7 +15452,7 @@ snapshots:
   '@rollup/rollup-linux-arm-gnueabihf@4.16.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.21.2':
+  '@rollup/rollup-linux-arm-gnueabihf@4.22.4':
     optional: true
 
   '@rollup/rollup-linux-arm-gnueabihf@4.9.6':
@@ -15511,13 +15461,13 @@ snapshots:
   '@rollup/rollup-linux-arm-musleabihf@4.16.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.21.2':
+  '@rollup/rollup-linux-arm-musleabihf@4.22.4':
     optional: true
 
   '@rollup/rollup-linux-arm64-gnu@4.16.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.21.2':
+  '@rollup/rollup-linux-arm64-gnu@4.22.4':
     optional: true
 
   '@rollup/rollup-linux-arm64-gnu@4.9.6':
@@ -15526,7 +15476,7 @@ snapshots:
   '@rollup/rollup-linux-arm64-musl@4.16.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.21.2':
+  '@rollup/rollup-linux-arm64-musl@4.22.4':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.9.6':
@@ -15535,13 +15485,13 @@ snapshots:
   '@rollup/rollup-linux-powerpc64le-gnu@4.16.2':
     optional: true
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.21.2':
+  '@rollup/rollup-linux-powerpc64le-gnu@4.22.4':
     optional: true
 
   '@rollup/rollup-linux-riscv64-gnu@4.16.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.21.2':
+  '@rollup/rollup-linux-riscv64-gnu@4.22.4':
     optional: true
 
   '@rollup/rollup-linux-riscv64-gnu@4.9.6':
@@ -15550,13 +15500,13 @@ snapshots:
   '@rollup/rollup-linux-s390x-gnu@4.16.2':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.21.2':
+  '@rollup/rollup-linux-s390x-gnu@4.22.4':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.16.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.21.2':
+  '@rollup/rollup-linux-x64-gnu@4.22.4':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.9.6':
@@ -15565,7 +15515,7 @@ snapshots:
   '@rollup/rollup-linux-x64-musl@4.16.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.21.2':
+  '@rollup/rollup-linux-x64-musl@4.22.4':
     optional: true
 
   '@rollup/rollup-linux-x64-musl@4.9.6':
@@ -15574,7 +15524,7 @@ snapshots:
   '@rollup/rollup-win32-arm64-msvc@4.16.2':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.21.2':
+  '@rollup/rollup-win32-arm64-msvc@4.22.4':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.9.6':
@@ -15583,7 +15533,7 @@ snapshots:
   '@rollup/rollup-win32-ia32-msvc@4.16.2':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.21.2':
+  '@rollup/rollup-win32-ia32-msvc@4.22.4':
     optional: true
 
   '@rollup/rollup-win32-ia32-msvc@4.9.6':
@@ -15592,7 +15542,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.16.2':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.21.2':
+  '@rollup/rollup-win32-x64-msvc@4.22.4':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.9.6':
@@ -15676,7 +15626,7 @@ snapshots:
       - vinxi
       - vite
 
-  '@solidjs/start@1.0.6(rollup@4.21.2)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))':
+  '@solidjs/start@1.0.6(rollup@4.22.4)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))':
     dependencies:
       '@vinxi/plugin-directives': 0.4.1(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))
       '@vinxi/server-components': 0.4.1(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))
@@ -15691,7 +15641,7 @@ snapshots:
       shikiji: 0.9.19
       source-map-js: 1.2.0
       terracotta: 1.0.5(solid-js@1.8.19)
-      vite-plugin-inspect: 0.7.42(rollup@4.21.2)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))
+      vite-plugin-inspect: 0.7.42(rollup@4.22.4)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))
       vite-plugin-solid: 2.10.2(solid-js@1.8.19)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0))
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -15702,7 +15652,7 @@ snapshots:
       - vinxi
       - vite
 
-  '@solidjs/start@1.0.6(rollup@4.21.2)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))':
+  '@solidjs/start@1.0.6(rollup@4.22.4)(solid-js@1.8.19)(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))':
     dependencies:
       '@vinxi/plugin-directives': 0.4.1(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))
       '@vinxi/server-components': 0.4.1(vinxi@0.4.1(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0))
@@ -15717,7 +15667,7 @@ snapshots:
       shikiji: 0.9.19
       source-map-js: 1.2.0
       terracotta: 1.0.5(solid-js@1.8.19)
-      vite-plugin-inspect: 0.7.42(rollup@4.21.2)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+      vite-plugin-inspect: 0.7.42(rollup@4.22.4)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
       vite-plugin-solid: 2.10.2(solid-js@1.8.19)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
     transitivePeerDependencies:
       - '@nuxt/kit'
@@ -16257,20 +16207,20 @@ snapshots:
       unhead: 1.9.7
       vue: 3.4.24(typescript@5.3.3)
 
-  '@unocss/astro@0.59.4(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))':
+  '@unocss/astro@0.59.4(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))':
     dependencies:
       '@unocss/core': 0.59.4
       '@unocss/reset': 0.59.4
-      '@unocss/vite': 0.59.4(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+      '@unocss/vite': 0.59.4(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
     optionalDependencies:
       vite: 5.2.10(@types/node@20.11.15)(terser@5.27.0)
     transitivePeerDependencies:
       - rollup
 
-  '@unocss/cli@0.59.4(rollup@4.21.2)':
+  '@unocss/cli@0.59.4(rollup@4.22.4)':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      '@rollup/pluginutils': 5.1.0(rollup@4.22.4)
       '@unocss/config': 0.59.4
       '@unocss/core': 0.59.4
       '@unocss/preset-uno': 0.59.4
@@ -16394,10 +16344,10 @@ snapshots:
     dependencies:
       '@unocss/core': 0.59.4
 
-  '@unocss/vite@0.59.4(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))':
+  '@unocss/vite@0.59.4(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      '@rollup/pluginutils': 5.1.0(rollup@4.22.4)
       '@unocss/config': 0.59.4
       '@unocss/core': 0.59.4
       '@unocss/inspector': 0.59.4
@@ -16769,10 +16719,10 @@ snapshots:
       loupe: 2.3.7
       pretty-format: 29.7.0
 
-  '@vue-macros/common@1.10.2(rollup@4.21.2)(vue@3.4.24(typescript@5.3.3))':
+  '@vue-macros/common@1.10.2(rollup@4.22.4)(vue@3.4.24(typescript@5.3.3))':
     dependencies:
       '@babel/types': 7.24.0
-      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      '@rollup/pluginutils': 5.1.0(rollup@4.22.4)
       '@vue/compiler-sfc': 3.4.24
       ast-kit: 0.12.1
       local-pkg: 0.5.0
@@ -16795,10 +16745,10 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  '@vue-macros/common@1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.4.5))':
+  '@vue-macros/common@1.12.2(rollup@4.22.4)(vue@3.5.0(typescript@5.4.5))':
     dependencies:
       '@babel/types': 7.25.6
-      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      '@rollup/pluginutils': 5.1.0(rollup@4.22.4)
       '@vue/compiler-sfc': 3.5.0
       ast-kit: 1.1.0
       local-pkg: 0.5.0
@@ -16958,12 +16908,12 @@ snapshots:
 
   '@vue/devtools-api@6.6.3': {}
 
-  '@vue/devtools-applet@7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))':
+  '@vue/devtools-applet@7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.22.4))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))':
     dependencies:
       '@vue/devtools-core': 7.0.27(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
       '@vue/devtools-kit': 7.0.27(vue@3.4.24(typescript@5.3.3))
       '@vue/devtools-shared': 7.0.27
-      '@vue/devtools-ui': 7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vue@3.4.24(typescript@5.3.3))
+      '@vue/devtools-ui': 7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.22.4))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vue@3.4.24(typescript@5.3.3))
       perfect-debounce: 1.0.0
       splitpanes: 3.1.5
       vue: 3.4.24(typescript@5.3.3)
@@ -17058,16 +17008,16 @@ snapshots:
     dependencies:
       rfdc: 1.4.1
 
-  '@vue/devtools-ui@7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vue@3.4.24(typescript@5.3.3))':
+  '@vue/devtools-ui@7.0.27(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.22.4))(vue@3.4.24(typescript@5.3.3)))(unocss@0.59.4(postcss@8.4.38)(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vue@3.4.24(typescript@5.3.3))':
     dependencies:
       '@unocss/reset': 0.59.4
       '@vueuse/components': 10.9.0(vue@3.4.24(typescript@5.3.3))
       '@vueuse/core': 10.9.0(vue@3.4.24(typescript@5.3.3))
       '@vueuse/integrations': 10.9.0(axios@0.25.0)(focus-trap@7.5.4)(vue@3.4.24(typescript@5.3.3))
       colord: 2.9.3
-      floating-vue: 5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3))
+      floating-vue: 5.2.2(@nuxt/kit@3.11.2(rollup@4.22.4))(vue@3.4.24(typescript@5.3.3))
       focus-trap: 7.5.4
-      unocss: 0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+      unocss: 0.59.4(postcss@8.4.38)(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
       vue: 3.4.24(typescript@5.3.3)
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -17587,10 +17537,10 @@ snapshots:
       '@babel/parser': 7.24.8
       pathe: 1.1.2
 
-  ast-kit@0.9.5(rollup@4.21.2):
+  ast-kit@0.9.5(rollup@4.22.4):
     dependencies:
       '@babel/parser': 7.24.8
-      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      '@rollup/pluginutils': 5.1.0(rollup@4.22.4)
       pathe: 1.1.2
     transitivePeerDependencies:
       - rollup
@@ -17606,10 +17556,10 @@ snapshots:
     dependencies:
       tslib: 2.6.2
 
-  ast-walker-scope@0.5.0(rollup@4.21.2):
+  ast-walker-scope@0.5.0(rollup@4.22.4):
     dependencies:
       '@babel/parser': 7.24.4
-      ast-kit: 0.9.5(rollup@4.21.2)
+      ast-kit: 0.9.5(rollup@4.22.4)
     transitivePeerDependencies:
       - rollup
 
@@ -19557,13 +19507,13 @@ snapshots:
 
   flatted@3.3.1: {}
 
-  floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)):
+  floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.22.4))(vue@3.4.24(typescript@5.3.3)):
     dependencies:
       '@floating-ui/dom': 1.1.1
       vue: 3.4.24(typescript@5.3.3)
       vue-resize: 2.0.0-alpha.1(vue@3.4.24(typescript@5.3.3))
     optionalDependencies:
-      '@nuxt/kit': 3.11.2(rollup@4.21.2)
+      '@nuxt/kit': 3.11.2(rollup@4.22.4)
 
   focus-trap@7.5.4:
     dependencies:
@@ -21418,14 +21368,14 @@ snapshots:
     dependencies:
       '@cloudflare/kv-asset-handler': 0.3.1
       '@netlify/functions': 2.6.0
-      '@rollup/plugin-alias': 5.1.0(rollup@4.21.2)
-      '@rollup/plugin-commonjs': 25.0.8(rollup@4.21.2)
-      '@rollup/plugin-inject': 5.0.5(rollup@4.21.2)
-      '@rollup/plugin-json': 6.1.0(rollup@4.21.2)
-      '@rollup/plugin-node-resolve': 15.2.3(rollup@4.21.2)
-      '@rollup/plugin-replace': 5.0.7(rollup@4.21.2)
-      '@rollup/plugin-terser': 0.4.4(rollup@4.21.2)
-      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      '@rollup/plugin-alias': 5.1.0(rollup@4.22.4)
+      '@rollup/plugin-commonjs': 25.0.8(rollup@4.22.4)
+      '@rollup/plugin-inject': 5.0.5(rollup@4.22.4)
+      '@rollup/plugin-json': 6.1.0(rollup@4.22.4)
+      '@rollup/plugin-node-resolve': 15.2.3(rollup@4.22.4)
+      '@rollup/plugin-replace': 5.0.7(rollup@4.22.4)
+      '@rollup/plugin-terser': 0.4.4(rollup@4.22.4)
+      '@rollup/pluginutils': 5.1.0(rollup@4.22.4)
       '@types/http-proxy': 1.17.14
       '@vercel/nft': 0.26.4(encoding@0.1.13)
       archiver: 7.0.1
@@ -21469,8 +21419,8 @@ snapshots:
       pkg-types: 1.1.0
       pretty-bytes: 6.1.1
       radix3: 1.1.2
-      rollup: 4.21.2
-      rollup-plugin-visualizer: 5.12.0(rollup@4.21.2)
+      rollup: 4.22.4
+      rollup-plugin-visualizer: 5.12.0(rollup@4.22.4)
       scule: 1.3.0
       semver: 7.6.0
       serve-placeholder: 2.0.1
@@ -21480,7 +21430,7 @@ snapshots:
       uncrypto: 0.1.3
       unctx: 2.3.1
       unenv: 1.9.0
-      unimport: 3.7.1(rollup@4.21.2)
+      unimport: 3.7.1(rollup@4.22.4)
       unstorage: 1.10.2(ioredis@5.4.1)
       unwasm: 0.3.9
     transitivePeerDependencies:
@@ -21507,14 +21457,14 @@ snapshots:
     dependencies:
       '@cloudflare/kv-asset-handler': 0.3.4
       '@netlify/functions': 2.8.1
-      '@rollup/plugin-alias': 5.1.0(rollup@4.21.2)
-      '@rollup/plugin-commonjs': 25.0.8(rollup@4.21.2)
-      '@rollup/plugin-inject': 5.0.5(rollup@4.21.2)
-      '@rollup/plugin-json': 6.1.0(rollup@4.21.2)
-      '@rollup/plugin-node-resolve': 15.2.3(rollup@4.21.2)
-      '@rollup/plugin-replace': 5.0.7(rollup@4.21.2)
-      '@rollup/plugin-terser': 0.4.4(rollup@4.21.2)
-      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      '@rollup/plugin-alias': 5.1.0(rollup@4.22.4)
+      '@rollup/plugin-commonjs': 25.0.8(rollup@4.22.4)
+      '@rollup/plugin-inject': 5.0.5(rollup@4.22.4)
+      '@rollup/plugin-json': 6.1.0(rollup@4.22.4)
+      '@rollup/plugin-node-resolve': 15.2.3(rollup@4.22.4)
+      '@rollup/plugin-replace': 5.0.7(rollup@4.22.4)
+      '@rollup/plugin-terser': 0.4.4(rollup@4.22.4)
+      '@rollup/pluginutils': 5.1.0(rollup@4.22.4)
       '@types/http-proxy': 1.17.14
       '@vercel/nft': 0.26.5(encoding@0.1.13)
       archiver: 7.0.1
@@ -21557,8 +21507,8 @@ snapshots:
       pkg-types: 1.2.0
       pretty-bytes: 6.1.1
       radix3: 1.1.2
-      rollup: 4.21.2
-      rollup-plugin-visualizer: 5.12.0(rollup@4.21.2)
+      rollup: 4.22.4
+      rollup-plugin-visualizer: 5.12.0(rollup@4.22.4)
       scule: 1.3.0
       semver: 7.6.3
       serve-placeholder: 2.0.2
@@ -21568,7 +21518,7 @@ snapshots:
       uncrypto: 0.1.3
       unctx: 2.3.1
       unenv: 1.10.0
-      unimport: 3.11.1(rollup@4.21.2)
+      unimport: 3.11.1(rollup@4.22.4)
       unstorage: 1.10.2(ioredis@5.4.1)
       unwasm: 0.3.9
     transitivePeerDependencies:
@@ -21752,15 +21702,15 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)):
+  nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.22.4))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.22.4)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.2.0(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.21.2))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.21.2)(unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
-      '@nuxt/kit': 3.11.2(rollup@4.21.2)
-      '@nuxt/schema': 3.11.2(rollup@4.21.2)
-      '@nuxt/telemetry': 2.5.4(rollup@4.21.2)
+      '@nuxt/devtools': 1.2.0(@unocss/reset@0.59.4)(axios@0.25.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.22.4))(vue@3.4.24(typescript@5.3.3)))(nuxt@3.11.2(@parcel/watcher@2.4.1)(@types/node@20.11.15)(@unocss/reset@0.59.4)(axios@0.25.0)(encoding@0.1.13)(eslint@8.56.0)(floating-vue@5.2.2(@nuxt/kit@3.11.2(rollup@4.22.4))(vue@3.4.24(typescript@5.3.3)))(ioredis@5.4.1)(optionator@0.9.3)(rollup@4.22.4)(terser@5.27.0)(typescript@5.3.3)(unocss@0.59.4(postcss@8.4.38)(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(rollup@4.22.4)(unocss@0.59.4(postcss@8.4.38)(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)))(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))(vue@3.4.24(typescript@5.3.3))
+      '@nuxt/kit': 3.11.2(rollup@4.22.4)
+      '@nuxt/schema': 3.11.2(rollup@4.22.4)
+      '@nuxt/telemetry': 2.5.4(rollup@4.22.4)
       '@nuxt/ui-templates': 1.3.3
-      '@nuxt/vite-builder': 3.11.2(@types/node@20.11.15)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.3.3)(vue@3.4.24(typescript@5.3.3))
+      '@nuxt/vite-builder': 3.11.2(@types/node@20.11.15)(eslint@8.56.0)(optionator@0.9.3)(rollup@4.22.4)(terser@5.27.0)(typescript@5.3.3)(vue@3.4.24(typescript@5.3.3))
       '@unhead/dom': 1.9.7
       '@unhead/ssr': 1.9.7
       '@unhead/vue': 1.9.7(vue@3.4.24(typescript@5.3.3))
@@ -21801,9 +21751,9 @@ snapshots:
       uncrypto: 0.1.3
       unctx: 2.3.1
       unenv: 1.9.0
-      unimport: 3.7.1(rollup@4.21.2)
+      unimport: 3.7.1(rollup@4.22.4)
       unplugin: 1.10.1
-      unplugin-vue-router: 0.7.0(rollup@4.21.2)(vue-router@4.3.2(vue@3.4.24(typescript@5.3.3)))(vue@3.4.24(typescript@5.3.3))
+      unplugin-vue-router: 0.7.0(rollup@4.22.4)(vue-router@4.3.2(vue@3.4.24(typescript@5.3.3)))(vue@3.4.24(typescript@5.3.3))
       unstorage: 1.10.2(ioredis@5.4.1)
       untyped: 1.4.2
       vue: 3.4.24(typescript@5.3.3)
@@ -21976,14 +21926,14 @@ snapshots:
       - vue-tsc
       - xml2js
 
-  nuxt@3.12.4(@parcel/watcher@2.4.1)(@types/node@20.12.12)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.4.5)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)):
+  nuxt@3.12.4(@parcel/watcher@2.4.1)(@types/node@20.12.12)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.22.4)(terser@5.27.0)(typescript@5.4.5)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.4.1(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
-      '@nuxt/kit': 3.12.4(magicast@0.3.4)(rollup@4.21.2)
-      '@nuxt/schema': 3.12.4(rollup@4.21.2)
-      '@nuxt/telemetry': 2.5.4(rollup@4.21.2)
-      '@nuxt/vite-builder': 3.12.4(@types/node@20.12.12)(eslint@8.56.0)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.4.5)(vue@3.5.0(typescript@5.4.5))
+      '@nuxt/devtools': 1.4.1(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+      '@nuxt/kit': 3.12.4(magicast@0.3.4)(rollup@4.22.4)
+      '@nuxt/schema': 3.12.4(rollup@4.22.4)
+      '@nuxt/telemetry': 2.5.4(rollup@4.22.4)
+      '@nuxt/vite-builder': 3.12.4(@types/node@20.12.12)(eslint@8.56.0)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.22.4)(terser@5.27.0)(typescript@5.4.5)(vue@3.5.0(typescript@5.4.5))
       '@unhead/dom': 1.10.4
       '@unhead/ssr': 1.10.4
       '@unhead/vue': 1.10.4(vue@3.5.0(typescript@5.4.5))
@@ -22028,9 +21978,9 @@ snapshots:
       uncrypto: 0.1.3
       unctx: 2.3.1
       unenv: 1.10.0
-      unimport: 3.11.1(rollup@4.21.2)
+      unimport: 3.11.1(rollup@4.22.4)
       unplugin: 1.12.3
-      unplugin-vue-router: 0.10.7(rollup@4.21.2)(vue-router@4.4.3(vue@3.5.0(typescript@5.4.5)))(vue@3.5.0(typescript@5.4.5))
+      unplugin-vue-router: 0.10.7(rollup@4.22.4)(vue-router@4.4.3(vue@3.5.0(typescript@5.4.5)))(vue@3.5.0(typescript@5.4.5))
       unstorage: 1.10.2(ioredis@5.4.1)
       untyped: 1.4.2
       vue: 3.5.0(typescript@5.4.5)
@@ -22083,14 +22033,14 @@ snapshots:
       - vue-tsc
       - xml2js
 
-  nuxt@3.12.4(@parcel/watcher@2.4.1)(@types/node@20.12.12)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.4.5)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)):
+  nuxt@3.12.4(@parcel/watcher@2.4.1)(@types/node@20.12.12)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.4.1)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.22.4)(terser@5.27.0)(typescript@5.4.5)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)):
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.4.1(rollup@4.21.2)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
-      '@nuxt/kit': 3.12.4(magicast@0.3.4)(rollup@4.21.2)
-      '@nuxt/schema': 3.12.4(rollup@4.21.2)
-      '@nuxt/telemetry': 2.5.4(rollup@4.21.2)
-      '@nuxt/vite-builder': 3.12.4(@types/node@20.12.12)(eslint@8.56.0)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.21.2)(terser@5.27.0)(typescript@5.4.5)(vue@3.5.0(typescript@5.4.5))
+      '@nuxt/devtools': 1.4.1(rollup@4.22.4)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0))
+      '@nuxt/kit': 3.12.4(magicast@0.3.4)(rollup@4.22.4)
+      '@nuxt/schema': 3.12.4(rollup@4.22.4)
+      '@nuxt/telemetry': 2.5.4(rollup@4.22.4)
+      '@nuxt/vite-builder': 3.12.4(@types/node@20.12.12)(eslint@8.56.0)(magicast@0.3.4)(optionator@0.9.3)(rollup@4.22.4)(terser@5.27.0)(typescript@5.4.5)(vue@3.5.0(typescript@5.4.5))
       '@unhead/dom': 1.10.4
       '@unhead/ssr': 1.10.4
       '@unhead/vue': 1.10.4(vue@3.5.0(typescript@5.4.5))
@@ -22135,9 +22085,9 @@ snapshots:
       uncrypto: 0.1.3
       unctx: 2.3.1
       unenv: 1.10.0
-      unimport: 3.11.1(rollup@4.21.2)
+      unimport: 3.11.1(rollup@4.22.4)
       unplugin: 1.12.3
-      unplugin-vue-router: 0.10.7(rollup@4.21.2)(vue-router@4.4.3(vue@3.5.0(typescript@5.4.5)))(vue@3.5.0(typescript@5.4.5))
+      unplugin-vue-router: 0.10.7(rollup@4.22.4)(vue-router@4.4.3(vue@3.5.0(typescript@5.4.5)))(vue@3.5.0(typescript@5.4.5))
       unstorage: 1.10.2(ioredis@5.4.1)
       untyped: 1.4.2
       vue: 3.5.0(typescript@5.4.5)
@@ -23398,14 +23348,14 @@ snapshots:
     optionalDependencies:
       rollup: 3.29.4
 
-  rollup-plugin-visualizer@5.12.0(rollup@4.21.2):
+  rollup-plugin-visualizer@5.12.0(rollup@4.22.4):
     dependencies:
       open: 8.4.2
       picomatch: 2.3.1
       source-map: 0.7.4
       yargs: 17.7.2
     optionalDependencies:
-      rollup: 4.21.2
+      rollup: 4.22.4
 
   rollup-route-manifest@1.0.0(rollup@3.29.4):
     dependencies:
@@ -23438,26 +23388,26 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.16.2
       fsevents: 2.3.3
 
-  rollup@4.21.2:
+  rollup@4.22.4:
     dependencies:
       '@types/estree': 1.0.5
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.21.2
-      '@rollup/rollup-android-arm64': 4.21.2
-      '@rollup/rollup-darwin-arm64': 4.21.2
-      '@rollup/rollup-darwin-x64': 4.21.2
-      '@rollup/rollup-linux-arm-gnueabihf': 4.21.2
-      '@rollup/rollup-linux-arm-musleabihf': 4.21.2
-      '@rollup/rollup-linux-arm64-gnu': 4.21.2
-      '@rollup/rollup-linux-arm64-musl': 4.21.2
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.21.2
-      '@rollup/rollup-linux-riscv64-gnu': 4.21.2
-      '@rollup/rollup-linux-s390x-gnu': 4.21.2
-      '@rollup/rollup-linux-x64-gnu': 4.21.2
-      '@rollup/rollup-linux-x64-musl': 4.21.2
-      '@rollup/rollup-win32-arm64-msvc': 4.21.2
-      '@rollup/rollup-win32-ia32-msvc': 4.21.2
-      '@rollup/rollup-win32-x64-msvc': 4.21.2
+      '@rollup/rollup-android-arm-eabi': 4.22.4
+      '@rollup/rollup-android-arm64': 4.22.4
+      '@rollup/rollup-darwin-arm64': 4.22.4
+      '@rollup/rollup-darwin-x64': 4.22.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.22.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.22.4
+      '@rollup/rollup-linux-arm64-gnu': 4.22.4
+      '@rollup/rollup-linux-arm64-musl': 4.22.4
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.22.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.22.4
+      '@rollup/rollup-linux-s390x-gnu': 4.22.4
+      '@rollup/rollup-linux-x64-gnu': 4.22.4
+      '@rollup/rollup-linux-x64-musl': 4.22.4
+      '@rollup/rollup-win32-arm64-msvc': 4.22.4
+      '@rollup/rollup-win32-ia32-msvc': 4.22.4
+      '@rollup/rollup-win32-x64-msvc': 4.22.4
       fsevents: 2.3.3
 
   rollup@4.9.6:
@@ -24828,9 +24778,9 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  unimport@3.11.1(rollup@4.21.2):
+  unimport@3.11.1(rollup@4.22.4):
     dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      '@rollup/pluginutils': 5.1.0(rollup@4.22.4)
       acorn: 8.12.1
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
@@ -24864,9 +24814,9 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  unimport@3.7.1(rollup@4.21.2):
+  unimport@3.7.1(rollup@4.22.4):
     dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      '@rollup/pluginutils': 5.1.0(rollup@4.22.4)
       acorn: 8.11.3
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
@@ -24930,10 +24880,10 @@ snapshots:
 
   universalify@2.0.0: {}
 
-  unocss@0.59.4(postcss@8.4.38)(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)):
+  unocss@0.59.4(postcss@8.4.38)(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
-      '@unocss/astro': 0.59.4(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
-      '@unocss/cli': 0.59.4(rollup@4.21.2)
+      '@unocss/astro': 0.59.4(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+      '@unocss/cli': 0.59.4(rollup@4.22.4)
       '@unocss/core': 0.59.4
       '@unocss/extractor-arbitrary-variants': 0.59.4
       '@unocss/postcss': 0.59.4(postcss@8.4.38)
@@ -24951,7 +24901,7 @@ snapshots:
       '@unocss/transformer-compile-class': 0.59.4
       '@unocss/transformer-directives': 0.59.4
       '@unocss/transformer-variant-group': 0.59.4
-      '@unocss/vite': 0.59.4(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
+      '@unocss/vite': 0.59.4(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0))
     optionalDependencies:
       vite: 5.2.10(@types/node@20.11.15)(terser@5.27.0)
     transitivePeerDependencies:
@@ -24983,11 +24933,11 @@ snapshots:
       - rollup
       - vue
 
-  unplugin-vue-router@0.10.7(rollup@4.21.2)(vue-router@4.4.3(vue@3.5.0(typescript@5.4.5)))(vue@3.5.0(typescript@5.4.5)):
+  unplugin-vue-router@0.10.7(rollup@4.22.4)(vue-router@4.4.3(vue@3.5.0(typescript@5.4.5)))(vue@3.5.0(typescript@5.4.5)):
     dependencies:
       '@babel/types': 7.25.6
-      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
-      '@vue-macros/common': 1.12.2(rollup@4.21.2)(vue@3.5.0(typescript@5.4.5))
+      '@rollup/pluginutils': 5.1.0(rollup@4.22.4)
+      '@vue-macros/common': 1.12.2(rollup@4.22.4)(vue@3.5.0(typescript@5.4.5))
       ast-walker-scope: 0.6.2
       chokidar: 3.6.0
       fast-glob: 3.3.2
@@ -25005,12 +24955,12 @@ snapshots:
       - rollup
       - vue
 
-  unplugin-vue-router@0.7.0(rollup@4.21.2)(vue-router@4.3.2(vue@3.4.24(typescript@5.3.3)))(vue@3.4.24(typescript@5.3.3)):
+  unplugin-vue-router@0.7.0(rollup@4.22.4)(vue-router@4.3.2(vue@3.4.24(typescript@5.3.3)))(vue@3.4.24(typescript@5.3.3)):
     dependencies:
       '@babel/types': 7.24.0
-      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
-      '@vue-macros/common': 1.10.2(rollup@4.21.2)(vue@3.4.24(typescript@5.3.3))
-      ast-walker-scope: 0.5.0(rollup@4.21.2)
+      '@rollup/pluginutils': 5.1.0(rollup@4.22.4)
+      '@vue-macros/common': 1.10.2(rollup@4.22.4)(vue@3.4.24(typescript@5.3.3))
+      ast-walker-scope: 0.5.0(rollup@4.22.4)
       chokidar: 3.6.0
       fast-glob: 3.3.2
       json5: 2.2.3
@@ -25488,10 +25438,10 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@0.7.42(rollup@4.21.2)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0)):
+  vite-plugin-inspect@0.7.42(rollup@4.22.4)(vite@5.2.10(@types/node@20.12.12)(terser@5.27.0)):
     dependencies:
       '@antfu/utils': 0.7.7
-      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      '@rollup/pluginutils': 5.1.0(rollup@4.22.4)
       debug: 4.3.4
       error-stack-parser-es: 0.1.1
       fs-extra: 11.2.0
@@ -25503,10 +25453,10 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@0.7.42(rollup@4.21.2)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)):
+  vite-plugin-inspect@0.7.42(rollup@4.22.4)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)):
     dependencies:
       '@antfu/utils': 0.7.7
-      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      '@rollup/pluginutils': 5.1.0(rollup@4.22.4)
       debug: 4.3.4
       error-stack-parser-es: 0.1.1
       fs-extra: 11.2.0
@@ -25518,10 +25468,10 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@0.8.4(@nuxt/kit@3.11.2(rollup@4.21.2))(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)):
+  vite-plugin-inspect@0.8.4(@nuxt/kit@3.11.2(rollup@4.22.4))(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
       '@antfu/utils': 0.7.7
-      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      '@rollup/pluginutils': 5.1.0(rollup@4.22.4)
       debug: 4.3.4
       error-stack-parser-es: 0.1.1
       fs-extra: 11.2.0
@@ -25531,7 +25481,7 @@ snapshots:
       sirv: 2.0.4
       vite: 5.2.10(@types/node@20.11.15)(terser@5.27.0)
     optionalDependencies:
-      '@nuxt/kit': 3.11.2(rollup@4.21.2)
+      '@nuxt/kit': 3.11.2(rollup@4.22.4)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -25554,10 +25504,10 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@0.8.7(@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@4.21.2))(rollup@4.21.2)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)):
+  vite-plugin-inspect@0.8.7(@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@4.22.4))(rollup@4.22.4)(vite@5.2.10(@types/node@20.11.15)(terser@5.27.0)):
     dependencies:
       '@antfu/utils': 0.7.10
-      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      '@rollup/pluginutils': 5.1.0(rollup@4.22.4)
       debug: 4.3.6
       error-stack-parser-es: 0.1.5
       fs-extra: 11.2.0
@@ -25567,15 +25517,15 @@ snapshots:
       sirv: 2.0.4
       vite: 5.2.10(@types/node@20.11.15)(terser@5.27.0)
     optionalDependencies:
-      '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.21.2)
+      '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.22.4)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@0.8.7(@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@4.21.2))(rollup@4.21.2)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)):
+  vite-plugin-inspect@0.8.7(@nuxt/kit@3.13.0(magicast@0.3.4)(rollup@4.22.4))(rollup@4.22.4)(vite@5.4.3(@types/node@20.12.12)(terser@5.27.0)):
     dependencies:
       '@antfu/utils': 0.7.10
-      '@rollup/pluginutils': 5.1.0(rollup@4.21.2)
+      '@rollup/pluginutils': 5.1.0(rollup@4.22.4)
       debug: 4.3.6
       error-stack-parser-es: 0.1.5
       fs-extra: 11.2.0
@@ -25585,7 +25535,7 @@ snapshots:
       sirv: 2.0.4
       vite: 5.4.3(@types/node@20.12.12)(terser@5.27.0)
     optionalDependencies:
-      '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.21.2)
+      '@nuxt/kit': 3.13.0(magicast@0.3.4)(rollup@4.22.4)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -25798,7 +25748,7 @@ snapshots:
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.44
-      rollup: 4.21.2
+      rollup: 4.22.4
     optionalDependencies:
       '@types/node': 20.10.0
       fsevents: 2.3.3
@@ -25808,7 +25758,7 @@ snapshots:
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.44
-      rollup: 4.21.2
+      rollup: 4.22.4
     optionalDependencies:
       '@types/node': 20.11.15
       fsevents: 2.3.3
@@ -25818,7 +25768,7 @@ snapshots:
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.44
-      rollup: 4.21.2
+      rollup: 4.22.4
     optionalDependencies:
       '@types/node': 20.12.12
       fsevents: 2.3.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -580,8 +580,8 @@ importers:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
       rollupV3:
-        specifier: npm:rollup@3.29.4
-        version: rollup@3.29.4
+        specifier: npm:rollup@3.29.5
+        version: rollup@3.29.5
       rollupV4:
         specifier: npm:rollup@4.22.4
         version: rollup@4.22.4
@@ -801,7 +801,7 @@ importers:
     devDependencies:
       '@rollup/plugin-replace':
         specifier: ^5.0.5
-        version: 5.0.7(rollup@3.29.4)
+        version: 5.0.7(rollup@4.22.4)
       '@types/micromatch':
         specifier: ^4.0.9
         version: 4.0.9
@@ -816,7 +816,7 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.12.12)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@3.29.4)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.22.4)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.4.5)
@@ -874,7 +874,7 @@ importers:
         version: 1.5.0(vitest@1.5.0(@types/node@20.11.15)(terser@5.27.0))
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@0.0.1-beta.5
-        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@4.22.4)'
+        version: '@codecov/rollup-plugin@0.0.1-beta.5(rollup@3.29.4)'
       msw:
         specifier: ^2.1.5
         version: 2.1.5(typescript@5.3.3)
@@ -9673,6 +9673,11 @@ packages:
 
   rollup@3.29.4:
     resolution: {integrity: sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==}
+    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  rollup@3.29.5:
+    resolution: {integrity: sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -23021,6 +23026,10 @@ snapshots:
       route-sort: 1.0.0
 
   rollup@3.29.4:
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  rollup@3.29.5:
     optionalDependencies:
       fsevents: 2.3.3
 


### PR DESCRIPTION
Resolve vulnerability in rollup (resolved versions - 4.22.4, 3.29.5)

Closes https://github.com/codecov/internal-issues/issues/931
