### PR TITLE
fix: Issue with building Typedocs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,7 +18,7 @@ const config = {
     "**/integration-tests/**/*.mjs",
     "**/integration-tests/test-api/**/*",
     "**/scripts/publish-docs.mjs",
-    "**/typedoc/plugin-remove-references.js",
+    "**/typedoc/plugin-remove-references.mjs",
   ],
   parserOptions: {
     ecmaVersion: "latest",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,52 @@ jobs:
       - name: Run TSC
         run: pnpm run type-check
 
+  build-docs:
+    name: Test docs build
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Cache node_modules
+        id: cache-node-modules
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-codecov-js-bundle-plugin-node-modules
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.cache-name }}-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build packages
+        run: pnpm run build
+
+      - name: Run Docs
+        run: pnpm run generate:typedoc
+
   unit-test:
     name: Run Unit Tests
     runs-on: ubuntu-latest
@@ -475,7 +521,7 @@ jobs:
           WEBPACK_API_URL: ${{ secrets.CODECOV_STAGING_API_URL }}
         run: pnpm run build
 
-  upldate-plugin-stats-production:
+  upload-plugin-stats-production:
     name: "Production: upload ${{ matrix.package }} stats"
     runs-on: ubuntu-latest
     needs: [install, unit-test, integration-test]
@@ -545,7 +591,7 @@ jobs:
           PLUGIN_CODECOV_API_URL: ${{ secrets.CODECOV_API_URL }}
         run: pnpm run build
 
-  upldate-plugin-stats-staging:
+  upload-plugin-stats-staging:
     name: "Staging: upload ${{ matrix.package }} stats"
     runs-on: ubuntu-latest
     needs: [install, unit-test, integration-test]

--- a/.gitignore
+++ b/.gitignore
@@ -137,4 +137,4 @@ dist
 
 # typedoc generated files
 typedoc/*
-!typedoc/plugin-remove-references.js
+!typedoc/plugin-remove-references.mjs

--- a/typedoc.json
+++ b/typedoc.json
@@ -12,5 +12,5 @@
   "excludeNotDocumented": true,
   "useTsLinkResolution": true,
   "githubPages": true,
-  "plugin": ["./typedoc/plugin-remove-references.js"]
+  "plugin": ["./typedoc/plugin-remove-references.mjs"]
 }

--- a/typedoc/plugin-remove-references.mjs
+++ b/typedoc/plugin-remove-references.mjs
@@ -22,9 +22,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-const { ReflectionKind, Converter } = require("typedoc");
+import { ReflectionKind, Converter } from "typedoc";
 
-function load({ application }) {
+export function load({ application }) {
   application.converter.on(Converter.EVENT_RESOLVE_BEGIN, (context) => {
     for (const reflection of context.project.getReflectionsByKind(
       ReflectionKind.Reference,
@@ -33,5 +33,3 @@ function load({ application }) {
     }
   });
 }
-
-module.exports = { load };


### PR DESCRIPTION
# Description

When updating the dependences in the previous PR I missed checking to see if the typedocs would still build, this PR resolves an issue with how they are being built. I've also added in a CI step to check to see if we're able to build the docs.

# Notable Changes

- Refactor plugin to ESM
- Update references
- Add in CI step to check if docs are able to be built
