### PR TITLE
feat: Remove minification & sourcemaps of packages

### DIFF
--- a/.changeset/eleven-spies-dance.md
+++ b/.changeset/eleven-spies-dance.md
@@ -1,0 +1,15 @@
+---
+"@codecov/nextjs-webpack-plugin": patch
+"@codecov/bundler-plugin-core": patch
+"@codecov/remix-vite-plugin": patch
+"@codecov/solidstart-plugin": patch
+"@codecov/sveltekit-plugin": patch
+"@codecov/bundle-analyzer": patch
+"@codecov/webpack-plugin": patch
+"@codecov/rollup-plugin": patch
+"@codecov/astro-plugin": patch
+"@codecov/nuxt-plugin": patch
+"@codecov/vite-plugin": patch
+---
+
+Remove minification from plugin build

--- a/.changeset/hip-dolphins-watch.md
+++ b/.changeset/hip-dolphins-watch.md
@@ -1,0 +1,15 @@
+---
+"@codecov/nextjs-webpack-plugin": patch
+"@codecov/bundler-plugin-core": patch
+"@codecov/remix-vite-plugin": patch
+"@codecov/solidstart-plugin": patch
+"@codecov/sveltekit-plugin": patch
+"@codecov/bundle-analyzer": patch
+"@codecov/webpack-plugin": patch
+"@codecov/rollup-plugin": patch
+"@codecov/astro-plugin": patch
+"@codecov/nuxt-plugin": patch
+"@codecov/vite-plugin": patch
+---
+
+Remove sourcemap generation from plugin build config

--- a/packages/astro-plugin/build.config.ts
+++ b/packages/astro-plugin/build.config.ts
@@ -6,7 +6,6 @@ export default defineBuildConfig({
   entries: ["./src/index"],
   outDir: "dist",
   declaration: "compatible",
-  sourcemap: true,
   externals: ["vite"],
   rollup: {
     dts: {

--- a/packages/astro-plugin/build.config.ts
+++ b/packages/astro-plugin/build.config.ts
@@ -15,9 +15,6 @@ export default defineBuildConfig({
       },
     },
     emitCJS: true,
-    esbuild: {
-      minify: true,
-    },
     replace: {
       preventAssignment: true,
       values: {

--- a/packages/bundle-analyzer/build.config.ts
+++ b/packages/bundle-analyzer/build.config.ts
@@ -17,9 +17,6 @@ export default defineBuildConfig({
       },
     },
     emitCJS: true,
-    esbuild: {
-      minify: true,
-    },
     replace: {
       preventAssignment: true,
       values: {

--- a/packages/bundle-analyzer/build.config.ts
+++ b/packages/bundle-analyzer/build.config.ts
@@ -9,7 +9,6 @@ export default defineBuildConfig({
   entries: ["./src/index.ts", "./src/cli.ts"],
   outDir: "dist",
   declaration: "compatible",
-  sourcemap: true,
   rollup: {
     dts: {
       compilerOptions: {

--- a/packages/bundler-plugin-core/build.config.ts
+++ b/packages/bundler-plugin-core/build.config.ts
@@ -14,9 +14,6 @@ export default defineBuildConfig({
       },
     },
     emitCJS: true,
-    esbuild: {
-      minify: true,
-    },
   },
   hooks: {
     "rollup:options": (ctx, opts) => {

--- a/packages/bundler-plugin-core/build.config.ts
+++ b/packages/bundler-plugin-core/build.config.ts
@@ -6,7 +6,6 @@ export default defineBuildConfig({
   entries: ["./src/index"],
   outDir: "dist",
   declaration: "compatible",
-  sourcemap: true,
   rollup: {
     dts: {
       compilerOptions: {

--- a/packages/nextjs-webpack-plugin/build.config.ts
+++ b/packages/nextjs-webpack-plugin/build.config.ts
@@ -6,7 +6,6 @@ export default defineBuildConfig({
   entries: ["./src/index"],
   outDir: "dist",
   declaration: "compatible",
-  sourcemap: true,
   rollup: {
     dts: {
       compilerOptions: {

--- a/packages/nextjs-webpack-plugin/build.config.ts
+++ b/packages/nextjs-webpack-plugin/build.config.ts
@@ -14,9 +14,6 @@ export default defineBuildConfig({
       },
     },
     emitCJS: true,
-    esbuild: {
-      minify: true,
-    },
     replace: {
       preventAssignment: true,
       values: {

--- a/packages/nuxt-plugin/build.config.ts
+++ b/packages/nuxt-plugin/build.config.ts
@@ -6,7 +6,6 @@ export default defineBuildConfig({
   entries: ["./src/index"],
   outDir: "dist",
   declaration: "compatible",
-  sourcemap: true,
   externals: ["vite"],
   rollup: {
     dts: {

--- a/packages/nuxt-plugin/build.config.ts
+++ b/packages/nuxt-plugin/build.config.ts
@@ -15,9 +15,6 @@ export default defineBuildConfig({
       },
     },
     emitCJS: true,
-    esbuild: {
-      minify: true,
-    },
     replace: {
       preventAssignment: true,
       values: {

--- a/packages/remix-vite-plugin/build.config.ts
+++ b/packages/remix-vite-plugin/build.config.ts
@@ -6,7 +6,6 @@ export default defineBuildConfig({
   entries: ["./src/index"],
   outDir: "dist",
   declaration: "compatible",
-  sourcemap: true,
   externals: ["vite"],
   rollup: {
     dts: {

--- a/packages/remix-vite-plugin/build.config.ts
+++ b/packages/remix-vite-plugin/build.config.ts
@@ -15,9 +15,6 @@ export default defineBuildConfig({
       },
     },
     emitCJS: true,
-    esbuild: {
-      minify: true,
-    },
     replace: {
       preventAssignment: true,
       values: {

--- a/packages/rollup-plugin/build.config.ts
+++ b/packages/rollup-plugin/build.config.ts
@@ -15,9 +15,6 @@ export default defineBuildConfig({
       },
     },
     emitCJS: true,
-    esbuild: {
-      minify: true,
-    },
     replace: {
       preventAssignment: true,
       values: {

--- a/packages/rollup-plugin/build.config.ts
+++ b/packages/rollup-plugin/build.config.ts
@@ -6,7 +6,6 @@ export default defineBuildConfig({
   entries: ["./src/index"],
   outDir: "dist",
   declaration: "compatible",
-  sourcemap: true,
   externals: ["rollup"],
   rollup: {
     dts: {

--- a/packages/solidstart-plugin/build.config.ts
+++ b/packages/solidstart-plugin/build.config.ts
@@ -6,7 +6,6 @@ export default defineBuildConfig({
   entries: ["./src/index"],
   outDir: "dist",
   declaration: "compatible",
-  sourcemap: true,
   externals: ["vite"],
   rollup: {
     dts: {

--- a/packages/solidstart-plugin/build.config.ts
+++ b/packages/solidstart-plugin/build.config.ts
@@ -15,9 +15,6 @@ export default defineBuildConfig({
       },
     },
     emitCJS: true,
-    esbuild: {
-      minify: true,
-    },
     replace: {
       preventAssignment: true,
       values: {

--- a/packages/sveltekit-plugin/build.config.ts
+++ b/packages/sveltekit-plugin/build.config.ts
@@ -6,7 +6,6 @@ export default defineBuildConfig({
   entries: ["./src/index"],
   outDir: "dist",
   declaration: "compatible",
-  sourcemap: true,
   externals: ["vite"],
   rollup: {
     dts: {

--- a/packages/sveltekit-plugin/build.config.ts
+++ b/packages/sveltekit-plugin/build.config.ts
@@ -15,9 +15,6 @@ export default defineBuildConfig({
       },
     },
     emitCJS: true,
-    esbuild: {
-      minify: true,
-    },
     replace: {
       preventAssignment: true,
       values: {

--- a/packages/vite-plugin/build.config.ts
+++ b/packages/vite-plugin/build.config.ts
@@ -6,7 +6,6 @@ export default defineBuildConfig({
   entries: ["./src/index"],
   outDir: "dist",
   declaration: "compatible",
-  sourcemap: true,
   externals: ["vite"],
   rollup: {
     dts: {

--- a/packages/vite-plugin/build.config.ts
+++ b/packages/vite-plugin/build.config.ts
@@ -15,9 +15,6 @@ export default defineBuildConfig({
       },
     },
     emitCJS: true,
-    esbuild: {
-      minify: true,
-    },
     replace: {
       preventAssignment: true,
       values: {

--- a/packages/webpack-plugin/build.config.ts
+++ b/packages/webpack-plugin/build.config.ts
@@ -6,7 +6,6 @@ export default defineBuildConfig({
   entries: ["./src/index"],
   outDir: "dist",
   declaration: "compatible",
-  sourcemap: true,
   rollup: {
     dts: {
       compilerOptions: {

--- a/packages/webpack-plugin/build.config.ts
+++ b/packages/webpack-plugin/build.config.ts
@@ -14,9 +14,6 @@ export default defineBuildConfig({
       },
     },
     emitCJS: true,
-    esbuild: {
-      minify: true,
-    },
     replace: {
       preventAssignment: true,
       values: {


### PR DESCRIPTION
# Description

This PR removes two build settings for all of the plugins: minification, and outputting sourcemaps. We're removing minification because as these are dev deps, and are fairly small there's really no reason to minify the packages and make things harder to read/debug if any errors are raised. Since we're removing minification, there's also no reason for us to generate sourcemaps anymore.

# Notable Changes

- Stop output packages from being minified
- Remove outputting of sourcemaps
