### PR TITLE
feat: Collect dynamicImports in plugins

### DIFF
--- a/.changeset/tame-glasses-compete.md
+++ b/.changeset/tame-glasses-compete.md
@@ -1,0 +1,13 @@
+---
+"@codecov/nextjs-webpack-plugin": minor
+"@codecov/bundler-plugin-core": minor
+"@codecov/remix-vite-plugin": minor
+"@codecov/solidstart-plugin": minor
+"@codecov/sveltekit-plugin": minor
+"@codecov/webpack-plugin": minor
+"@codecov/rollup-plugin": minor
+"@codecov/nuxt-plugin": minor
+"@codecov/vite-plugin": minor
+---
+
+Collect dynamic imports for base bundler plugins, which apply to the extended meta-framework plugins.

--- a/integration-tests/fixtures/generate-bundle-stats/bundle-analyzer/dotenv-vercel/__snapshots__/bundle-analyzer.test.ts.snap
+++ b/integration-tests/fixtures/generate-bundle-stats/bundle-analyzer/dotenv-vercel/__snapshots__/bundle-analyzer.test.ts.snap
@@ -12,6 +12,6 @@ exports[`Bundle Analyzer Integration Tests should generate a report and match th
     "name": StringMatching "@codecov/bundle-analyzer",
     "version": Any<String>,
   },
-  "version": "2",
+  "version": "3",
 }
 `;

--- a/integration-tests/fixtures/generate-bundle-stats/nextjs/nextjs-plugin.test.ts
+++ b/integration-tests/fixtures/generate-bundle-stats/nextjs/nextjs-plugin.test.ts
@@ -82,6 +82,7 @@ describe("Generating nextjs stats", () => {
               entry: expect.any(Boolean),
               files: expect.arrayContaining([expect.any(String)]),
               names: expect.arrayContaining([expect.any(String)]),
+              dynamicImports: expect.any(Array),
             },
           ]),
           modules: expect.arrayContaining([
@@ -130,6 +131,7 @@ describe("Generating nextjs stats", () => {
               entry: expect.any(Boolean),
               files: expect.arrayContaining([expect.any(String)]),
               names: expect.arrayContaining([expect.any(String)]),
+              dynamicImports: expect.any(Array),
             },
           ]),
           modules: expect.arrayContaining([

--- a/integration-tests/fixtures/generate-bundle-stats/nuxt/__snapshots__/nuxt-plugin.test.ts.snap
+++ b/integration-tests/fixtures/generate-bundle-stats/nuxt/__snapshots__/nuxt-plugin.test.ts.snap
@@ -17,7 +17,7 @@ exports[`Generating nuxt stats 3 {"format":"amd","expected":"amd"} matches the s
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -38,7 +38,7 @@ exports[`Generating nuxt stats 3 {"format":"amd","expected":"amd"} matches the s
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -59,7 +59,7 @@ exports[`Generating nuxt stats 3 {"format":"cjs","expected":"cjs"} matches the s
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -80,7 +80,7 @@ exports[`Generating nuxt stats 3 {"format":"cjs","expected":"cjs"} matches the s
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -101,7 +101,7 @@ exports[`Generating nuxt stats 3 {"format":"es","expected":"esm"} matches the sn
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -122,7 +122,7 @@ exports[`Generating nuxt stats 3 {"format":"es","expected":"esm"} matches the sn
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -143,7 +143,7 @@ exports[`Generating nuxt stats 3 {"format":"esm","expected":"esm"} matches the s
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -164,7 +164,7 @@ exports[`Generating nuxt stats 3 {"format":"esm","expected":"esm"} matches the s
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -185,7 +185,7 @@ exports[`Generating nuxt stats 3 {"format":"module","expected":"esm"} matches th
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -206,7 +206,7 @@ exports[`Generating nuxt stats 3 {"format":"module","expected":"esm"} matches th
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -227,7 +227,7 @@ exports[`Generating nuxt stats 3 {"format":"iife","expected":"iife"} matches the
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -248,7 +248,7 @@ exports[`Generating nuxt stats 3 {"format":"iife","expected":"iife"} matches the
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -269,7 +269,7 @@ exports[`Generating nuxt stats 3 {"format":"umd","expected":"umd"} matches the s
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -290,7 +290,7 @@ exports[`Generating nuxt stats 3 {"format":"umd","expected":"umd"} matches the s
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -311,7 +311,7 @@ exports[`Generating nuxt stats 3 {"format":"system","expected":"system"} matches
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -332,7 +332,7 @@ exports[`Generating nuxt stats 3 {"format":"system","expected":"system"} matches
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -353,7 +353,7 @@ exports[`Generating nuxt stats 3 {"format":"systemjs","expected":"system"} match
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -374,6 +374,6 @@ exports[`Generating nuxt stats 3 {"format":"systemjs","expected":"system"} match
     "name": StringMatching "@codecov/nuxt-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;

--- a/integration-tests/fixtures/generate-bundle-stats/nuxt/nuxt-plugin.test.ts
+++ b/integration-tests/fixtures/generate-bundle-stats/nuxt/nuxt-plugin.test.ts
@@ -91,6 +91,7 @@ describe("Generating nuxt stats", () => {
                 entry: expect.any(Boolean),
                 files: expect.arrayContaining([expect.any(String)]),
                 names: expect.arrayContaining([expect.any(String)]),
+                dynamicImports: expect.any(Array),
               },
             ]),
             modules: expect.arrayContaining([
@@ -135,6 +136,7 @@ describe("Generating nuxt stats", () => {
                 entry: expect.any(Boolean),
                 files: expect.arrayContaining([expect.any(String)]),
                 names: expect.arrayContaining([expect.any(String)]),
+                dynamicImports: expect.any(Array),
               },
             ]),
             modules: expect.arrayContaining([

--- a/integration-tests/fixtures/generate-bundle-stats/remix/__snapshots__/remix-plugin.test.ts.snap
+++ b/integration-tests/fixtures/generate-bundle-stats/remix/__snapshots__/remix-plugin.test.ts.snap
@@ -17,7 +17,7 @@ exports[`Generating remix stats 2 {"format":"amd","expected":"amd"} matches the 
     "name": StringMatching "@codecov/remix-vite-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -38,7 +38,7 @@ exports[`Generating remix stats 2 {"format":"amd","expected":"amd"} matches the 
     "name": StringMatching "@codecov/remix-vite-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -59,7 +59,7 @@ exports[`Generating remix stats 2 {"format":"cjs","expected":"cjs"} matches the 
     "name": StringMatching "@codecov/remix-vite-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -80,7 +80,7 @@ exports[`Generating remix stats 2 {"format":"cjs","expected":"cjs"} matches the 
     "name": StringMatching "@codecov/remix-vite-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -101,7 +101,7 @@ exports[`Generating remix stats 2 {"format":"es","expected":"esm"} matches the s
     "name": StringMatching "@codecov/remix-vite-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -122,7 +122,7 @@ exports[`Generating remix stats 2 {"format":"es","expected":"esm"} matches the s
     "name": StringMatching "@codecov/remix-vite-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -143,7 +143,7 @@ exports[`Generating remix stats 2 {"format":"esm","expected":"esm"} matches the 
     "name": StringMatching "@codecov/remix-vite-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -164,7 +164,7 @@ exports[`Generating remix stats 2 {"format":"esm","expected":"esm"} matches the 
     "name": StringMatching "@codecov/remix-vite-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -185,7 +185,7 @@ exports[`Generating remix stats 2 {"format":"module","expected":"esm"} matches t
     "name": StringMatching "@codecov/remix-vite-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -206,6 +206,6 @@ exports[`Generating remix stats 2 {"format":"module","expected":"esm"} matches t
     "name": StringMatching "@codecov/remix-vite-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;

--- a/integration-tests/fixtures/generate-bundle-stats/remix/remix-plugin.test.ts
+++ b/integration-tests/fixtures/generate-bundle-stats/remix/remix-plugin.test.ts
@@ -88,6 +88,7 @@ describe("Generating remix stats", () => {
                 entry: expect.any(Boolean),
                 files: expect.arrayContaining([expect.any(String)]),
                 names: expect.arrayContaining([expect.any(String)]),
+                dynamicImports: expect.any(Array),
               },
             ]),
             modules: expect.arrayContaining([
@@ -130,6 +131,7 @@ describe("Generating remix stats", () => {
                 entry: expect.any(Boolean),
                 files: expect.arrayContaining([expect.any(String)]),
                 names: expect.arrayContaining([expect.any(String)]),
+                dynamicImports: expect.any(Array),
               },
             ]),
             modules: expect.arrayContaining([

--- a/integration-tests/fixtures/generate-bundle-stats/rollup/__snapshots__/rollup-plugin.test.ts.snap
+++ b/integration-tests/fixtures/generate-bundle-stats/rollup/__snapshots__/rollup-plugin.test.ts.snap
@@ -18,6 +18,7 @@ exports[`Generating rollup stats 3 {"format":"amd","expected":"amd"} matches the
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "main-1cbfd464.js",
@@ -73,7 +74,7 @@ exports[`Generating rollup stats 3 {"format":"amd","expected":"amd"} matches the
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -95,6 +96,7 @@ exports[`Generating rollup stats 3 {"format":"cjs","expected":"cjs"} matches the
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "main-420d8aeb.js",
@@ -150,7 +152,7 @@ exports[`Generating rollup stats 3 {"format":"cjs","expected":"cjs"} matches the
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -172,6 +174,7 @@ exports[`Generating rollup stats 3 {"format":"es","expected":"esm"} matches the 
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "main-6ff1e9ca.js",
@@ -227,7 +230,7 @@ exports[`Generating rollup stats 3 {"format":"es","expected":"esm"} matches the 
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -249,6 +252,7 @@ exports[`Generating rollup stats 3 {"format":"esm","expected":"esm"} matches the
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "main-6ff1e9ca.js",
@@ -304,7 +308,7 @@ exports[`Generating rollup stats 3 {"format":"esm","expected":"esm"} matches the
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -326,6 +330,7 @@ exports[`Generating rollup stats 3 {"format":"module","expected":"esm"} matches 
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "main-6ff1e9ca.js",
@@ -381,7 +386,7 @@ exports[`Generating rollup stats 3 {"format":"module","expected":"esm"} matches 
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -403,6 +408,7 @@ exports[`Generating rollup stats 3 {"format":"iife","expected":"iife"} matches t
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "main-cc182ba1.js",
@@ -458,7 +464,7 @@ exports[`Generating rollup stats 3 {"format":"iife","expected":"iife"} matches t
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -480,6 +486,7 @@ exports[`Generating rollup stats 3 {"format":"umd","expected":"umd"} matches the
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "main-cdb2522f.js",
@@ -535,7 +542,7 @@ exports[`Generating rollup stats 3 {"format":"umd","expected":"umd"} matches the
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -557,6 +564,7 @@ exports[`Generating rollup stats 3 {"format":"system","expected":"system"} match
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "main-b7135d24.js",
@@ -612,7 +620,7 @@ exports[`Generating rollup stats 3 {"format":"system","expected":"system"} match
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -634,6 +642,7 @@ exports[`Generating rollup stats 3 {"format":"systemjs","expected":"system"} mat
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "main-b7135d24.js",
@@ -689,7 +698,7 @@ exports[`Generating rollup stats 3 {"format":"systemjs","expected":"system"} mat
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -711,6 +720,7 @@ exports[`Generating rollup stats 3 source maps are enabled does not include any 
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "main-6ff1e9ca.js",
@@ -766,7 +776,7 @@ exports[`Generating rollup stats 3 source maps are enabled does not include any 
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -788,6 +798,7 @@ exports[`Generating rollup stats 4 {"format":"amd","expected":"amd"} matches the
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "main-Bz9ahex4.js",
@@ -843,7 +854,7 @@ exports[`Generating rollup stats 4 {"format":"amd","expected":"amd"} matches the
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -865,6 +876,7 @@ exports[`Generating rollup stats 4 {"format":"cjs","expected":"cjs"} matches the
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "main-xb59kfqA.js",
@@ -920,7 +932,7 @@ exports[`Generating rollup stats 4 {"format":"cjs","expected":"cjs"} matches the
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -942,6 +954,7 @@ exports[`Generating rollup stats 4 {"format":"es","expected":"esm"} matches the 
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "main-DTMU6eC0.js",
@@ -997,7 +1010,7 @@ exports[`Generating rollup stats 4 {"format":"es","expected":"esm"} matches the 
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -1019,6 +1032,7 @@ exports[`Generating rollup stats 4 {"format":"esm","expected":"esm"} matches the
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "main-DTMU6eC0.js",
@@ -1074,7 +1088,7 @@ exports[`Generating rollup stats 4 {"format":"esm","expected":"esm"} matches the
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -1096,6 +1110,7 @@ exports[`Generating rollup stats 4 {"format":"module","expected":"esm"} matches 
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "main-DTMU6eC0.js",
@@ -1151,7 +1166,7 @@ exports[`Generating rollup stats 4 {"format":"module","expected":"esm"} matches 
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -1173,6 +1188,7 @@ exports[`Generating rollup stats 4 {"format":"iife","expected":"iife"} matches t
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "main-B7VbaLUG.js",
@@ -1228,7 +1244,7 @@ exports[`Generating rollup stats 4 {"format":"iife","expected":"iife"} matches t
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -1250,6 +1266,7 @@ exports[`Generating rollup stats 4 {"format":"umd","expected":"umd"} matches the
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "main-DXhL8JQx.js",
@@ -1305,7 +1322,7 @@ exports[`Generating rollup stats 4 {"format":"umd","expected":"umd"} matches the
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -1327,6 +1344,7 @@ exports[`Generating rollup stats 4 {"format":"system","expected":"system"} match
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "main-DwblAVj_.js",
@@ -1382,7 +1400,7 @@ exports[`Generating rollup stats 4 {"format":"system","expected":"system"} match
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -1404,6 +1422,7 @@ exports[`Generating rollup stats 4 {"format":"systemjs","expected":"system"} mat
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "main-DwblAVj_.js",
@@ -1459,7 +1478,7 @@ exports[`Generating rollup stats 4 {"format":"systemjs","expected":"system"} mat
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -1481,6 +1500,7 @@ exports[`Generating rollup stats 4 source maps are enabled does not include any 
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "main-DTMU6eC0.js",
@@ -1536,6 +1556,6 @@ exports[`Generating rollup stats 4 source maps are enabled does not include any 
     "name": StringMatching "@codecov/rollup-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;

--- a/integration-tests/fixtures/generate-bundle-stats/solidstart/solidstart-plugin.test.ts
+++ b/integration-tests/fixtures/generate-bundle-stats/solidstart/solidstart-plugin.test.ts
@@ -90,6 +90,7 @@ describe("Generating solidstart stats", () => {
                 entry: expect.any(Boolean),
                 files: expect.arrayContaining([expect.any(String)]),
                 names: expect.arrayContaining([expect.any(String)]),
+                dynamicImports: expect.any(Array),
               },
             ]),
             modules: expect.arrayContaining([
@@ -138,6 +139,7 @@ describe("Generating solidstart stats", () => {
                 entry: expect.any(Boolean),
                 files: expect.arrayContaining([expect.any(String)]),
                 names: expect.arrayContaining([expect.any(String)]),
+                dynamicImports: expect.any(Array),
               },
             ]),
             modules: expect.arrayContaining([

--- a/integration-tests/fixtures/generate-bundle-stats/sveltekit/__snapshots__/sveltekit-plugin.test.ts.snap
+++ b/integration-tests/fixtures/generate-bundle-stats/sveltekit/__snapshots__/sveltekit-plugin.test.ts.snap
@@ -17,7 +17,7 @@ exports[`Generating sveltekit stats 2 {"format":"es","expected":"esm"} matches t
     "name": StringMatching "@codecov/sveltekit-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -38,7 +38,7 @@ exports[`Generating sveltekit stats 2 {"format":"es","expected":"esm"} matches t
     "name": StringMatching "@codecov/sveltekit-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -59,7 +59,7 @@ exports[`Generating sveltekit stats 2 {"format":"esm","expected":"esm"} matches 
     "name": StringMatching "@codecov/sveltekit-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -80,7 +80,7 @@ exports[`Generating sveltekit stats 2 {"format":"esm","expected":"esm"} matches 
     "name": StringMatching "@codecov/sveltekit-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -101,7 +101,7 @@ exports[`Generating sveltekit stats 2 {"format":"module","expected":"esm"} match
     "name": StringMatching "@codecov/sveltekit-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -122,6 +122,6 @@ exports[`Generating sveltekit stats 2 {"format":"module","expected":"esm"} match
     "name": StringMatching "@codecov/sveltekit-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;

--- a/integration-tests/fixtures/generate-bundle-stats/sveltekit/sveltekit-plugin.test.ts
+++ b/integration-tests/fixtures/generate-bundle-stats/sveltekit/sveltekit-plugin.test.ts
@@ -84,6 +84,7 @@ describe("Generating sveltekit stats", () => {
                 entry: expect.any(Boolean),
                 files: expect.arrayContaining([expect.any(String)]),
                 names: expect.arrayContaining([expect.any(String)]),
+                dynamicImports: expect.any(Array),
               },
             ]),
             modules: expect.arrayContaining([
@@ -126,6 +127,7 @@ describe("Generating sveltekit stats", () => {
                 entry: expect.any(Boolean),
                 files: expect.arrayContaining([expect.any(String)]),
                 names: expect.arrayContaining([expect.any(String)]),
+                dynamicImports: expect.any(Array),
               },
             ]),
             modules: expect.arrayContaining([

--- a/integration-tests/fixtures/generate-bundle-stats/vite/__snapshots__/vite-plugin.test.ts.snap
+++ b/integration-tests/fixtures/generate-bundle-stats/vite/__snapshots__/vite-plugin.test.ts.snap
@@ -18,6 +18,7 @@ exports[`Generating vite stats v4 {"format":"amd","expected":"amd"} matches the 
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "assets/index-b7a309be.js",
@@ -87,7 +88,7 @@ exports[`Generating vite stats v4 {"format":"amd","expected":"amd"} matches the 
     "name": StringMatching "@codecov/vite-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -109,6 +110,7 @@ exports[`Generating vite stats v4 {"format":"cjs","expected":"cjs"} matches the 
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "assets/index-7de22500.js",
@@ -178,7 +180,7 @@ exports[`Generating vite stats v4 {"format":"cjs","expected":"cjs"} matches the 
     "name": StringMatching "@codecov/vite-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -200,6 +202,7 @@ exports[`Generating vite stats v4 {"format":"es","expected":"esm"} matches the s
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "assets/index-320c8eaf.js",
@@ -269,7 +272,7 @@ exports[`Generating vite stats v4 {"format":"es","expected":"esm"} matches the s
     "name": StringMatching "@codecov/vite-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -291,6 +294,7 @@ exports[`Generating vite stats v4 {"format":"esm","expected":"esm"} matches the 
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "assets/index-320c8eaf.js",
@@ -360,7 +364,7 @@ exports[`Generating vite stats v4 {"format":"esm","expected":"esm"} matches the 
     "name": StringMatching "@codecov/vite-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -382,6 +386,7 @@ exports[`Generating vite stats v4 {"format":"module","expected":"esm"} matches t
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "assets/index-320c8eaf.js",
@@ -451,7 +456,7 @@ exports[`Generating vite stats v4 {"format":"module","expected":"esm"} matches t
     "name": StringMatching "@codecov/vite-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -473,6 +478,7 @@ exports[`Generating vite stats v4 {"format":"iife","expected":"iife"} matches th
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "assets/index-646c8a11.js",
@@ -542,7 +548,7 @@ exports[`Generating vite stats v4 {"format":"iife","expected":"iife"} matches th
     "name": StringMatching "@codecov/vite-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -564,6 +570,7 @@ exports[`Generating vite stats v4 {"format":"umd","expected":"umd"} matches the 
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "assets/index-5458a54a.js",
@@ -633,7 +640,7 @@ exports[`Generating vite stats v4 {"format":"umd","expected":"umd"} matches the 
     "name": StringMatching "@codecov/vite-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -655,6 +662,7 @@ exports[`Generating vite stats v4 {"format":"system","expected":"system"} matche
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "assets/index-2fd1a797.js",
@@ -724,7 +732,7 @@ exports[`Generating vite stats v4 {"format":"system","expected":"system"} matche
     "name": StringMatching "@codecov/vite-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -746,6 +754,7 @@ exports[`Generating vite stats v4 {"format":"systemjs","expected":"system"} matc
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "assets/index-2fd1a797.js",
@@ -815,7 +824,7 @@ exports[`Generating vite stats v4 {"format":"systemjs","expected":"system"} matc
     "name": StringMatching "@codecov/vite-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -837,6 +846,7 @@ exports[`Generating vite stats v4 source maps are enabled does not include any s
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "assets/index-320c8eaf.js",
@@ -906,7 +916,7 @@ exports[`Generating vite stats v4 source maps are enabled does not include any s
     "name": StringMatching "@codecov/vite-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -928,6 +938,7 @@ exports[`Generating vite stats v5 {"format":"amd","expected":"amd"} matches the 
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "assets/index-D0r0olUW.js",
@@ -997,7 +1008,7 @@ exports[`Generating vite stats v5 {"format":"amd","expected":"amd"} matches the 
     "name": StringMatching "@codecov/vite-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -1019,6 +1030,7 @@ exports[`Generating vite stats v5 {"format":"cjs","expected":"cjs"} matches the 
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "assets/index-_9bu_Rar.js",
@@ -1088,7 +1100,7 @@ exports[`Generating vite stats v5 {"format":"cjs","expected":"cjs"} matches the 
     "name": StringMatching "@codecov/vite-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -1110,6 +1122,7 @@ exports[`Generating vite stats v5 {"format":"es","expected":"esm"} matches the s
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "assets/index-Cq3U4pkx.js",
@@ -1179,7 +1192,7 @@ exports[`Generating vite stats v5 {"format":"es","expected":"esm"} matches the s
     "name": StringMatching "@codecov/vite-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -1201,6 +1214,7 @@ exports[`Generating vite stats v5 {"format":"esm","expected":"esm"} matches the 
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "assets/index-Cq3U4pkx.js",
@@ -1270,7 +1284,7 @@ exports[`Generating vite stats v5 {"format":"esm","expected":"esm"} matches the 
     "name": StringMatching "@codecov/vite-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -1292,6 +1306,7 @@ exports[`Generating vite stats v5 {"format":"module","expected":"esm"} matches t
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "assets/index-Cq3U4pkx.js",
@@ -1361,7 +1376,7 @@ exports[`Generating vite stats v5 {"format":"module","expected":"esm"} matches t
     "name": StringMatching "@codecov/vite-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -1383,6 +1398,7 @@ exports[`Generating vite stats v5 {"format":"iife","expected":"iife"} matches th
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "assets/index-B31DUBuo.js",
@@ -1452,7 +1468,7 @@ exports[`Generating vite stats v5 {"format":"iife","expected":"iife"} matches th
     "name": StringMatching "@codecov/vite-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -1474,6 +1490,7 @@ exports[`Generating vite stats v5 {"format":"umd","expected":"umd"} matches the 
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "assets/index-BFgpG9Ne.js",
@@ -1543,7 +1560,7 @@ exports[`Generating vite stats v5 {"format":"umd","expected":"umd"} matches the 
     "name": StringMatching "@codecov/vite-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -1565,6 +1582,7 @@ exports[`Generating vite stats v5 {"format":"system","expected":"system"} matche
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "assets/index-Cn9uVtOh.js",
@@ -1634,7 +1652,7 @@ exports[`Generating vite stats v5 {"format":"system","expected":"system"} matche
     "name": StringMatching "@codecov/vite-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -1656,6 +1674,7 @@ exports[`Generating vite stats v5 {"format":"systemjs","expected":"system"} matc
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "assets/index-Cn9uVtOh.js",
@@ -1725,7 +1744,7 @@ exports[`Generating vite stats v5 {"format":"systemjs","expected":"system"} matc
     "name": StringMatching "@codecov/vite-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -1747,6 +1766,7 @@ exports[`Generating vite stats v5 source maps are enabled does not include any s
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "assets/index-Cq3U4pkx.js",
@@ -1816,6 +1836,6 @@ exports[`Generating vite stats v5 source maps are enabled does not include any s
     "name": StringMatching "@codecov/vite-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;

--- a/integration-tests/fixtures/generate-bundle-stats/webpack/__snapshots__/webpack-plugin.test.ts.snap
+++ b/integration-tests/fixtures/generate-bundle-stats/webpack/__snapshots__/webpack-plugin.test.ts.snap
@@ -18,6 +18,7 @@ exports[`Generating webpack stats 5 {"format":"array-push","expected":"array-pus
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "main-2c458a0c7e378af1ec1a.js",
@@ -71,7 +72,7 @@ exports[`Generating webpack stats 5 {"format":"array-push","expected":"array-pus
     "name": StringMatching "@codecov/webpack-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -93,6 +94,7 @@ exports[`Generating webpack stats 5 {"format":"commonjs","expected":"cjs"} match
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "main-2c458a0c7e378af1ec1a.js",
@@ -146,7 +148,7 @@ exports[`Generating webpack stats 5 {"format":"commonjs","expected":"cjs"} match
     "name": StringMatching "@codecov/webpack-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -168,6 +170,7 @@ exports[`Generating webpack stats 5 {"format":"module","expected":"esm"} matches
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "main-2c458a0c7e378af1ec1a.js",
@@ -221,7 +224,7 @@ exports[`Generating webpack stats 5 {"format":"module","expected":"esm"} matches
     "name": StringMatching "@codecov/webpack-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;
 
@@ -243,6 +246,7 @@ exports[`Generating webpack stats 5 source maps are enabled does not include any
   },
   "chunks": [
     {
+      "dynamicImports": [],
       "entry": true,
       "files": [
         "main-2c458a0c7e378af1ec1a.js",
@@ -296,6 +300,6 @@ exports[`Generating webpack stats 5 source maps are enabled does not include any
     "name": StringMatching "@codecov/webpack-plugin",
     "version": "1.5.1",
   },
-  "version": "2",
+  "version": "3",
 }
 `;

--- a/packages/bundler-plugin-core/src/types.ts
+++ b/packages/bundler-plugin-core/src/types.ts
@@ -21,6 +21,7 @@ export interface Chunk {
   initial: boolean;
   names: string[];
   files: string[];
+  dynamicImports: string[];
 }
 
 export interface Module {

--- a/packages/bundler-plugin-core/src/utils/Output.ts
+++ b/packages/bundler-plugin-core/src/utils/Output.ts
@@ -57,7 +57,7 @@ class Output {
   };
 
   constructor(userOptions: NormalizedOptions) {
-    this.version = "2";
+    this.version = "3";
     this.apiUrl = userOptions.apiUrl;
     this.dryRun = userOptions.dryRun;
     this.retryCount = userOptions.retryCount;

--- a/packages/nextjs-webpack-plugin/src/nextjs-webpack-bundle-analysis/__tests__/__snapshots__/nextJSWebpackBundleAnalysisPlugin.test.ts.snap
+++ b/packages/nextjs-webpack-plugin/src/nextjs-webpack-bundle-analysis/__tests__/__snapshots__/nextJSWebpackBundleAnalysisPlugin.test.ts.snap
@@ -6,7 +6,7 @@ exports[`webpackBundleAnalysisPlugin > when called > returns a plugin object 1`]
   "buildStart": [Function],
   "name": "@codecov/nextjs-webpack-plugin",
   "pluginVersion": "1.5.1",
-  "version": "2",
+  "version": "3",
   "webpack": [Function],
   "writeBundle": [Function],
 }

--- a/packages/nextjs-webpack-plugin/src/nextjs-webpack-bundle-analysis/nextJSWebpackBundleAnalysisPlugin.ts
+++ b/packages/nextjs-webpack-plugin/src/nextjs-webpack-bundle-analysis/nextJSWebpackBundleAnalysisPlugin.ts
@@ -85,6 +85,8 @@ export const nextJSWebpackBundleAnalysisPlugin: ExtendedBAUploadPlugin<{
             output.assets = collectedAssets;
           }
 
+          // need to collect all possible chunk ids beforehand
+          // this collection is done in the processChunks function
           const chunkIdMap = new Map<number | string, string>();
           if (chunks) {
             output.chunks = processChunks({ chunks, chunkIdMap });

--- a/packages/nuxt-plugin/src/nuxt-bundle-analysis/__tests__/__snapshots__/nuxtBundleAnalysisPlugin.test.ts.snap
+++ b/packages/nuxt-plugin/src/nuxt-bundle-analysis/__tests__/__snapshots__/nuxtBundleAnalysisPlugin.test.ts.snap
@@ -4,7 +4,7 @@ exports[`nuxtBundleAnalysisPlugin > when called > returns a plugin object 1`] = 
 {
   "name": "@codecov/nuxt-plugin",
   "pluginVersion": "1.5.1",
-  "version": "2",
+  "version": "3",
   "vite": {
     "generateBundle": [Function],
   },

--- a/packages/remix-vite-plugin/src/remix-bundle-analysis/__tests__/__snapshots__/remixBundleAnalysisPlugin.test.ts.snap
+++ b/packages/remix-vite-plugin/src/remix-bundle-analysis/__tests__/__snapshots__/remixBundleAnalysisPlugin.test.ts.snap
@@ -4,7 +4,7 @@ exports[`remixBundleAnalysisPlugin > when called > returns a plugin object 1`] =
 {
   "name": "@codecov/remix-vite-plugin",
   "pluginVersion": "1.5.1",
-  "version": "2",
+  "version": "3",
   "vite": {
     "generateBundle": [Function],
   },

--- a/packages/rollup-plugin/src/rollup-bundle-analysis/__tests__/__snapshots__/rollupBundleAnalysisPlugin.test.ts.snap
+++ b/packages/rollup-plugin/src/rollup-bundle-analysis/__tests__/__snapshots__/rollupBundleAnalysisPlugin.test.ts.snap
@@ -9,7 +9,7 @@ exports[`rollupBundleAnalysisPlugin > when called > returns a plugin object 1`] 
   "rollup": {
     "generateBundle": [Function],
   },
-  "version": "2",
+  "version": "3",
   "writeBundle": [Function],
 }
 `;

--- a/packages/rollup-plugin/src/rollup-bundle-analysis/rollupBundleAnalysisPlugin.ts
+++ b/packages/rollup-plugin/src/rollup-bundle-analysis/rollupBundleAnalysisPlugin.ts
@@ -105,6 +105,7 @@ export const rollupBundleAnalysisPlugin: BundleAnalysisUploadPlugin = ({
               initial: item?.isDynamicEntry,
               files: [fileName],
               names: [item?.name],
+              dynamicImports: item?.dynamicImports ?? [],
             });
 
             const moduleEntries = Object.entries(item?.modules ?? {});

--- a/packages/solidstart-plugin/src/solidstart-bundle-analysis/__tests__/__snapshots__/solidstartBundleAnalysisPlugin.test.ts.snap
+++ b/packages/solidstart-plugin/src/solidstart-bundle-analysis/__tests__/__snapshots__/solidstartBundleAnalysisPlugin.test.ts.snap
@@ -4,7 +4,7 @@ exports[`solidstartBundleAnalysisPlugin > when called > returns a plugin object 
 {
   "name": "@codecov/solidstart-plugin",
   "pluginVersion": "1.5.1",
-  "version": "2",
+  "version": "3",
   "vite": {
     "generateBundle": [Function],
   },
@@ -15,7 +15,7 @@ exports[`sveltekitBundleAnalysisPlugin > when called > returns a plugin object 1
 {
   "name": "@codecov/sveltekit-plugin",
   "pluginVersion": "1.5.1",
-  "version": "2",
+  "version": "3",
   "vite": {
     "generateBundle": [Function],
   },

--- a/packages/sveltekit-plugin/src/sveltekit-bundle-analysis/__tests__/__snapshots__/sveltekitBundleAnalysisPlugin.test.ts.snap
+++ b/packages/sveltekit-plugin/src/sveltekit-bundle-analysis/__tests__/__snapshots__/sveltekitBundleAnalysisPlugin.test.ts.snap
@@ -4,7 +4,7 @@ exports[`sveltekitBundleAnalysisPlugin > when called > returns a plugin object 1
 {
   "name": "@codecov/sveltekit-plugin",
   "pluginVersion": "1.5.1",
-  "version": "2",
+  "version": "3",
   "vite": {
     "generateBundle": [Function],
   },

--- a/packages/vite-plugin/src/vite-bundle-analysis/__tests__/__snapshots__/viteBundleAnalysisPlugin.test.ts.snap
+++ b/packages/vite-plugin/src/vite-bundle-analysis/__tests__/__snapshots__/viteBundleAnalysisPlugin.test.ts.snap
@@ -6,7 +6,7 @@ exports[`viteBundleAnalysisPlugin > when called > returns a plugin object 1`] = 
   "buildStart": [Function],
   "name": "@codecov/vite-plugin",
   "pluginVersion": "1.5.1",
-  "version": "2",
+  "version": "3",
   "vite": {
     "generateBundle": [Function],
   },

--- a/packages/vite-plugin/src/vite-bundle-analysis/viteBundleAnalysisPlugin.ts
+++ b/packages/vite-plugin/src/vite-bundle-analysis/viteBundleAnalysisPlugin.ts
@@ -98,6 +98,7 @@ export const viteBundleAnalysisPlugin: BundleAnalysisUploadPlugin = ({
 
             const chunkId = item?.name ?? "";
             const uniqueId = `${counter}-${chunkId}`;
+
             chunks.push({
               id: chunkId,
               uniqueId: uniqueId,
@@ -105,6 +106,7 @@ export const viteBundleAnalysisPlugin: BundleAnalysisUploadPlugin = ({
               initial: item?.isDynamicEntry,
               files: [fileName],
               names: [item?.name],
+              dynamicImports: item?.dynamicImports ?? [],
             });
 
             const moduleEntries = Object.entries(item?.modules ?? {});

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -53,6 +53,7 @@
     "@types/node": "^20.10.0",
     "@types/webpack": "^5.28.5",
     "@vitest/coverage-v8": "^1.5.0",
+    "chalk": "4.1.2",
     "codecovProdRollupPlugin": "npm:@codecov/rollup-plugin@1.5.0",
     "msw": "^2.1.5",
     "ts-node": "^10.9.2",

--- a/packages/webpack-plugin/src/webpack-bundle-analysis/__tests__/__snapshots__/webpackBundleAnalysisPlugin.test.ts.snap
+++ b/packages/webpack-plugin/src/webpack-bundle-analysis/__tests__/__snapshots__/webpackBundleAnalysisPlugin.test.ts.snap
@@ -6,7 +6,7 @@ exports[`webpackBundleAnalysisPlugin > when called > returns a plugin object 1`]
   "buildStart": [Function],
   "name": "@codecov/webpack-plugin",
   "pluginVersion": "1.5.1",
-  "version": "2",
+  "version": "3",
   "webpack": [Function],
   "writeBundle": [Function],
 }

--- a/packages/webpack-plugin/src/webpack-bundle-analysis/utils/__tests__/processChunks.test.ts
+++ b/packages/webpack-plugin/src/webpack-bundle-analysis/utils/__tests__/processChunks.test.ts
@@ -49,6 +49,7 @@ describe("processChunks", () => {
           initial: true,
           files: ["file1.js"],
           names: ["chunk1"],
+          dynamicImports: [],
         },
         {
           id: "2",
@@ -57,6 +58,7 @@ describe("processChunks", () => {
           initial: true,
           files: ["file2.js"],
           names: ["chunk2"],
+          dynamicImports: [],
         },
       ]);
     });
@@ -105,6 +107,7 @@ describe("processChunks", () => {
           initial: true,
           files: ["file1.js"],
           names: ["chunk1"],
+          dynamicImports: [],
         },
         {
           id: "",
@@ -113,6 +116,69 @@ describe("processChunks", () => {
           initial: true,
           files: ["file2.js"],
           names: ["chunk2"],
+          dynamicImports: [],
+        },
+      ]);
+    });
+  });
+
+  describe("there are children in the chunks", () => {
+    it("includes the children as dynamic imports", () => {
+      const chunks = [
+        {
+          id: "1",
+          entry: true,
+          initial: true,
+          files: ["file1.js"],
+          names: ["chunk1"],
+          rendered: true,
+          recorded: true,
+          size: 1000,
+          hash: "hash1",
+          sizes: {},
+          idHints: [],
+          children: [],
+          auxiliaryFiles: [],
+          childrenByOrder: {},
+        },
+        {
+          id: 2,
+          entry: true,
+          initial: true,
+          files: ["file2.js"],
+          names: ["chunk2"],
+          rendered: true,
+          recorded: true,
+          size: 2000,
+          hash: "hash2",
+          sizes: {},
+          idHints: [],
+          children: [1],
+          auxiliaryFiles: [],
+          childrenByOrder: {},
+        },
+      ] satisfies StatsChunk[];
+
+      const chunkIdMap = new Map();
+
+      expect(processChunks({ chunks, chunkIdMap })).toEqual([
+        {
+          id: "1",
+          uniqueId: "0-1",
+          entry: true,
+          initial: true,
+          files: ["file1.js"],
+          names: ["chunk1"],
+          dynamicImports: [],
+        },
+        {
+          id: "2",
+          uniqueId: "1-2",
+          entry: true,
+          initial: true,
+          files: ["file2.js"],
+          names: ["chunk2"],
+          dynamicImports: ["file1.js"],
         },
       ]);
     });

--- a/packages/webpack-plugin/src/webpack-bundle-analysis/utils/__tests__/processChunks.test.ts
+++ b/packages/webpack-plugin/src/webpack-bundle-analysis/utils/__tests__/processChunks.test.ts
@@ -1,5 +1,7 @@
+import Chalk from "chalk";
 import { describe, it, expect } from "vitest";
 import { type StatsChunk } from "webpack";
+import { vi } from "vitest";
 
 import { processChunks } from "../processChunks";
 
@@ -181,6 +183,55 @@ describe("processChunks", () => {
           dynamicImports: ["file1.js"],
         },
       ]);
+    });
+  });
+
+  describe("child chunk not found in chunkMap", () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => null);
+
+    it("should log an error", () => {
+      const chunkIdMap = new Map();
+      const chunks = [
+        {
+          id: "1",
+          entry: true,
+          initial: true,
+          files: ["file1.js"],
+          names: ["chunk1"],
+          rendered: true,
+          recorded: true,
+          size: 1000,
+          hash: "hash1",
+          sizes: {},
+          idHints: [],
+          children: [],
+          auxiliaryFiles: [],
+          childrenByOrder: {},
+        },
+        {
+          id: 2,
+          entry: true,
+          initial: true,
+          files: ["file2.js"],
+          names: ["chunk2"],
+          rendered: true,
+          recorded: true,
+          size: 2000,
+          hash: "hash2",
+          sizes: {},
+          idHints: [],
+          children: [3],
+          auxiliaryFiles: [],
+          childrenByOrder: {},
+        },
+      ] satisfies StatsChunk[];
+
+      processChunks({ chunks, chunkIdMap });
+
+      expect(consoleSpy).toHaveBeenCalled();
+      expect(consoleSpy).toHaveBeenCalledWith(
+        `[codecov] ${Chalk.red("Child chunk 3 not found in chunkMap")}`,
+      );
     });
   });
 });

--- a/packages/webpack-plugin/src/webpack-bundle-analysis/utils/processChunks.ts
+++ b/packages/webpack-plugin/src/webpack-bundle-analysis/utils/processChunks.ts
@@ -7,13 +7,13 @@ export interface ProcessChunksArgs {
 }
 
 export const processChunks = ({ chunks, chunkIdMap }: ProcessChunksArgs) => {
-  const chunkMap = new Map<PropertyKey, StatsChunk>();
-
-  // need to collect all possible chunk ids beforehand so we can use them to
-  // collect the dynamic imports
+  // need a reference of all chunks by their id so we can use it to collect
+  // the dynamic imports from the children chunks without having to search
+  // through the entire list of chunks every time
+  const referenceChunkMapById = new Map<PropertyKey, StatsChunk>();
   chunks.forEach((chunk) => {
     if (chunk.id) {
-      chunkMap.set(chunk.id.toString(), chunk);
+      referenceChunkMapById.set(chunk.id.toString(), chunk);
     }
   });
 
@@ -25,7 +25,7 @@ export const processChunks = ({ chunks, chunkIdMap }: ProcessChunksArgs) => {
     const dynamicImports: string[] = [];
     chunk.children?.forEach((child) => {
       const childIdString = child.toString();
-      const childChunk = chunkMap.get(childIdString);
+      const childChunk = referenceChunkMapById.get(childIdString);
 
       if (!childChunk || !childChunk.files) {
         red(`Child chunk ${childIdString} not found in chunkMap`);

--- a/packages/webpack-plugin/src/webpack-bundle-analysis/webpackBundleAnalysisPlugin.ts
+++ b/packages/webpack-plugin/src/webpack-bundle-analysis/webpackBundleAnalysisPlugin.ts
@@ -78,6 +78,8 @@ export const webpackBundleAnalysisPlugin: BundleAnalysisUploadPlugin = ({
             output.assets = collectedAssets;
           }
 
+          // need to collect all possible chunk ids beforehand
+          // this collection is done in the processChunks function
           const chunkIdMap = new Map<number | string, string>();
           if (chunks) {
             output.chunks = processChunks({ chunks, chunkIdMap });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1285,6 +1285,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^1.5.0
         version: 1.5.0(vitest@1.5.0(@types/node@20.10.0)(terser@5.27.0))
+      chalk:
+        specifier: 4.1.2
+        version: 4.1.2
       codecovProdRollupPlugin:
         specifier: npm:@codecov/rollup-plugin@1.5.0
         version: '@codecov/rollup-plugin@1.5.0(rollup@4.27.3)'


### PR DESCRIPTION
# Description

This PR adds the functionality in the base plugins to capture the "dynamic imports". A dynamic import is when a given asset has code that lazily loads code when executed. The reason why we're adding in this functionality now, is that we need the dynamic imports to better inform the end user of what JS will be loaded initially and potentionally eventually on their given endpoint as a part of codecov/engineering-team#2570.

Closes codecov/engineering-team#3034

# Notable Changes

- Update `Chunk` type to include `dynamicImports` field which is of type `string[]`
- Update `rollup` and `vite` plugins to grab `dynamicImports` and assign to chunks
- Update `webpack` plugin to grab `children` array and assign the associated assets to the `dynamicImports` field
  - Had to do a bit more work for the `webpack` as the children array is an array of chunks and not assets
- Update some unit tests, integration test snapshot matchers, and snapshots