### PR TITLE
feat: Add finer Sentry HTTP Tracing

### DIFF
--- a/packages/bundler-plugin-core/src/utils/Output.ts
+++ b/packages/bundler-plugin-core/src/utils/Output.ts
@@ -239,7 +239,7 @@ class Output {
               scope: this.sentryScope,
               parentSpan: outputWriteSpan,
             },
-            async () => {
+            async (getPreSignedURLSpan) => {
               let url = "";
               try {
                 url = await getPreSignedURL({
@@ -249,6 +249,8 @@ class Output {
                   oidc: this.oidc,
                   retryCount: this.retryCount,
                   serviceParams: provider,
+                  sentryScope: this.sentryScope,
+                  sentrySpan: getPreSignedURLSpan,
                 });
               } catch (error) {
                 if (this.sentryClient && this.sentryScope) {
@@ -291,13 +293,15 @@ class Output {
               scope: this.sentryScope,
               parentSpan: outputWriteSpan,
             },
-            async () => {
+            async (uploadStatsSpan) => {
               try {
                 await uploadStats({
                   preSignedUrl: presignedURL,
                   bundleName: this.bundleName,
                   message: this.bundleStatsToJson(),
-                  retryCount: this?.retryCount,
+                  retryCount: this.retryCount,
+                  sentryScope: this.sentryScope,
+                  sentrySpan: uploadStatsSpan,
                 });
               } catch (error) {
                 // this is being set as an error because this could not be caused by a user error

--- a/packages/bundler-plugin-core/src/utils/normalizeOptions.ts
+++ b/packages/bundler-plugin-core/src/utils/normalizeOptions.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 import { type Options } from "../types.ts";
 import { red } from "./logging.ts";
 
+export const DEFAULT_API_URL = "https://api.codecov.io";
+
 export type NormalizedOptions = z.infer<
   ReturnType<typeof optionsSchemaFactory>
 > &
@@ -87,7 +89,7 @@ const optionsSchemaFactory = (options: Options) =>
       .url({
         message: `apiUrl: \`${options?.apiUrl}\` is not a valid URL.`,
       })
-      .default("https://api.codecov.io"),
+      .default(DEFAULT_API_URL),
     bundleName: z
       .string({
         invalid_type_error: "`bundleName` must be a string.",


### PR DESCRIPTION
# Description

This PR adds in some extra tracing that's a bit finer grain looking at the specific fetch requests for getting the pre-signed URL, and uploading stats. As well we've added in distributed tracing for getting the pre-signed URL (only when talking to Codecov).

Ticket: codecov/engineering-team#954

# Notable Changes

- Add tracing around `getPreSignedURL`, and `uploadStats` fetching