### PR TITLE
feat: include user agent in headers

### DIFF
--- a/packages/bundler-plugin-core/src/utils/__tests__/Output.test.ts
+++ b/packages/bundler-plugin-core/src/utils/__tests__/Output.test.ts
@@ -693,6 +693,7 @@ describe("Output", () => {
             headers: new Headers({
               Authorization: "token token",
               "Content-Type": "application/json",
+              "User-Agent": "codecov-bundler_plugin/1.9.1",
             }),
             body: JSON.stringify({
               branch: "main",

--- a/packages/bundler-plugin-core/src/utils/__tests__/Output.test.ts
+++ b/packages/bundler-plugin-core/src/utils/__tests__/Output.test.ts
@@ -693,7 +693,7 @@ describe("Output", () => {
             headers: new Headers({
               Authorization: "token token",
               "Content-Type": "application/json",
-              "User-Agent": "codecov-bundler_plugin/1.9.1",
+              "User-Agent": "codecov-bundler-plugin/1.9.1",
             }),
             body: JSON.stringify({
               branch: "main",

--- a/packages/bundler-plugin-core/src/utils/getPreSignedURL.ts
+++ b/packages/bundler-plugin-core/src/utils/getPreSignedURL.ts
@@ -7,6 +7,7 @@ import {
   type Span,
 } from "@sentry/core";
 import { z } from "zod";
+import { version } from "../../package.json" with { type: "json" };
 import { FailedFetchError } from "../errors/FailedFetchError.ts";
 import { UploadLimitReachedError } from "../errors/UploadLimitReachedError.ts";
 import { type ProviderServiceParams } from "../types.ts";
@@ -53,6 +54,7 @@ export const getPreSignedURL = async ({
 }: GetPreSignedURLArgs) => {
   const headers = new Headers({
     "Content-Type": "application/json",
+    "User-Agent": `codecov-bundler_plugin/${version}`,
   });
 
   const requestBody: RequestBody = serviceParams;

--- a/packages/bundler-plugin-core/src/utils/getPreSignedURL.ts
+++ b/packages/bundler-plugin-core/src/utils/getPreSignedURL.ts
@@ -54,7 +54,7 @@ export const getPreSignedURL = async ({
 }: GetPreSignedURLArgs) => {
   const headers = new Headers({
     "Content-Type": "application/json",
-    "User-Agent": `codecov-bundler_plugin/${version}`,
+    "User-Agent": `codecov-bundler-plugin/${version}`,
   });
 
   const requestBody: RequestBody = serviceParams;


### PR DESCRIPTION
this will be helpful in the future for debugging customer issues since it will tell us what version of the plugins (at least the bundler core) they're using