### PR TITLE
fix: Resolve issues with the Local Provider

### DIFF
--- a/.changeset/little-dryers-switch.md
+++ b/.changeset/little-dryers-switch.md
@@ -1,0 +1,15 @@
+---
+"@codecov/bundler-plugin-core": patch
+"@codecov/astro-plugin": patch
+"@codecov/bundle-analyzer": patch
+"@codecov/nextjs-webpack-plugin": patch
+"@codecov/nuxt-plugin": patch
+"@codecov/remix-vite-plugin": patch
+"@codecov/rollup-plugin": patch
+"@codecov/solidstart-plugin": patch
+"@codecov/sveltekit-plugin": patch
+"@codecov/vite-plugin": patch
+"@codecov/webpack-plugin": patch
+---
+
+Resolve issue with Local provider conditional check not being able to detect local values

--- a/packages/bundler-plugin-core/src/utils/providers/Local.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/Local.ts
@@ -37,7 +37,7 @@ function _getBranch(
 ): ProviderServiceParams["branch"] {
   const { args, envs } = inputs;
   const branch = args?.branch ?? envs?.GIT_BRANCH ?? envs?.BRANCH_NAME ?? null;
-  if (branch !== "") {
+  if (branch !== "" && branch !== null) {
     debug(`Using branch: ${branch}`, { enabled: output.debug });
     return branch;
   }
@@ -91,7 +91,7 @@ function _getSHA(
 ): ProviderServiceParams["commit"] {
   const { args, envs } = inputs;
   const sha = args?.sha ?? envs?.GIT_COMMIT ?? null;
-  if (sha !== "") {
+  if (sha !== "" && sha !== null) {
     debug(`Using commit: ${sha}`, { enabled: output.debug });
     return sha;
   }


### PR DESCRIPTION
# Description

This PR fixes some conditional checks in the `Local` provider where values were being set as `null` then failing the next conditional and breaking uploads on local machines.

# Notable Changes

- Update conditional in `Local` where we also needed to check for `null`
- Add in changeset
