### PR TITLE
fix: add github permissions

### DIFF
--- a/.changeset/purple-bikes-jam.md
+++ b/.changeset/purple-bikes-jam.md
@@ -1,0 +1,15 @@
+---
+"@codecov/astro-plugin": patch
+"@codecov/bundle-analyzer": patch
+"@codecov/bundler-plugin-core": patch
+"@codecov/nextjs-webpack-plugin": patch
+"@codecov/nuxt-plugin": patch
+"@codecov/remix-vite-plugin": patch
+"@codecov/rollup-plugin": patch
+"@codecov/solidstart-plugin": patch
+"@codecov/sveltekit-plugin": patch
+"@codecov/vite-plugin": patch
+"@codecov/webpack-plugin": patch
+---
+
+update GitHub Actions workflow permissions

--- a/.github/workflows/cache_cleanup.yml
+++ b/.github/workflows/cache_cleanup.yml
@@ -4,6 +4,9 @@ on:
     types:
       - closed
 
+permissions:
+  contents: read
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest
@@ -21,7 +24,7 @@ jobs:
           echo "Fetching list of cache key"
           cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH -L 100 | cut -f 1 )
 
-          ## Setting this to not fail the workflow while deleting cache keys. 
+          ## Setting this to not fail the workflow while deleting cache keys.
           set +e
           echo "Deleting caches..."
           for cacheKey in $cacheKeysForPR

--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main, master]
 
+permissions:
+  contents: read
+
 jobs:
   enforce-license-compliance:
     runs-on: ubuntu-latest

--- a/.github/workflows/prepare-publish.yml
+++ b/.github/workflows/prepare-publish.yml
@@ -3,6 +3,10 @@ name: Prepare Publish
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - "**/CHANGELOG.md"
 
+permissions:
+  contents: read
+
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
@@ -16,7 +19,7 @@ jobs:
     # For whatever reason, yaml does not like the full "meta(changelog): Update package versions" string
     # So we check this in two parts
     if: |
-      contains(github.event.head_commit.message, 'meta(changelog)') 
+      contains(github.event.head_commit.message, 'meta(changelog)')
       && contains(github.event.head_commit.message, 'Update package versions')
     steps:
       - name: Checkout Repo
@@ -68,7 +71,7 @@ jobs:
     # For whatever reason, yaml does not like the full "meta(changelog): Update package versions" string
     # So we check this in two parts
     if: |
-      contains(github.event.head_commit.message, 'meta(changelog)') 
+      contains(github.event.head_commit.message, 'meta(changelog)')
       && contains(github.event.head_commit.message, 'Update package versions')
     steps:
       - name: Checkout Repo

--- a/.github/workflows/test-api-ci.yml
+++ b/.github/workflows/test-api-ci.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - integration-tests/test-api/**
 
+permissions:
+  content: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/test-api-push.yml
+++ b/.github/workflows/test-api-push.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - integration-tests/test-api/**
 
+permissions:
+  content: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/typedoc-manual-deploy.yml
+++ b/.github/workflows/typedoc-manual-deploy.yml
@@ -3,6 +3,9 @@ name: Publish TypeDocs
 on:
   workflow_dispatch:
 
+permissions:
+  content: read
+
 jobs:
   deploy_docs:
     permissions:


### PR DESCRIPTION
# Description

Adding in explicit permissions for the `GITHUB_TOKEN` to address security issues (see https://github.com/codecov/codecov-javascript-bundler-plugins/security/code-scanning/79 as an example)

# Code Example

# Notable Changes

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
