### PR TITLE
fix: Remove unused regex escape char

### DIFF
--- a/.changeset/rare-foxes-cheat.md
+++ b/.changeset/rare-foxes-cheat.md
@@ -1,0 +1,14 @@
+---
+"@codecov/bundler-plugin-core": patch
+"@codecov/bundle-analyzer": patch
+"@codecov/nextjs-webpack-plugin": patch
+"@codecov/nuxt-plugin": patch
+"@codecov/remix-vite-plugin": patch
+"@codecov/rollup-plugin": patch
+"@codecov/solidstart-plugin": patch
+"@codecov/sveltekit-plugin": patch
+"@codecov/vite-plugin": patch
+"@codecov/webpack-plugin": patch
+---
+
+Remove unused regex character escape from normalizePath

--- a/packages/bundler-plugin-core/src/utils/normalizePath.ts
+++ b/packages/bundler-plugin-core/src/utils/normalizePath.ts
@@ -45,7 +45,7 @@ export const normalizePath = (path: string, format: string): string => {
     // create a regex that will match the hash
     // potential values gathered from: https://en.wikipedia.org/wiki/Base64
     // added in `\-` and `\_` to account for the `-` `_` as they are included in the potential hashes: https://rollupjs.org/configuration-options/#output-hashcharacters
-    const regexString = `(${leadingRegex}(?<hash>[0-9a-zA-Z/\+=_\/+=-]+)${endingRegex})`;
+    const regexString = `(${leadingRegex}(?<hash>[0-9a-zA-Z/+=_\/+=-]+)${endingRegex})`;
     const HASH_REPLACE_REGEX = new RegExp(regexString, "i");
 
     // replace the hash with a wildcard and the delimiters


### PR DESCRIPTION
# Description

Quick PR to remove an unused regex escape char in `normalizePath` function.
