### PR TITLE
feat: Inline `@sentry/core` dependency

### DIFF
--- a/packages/bundler-plugin-core/build.config.ts
+++ b/packages/bundler-plugin-core/build.config.ts
@@ -19,7 +19,25 @@ export default defineBuildConfig({
     },
   },
   hooks: {
-    "rollup:options": (_ctx, opts) => {
+    "rollup:options": (ctx, opts) => {
+      // We want to ensure that `@sentry/core` is not externalized
+      // So we do not ship this dependency to users, as this may lead to conflicts with their installed Sentry versions
+      // TODO: When unbuild is updated to 3.3.0, this can be simplified by configuring `inlineDependencies`
+      // See: https://github.com/unjs/unbuild/releases/tag/v3.3.0
+      // Inspired by https://github.com/nuxt/nuxt/blob/f0ce20388d2ab533eba016de0565c150ea3c5172/packages/schema/build.config.ts#L23-L34
+      ctx.options.rollup.dts.respectExternal = false;
+      const isExternal = opts.external as (
+        id: string,
+        importer?: string,
+        isResolved?: boolean,
+      ) => boolean;
+      opts.external = (source, importer, isResolved) => {
+        if (source === "@sentry/core") {
+          return false;
+        }
+        return isExternal(source, importer, isResolved);
+      };
+
       if (process.env.PLUGIN_CODECOV_TOKEN && Array.isArray(opts.plugins)) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-floating-promises
         opts.plugins = [

--- a/packages/bundler-plugin-core/package.json
+++ b/packages/bundler-plugin-core/package.json
@@ -41,7 +41,6 @@
   "dependencies": {
     "@actions/core": "^1.10.1",
     "@actions/github": "^6.0.0",
-    "@sentry/core": "^8.42.0",
     "chalk": "4.1.2",
     "semver": "^7.5.4",
     "unplugin": "^1.10.1",
@@ -49,6 +48,7 @@
   },
   "devDependencies": {
     "@octokit/webhooks-definitions": "^3.67.3",
+    "@sentry/core": "^8.42.0",
     "@types/node": "^20.11.15",
     "@types/semver": "^7.5.6",
     "@vitest/coverage-v8": "^2.1.8",


### PR DESCRIPTION
This PR inlines the `@sentry/core` dependency into the build, moving it from `dependencies` to `devDependencies`.

The reason for this is to avoid shipping this dependency to users, as this _may_ conflict with their own installed Sentry version.
Ideally, this should not really be a problem, but we have seen reports where package managers could not solve this issue nicely. So this is the "safer" solution, and also what we do at https://github.com/getsentry/sentry-javascript-bundler-plugins.

I played around a bit with unbuild and found this reference here: https://github.com/nuxt/nuxt/blob/f0ce20388d2ab533eba016de0565c150ea3c5172/packages/schema/build.config.ts#L23-L34, which I used as a basis for this. If unbuild were to be updated to 3.3.0+, this could be done via the new `inlineDependencies` config.