### PR TITLE
fix: Bundle names not being reset properly

### DIFF
--- a/.changeset/neat-jobs-train.md
+++ b/.changeset/neat-jobs-train.md
@@ -1,0 +1,14 @@
+---
+"@codecov/nextjs-webpack-plugin": patch
+"@codecov/bundler-plugin-core": patch
+"@codecov/webpack-plugin": patch
+"@codecov/rollup-plugin": patch
+"@codecov/vite-plugin": patch
+"@codecov/bundle-analyzer": patch
+"@codecov/nuxt-plugin": patch
+"@codecov/remix-vite-plugin": patch
+"@codecov/solidstart-plugin": patch
+"@codecov/sveltekit-plugin": patch
+---
+
+Fix issue with bundle names not being reset in nextjs, rollup, vite, and webpack plugins.

--- a/packages/bundler-plugin-core/src/utils/Output.ts
+++ b/packages/bundler-plugin-core/src/utils/Output.ts
@@ -26,7 +26,7 @@ class Output {
   };
   debug: boolean;
   gitService?: ValidGitService;
-  originalBundleName: string;
+  #internalOriginalBundleName: string;
   // uploader overrides
   branch?: string;
   build?: string;
@@ -65,7 +65,7 @@ class Output {
     this.uploadToken = userOptions.uploadToken;
     this.debug = userOptions.debug;
     this.gitService = userOptions.gitService;
-    this.originalBundleName = userOptions.bundleName;
+    this.#internalOriginalBundleName = userOptions.bundleName;
     this.oidc = userOptions.oidc;
 
     if (userOptions.uploadOverrides) {
@@ -105,6 +105,10 @@ class Output {
 
   get bundleName() {
     return this.#internalBundleName;
+  }
+
+  get originalBundleName() {
+    return this.#internalOriginalBundleName;
   }
 
   setPlugin(pluginName: string, pluginVersion: string) {

--- a/packages/bundler-plugin-core/src/utils/__tests__/Output.test.ts
+++ b/packages/bundler-plugin-core/src/utils/__tests__/Output.test.ts
@@ -253,47 +253,6 @@ describe("Output", () => {
     });
   });
 
-  describe("resetBundleName method", () => {
-    describe("bundle name is not locked", () => {
-      it("resets the bundle name", () => {
-        const output = new Output({
-          apiUrl: "http://localhost",
-          bundleName: "output-test",
-          debug: false,
-          dryRun: false,
-          enableBundleAnalysis: true,
-          retryCount: 1,
-          uploadToken: "token",
-        });
-
-        output.setBundleName("new-bundle");
-        output.resetBundleName();
-
-        expect(output.bundleName).toBe("output-test");
-      });
-    });
-
-    describe("bundle name is locked", () => {
-      it("does not reset the bundle name", () => {
-        const output = new Output({
-          apiUrl: "http://localhost",
-          bundleName: "output-test",
-          debug: false,
-          dryRun: false,
-          enableBundleAnalysis: true,
-          retryCount: 1,
-          uploadToken: "token",
-        });
-
-        output.setBundleName("new-bundle");
-        output.lockBundleName();
-        output.resetBundleName();
-
-        expect(output.bundleName).toBe("new-bundle");
-      });
-    });
-  });
-
   describe("write method", () => {
     describe("dryRun is enabled", () => {
       it("immediately returns", async () => {

--- a/packages/bundler-plugin-core/src/utils/__tests__/Output.test.ts
+++ b/packages/bundler-plugin-core/src/utils/__tests__/Output.test.ts
@@ -253,6 +253,47 @@ describe("Output", () => {
     });
   });
 
+  describe("resetBundleName method", () => {
+    describe("bundle name is not locked", () => {
+      it("resets the bundle name", () => {
+        const output = new Output({
+          apiUrl: "http://localhost",
+          bundleName: "output-test",
+          debug: false,
+          dryRun: false,
+          enableBundleAnalysis: true,
+          retryCount: 1,
+          uploadToken: "token",
+        });
+
+        output.setBundleName("new-bundle");
+        output.resetBundleName();
+
+        expect(output.bundleName).toBe("output-test");
+      });
+    });
+
+    describe("bundle name is locked", () => {
+      it("does not reset the bundle name", () => {
+        const output = new Output({
+          apiUrl: "http://localhost",
+          bundleName: "output-test",
+          debug: false,
+          dryRun: false,
+          enableBundleAnalysis: true,
+          retryCount: 1,
+          uploadToken: "token",
+        });
+
+        output.setBundleName("new-bundle");
+        output.lockBundleName();
+        output.resetBundleName();
+
+        expect(output.bundleName).toBe("new-bundle");
+      });
+    });
+  });
+
   describe("write method", () => {
     describe("dryRun is enabled", () => {
       it("immediately returns", async () => {

--- a/packages/nextjs-webpack-plugin/src/nextjs-webpack-bundle-analysis/nextJSWebpackBundleAnalysisPlugin.ts
+++ b/packages/nextjs-webpack-plugin/src/nextjs-webpack-bundle-analysis/nextJSWebpackBundleAnalysisPlugin.ts
@@ -43,7 +43,7 @@ export const nextJSWebpackBundleAnalysisPlugin: ExtendedBAUploadPlugin<{
           stage: webpack.Compilation.PROCESS_ASSETS_STAGE_REPORT,
         },
         async () => {
-          output.setBundleName(output.bundleName);
+          output.setBundleName(output.originalBundleName);
           // Webpack base chunk format options: https://webpack.js.org/configuration/output/#outputchunkformat
           if (typeof compilation.outputOptions.chunkFormat === "string") {
             if (compilation.name && compilation.name !== "") {

--- a/packages/rollup-plugin/src/rollup-bundle-analysis/rollupBundleAnalysisPlugin.ts
+++ b/packages/rollup-plugin/src/rollup-bundle-analysis/rollupBundleAnalysisPlugin.ts
@@ -38,7 +38,7 @@ export const rollupBundleAnalysisPlugin: BundleAnalysisUploadPlugin = ({
         return;
       }
 
-      output.setBundleName(output.bundleName);
+      output.setBundleName(output.originalBundleName);
       if (options.name && options.name !== "") {
         output.setBundleName(`${output.bundleName}-${options.name}`);
       }

--- a/packages/vite-plugin/src/vite-bundle-analysis/viteBundleAnalysisPlugin.ts
+++ b/packages/vite-plugin/src/vite-bundle-analysis/viteBundleAnalysisPlugin.ts
@@ -38,7 +38,7 @@ export const viteBundleAnalysisPlugin: BundleAnalysisUploadPlugin = ({
         return;
       }
 
-      output.setBundleName(output.bundleName);
+      output.setBundleName(output.originalBundleName);
       // add in bundle name if present
       if (options.name && options.name !== "") {
         output.setBundleName(`${output.bundleName}-${options.name}`);

--- a/packages/webpack-plugin/src/webpack-bundle-analysis/webpackBundleAnalysisPlugin.ts
+++ b/packages/webpack-plugin/src/webpack-bundle-analysis/webpackBundleAnalysisPlugin.ts
@@ -36,7 +36,7 @@ export const webpackBundleAnalysisPlugin: BundleAnalysisUploadPlugin = ({
           stage: webpack.Compilation.PROCESS_ASSETS_STAGE_REPORT,
         },
         async () => {
-          output.setBundleName(output.bundleName);
+          output.setBundleName(output.originalBundleName);
           // Webpack base chunk format options: https://webpack.js.org/configuration/output/#outputchunkformat
           if (typeof compilation.outputOptions.chunkFormat === "string") {
             if (compilation.name && compilation.name !== "") {


### PR DESCRIPTION
# Description

We noticed that when running the plugins to analyze the plugins the bundle names were not being reset with Unbuild correctly. This resolves the issue, by reseting the bundle name when running.
