### PR TITLE
Add accurate homepage, repository and bugs metadata to all packages

### DIFF
--- a/packages/astro-plugin/package.json
+++ b/packages/astro-plugin/package.json
@@ -5,7 +5,14 @@
   "author": "Codecov",
   "license": "MIT",
   "homepage": "https://github.com/codecov/codecov-javascript-bundler-plugins/tree/main/packages/astro-plugin",
-  "repository": "git://github.com/codecov/codecov-javascript-bundler-plugins.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codecov/codecov-javascript-bundler-plugins.git",
+    "directory": "packages/astro-plugin"
+  },
+  "bugs": {
+    "url": "https://github.com/codecov/codecov-javascript-bundler-plugins/issues"
+  },
   "keywords": [
     "withastro",
     "astro-component",

--- a/packages/bundle-analyzer/package.json
+++ b/packages/bundle-analyzer/package.json
@@ -4,6 +4,15 @@
   "description": "Official Codecov Bundle Analyzer",
   "author": "Codecov",
   "license": "MIT",
+  "homepage": "https://github.com/codecov/codecov-javascript-bundler-plugins/tree/main/packages/bundle-analyzer",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codecov/codecov-javascript-bundler-plugins.git",
+    "directory": "packages/bundle-analyzer"
+  },
+  "bugs": {
+    "url": "https://github.com/codecov/codecov-javascript-bundler-plugins/issues"
+  },
   "keywords": [
     "Codecov",
     "bundle-analyzer",

--- a/packages/bundler-plugin-core/package.json
+++ b/packages/bundler-plugin-core/package.json
@@ -4,6 +4,15 @@
   "description": "Official Codecov Bundler Plugin Core",
   "author": "Codecov",
   "license": "MIT",
+  "homepage": "https://github.com/codecov/codecov-javascript-bundler-plugins/tree/main/packages/bundler-plugin-core",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codecov/codecov-javascript-bundler-plugins.git",
+    "directory": "packages/bundler-plugin-core"
+  },
+  "bugs": {
+    "url": "https://github.com/codecov/codecov-javascript-bundler-plugins/issues"
+  },
   "type": "module",
   "exports": {
     ".": {

--- a/packages/nextjs-webpack-plugin/package.json
+++ b/packages/nextjs-webpack-plugin/package.json
@@ -4,6 +4,15 @@
   "description": "Official Codecov NextJS (Webpack) plugin",
   "author": "Codecov",
   "license": "MIT",
+  "homepage": "https://github.com/codecov/codecov-javascript-bundler-plugins/tree/main/packages/nextjs-webpack-plugin",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codecov/codecov-javascript-bundler-plugins.git",
+    "directory": "packages/nextjs-webpack-plugin"
+  },
+  "bugs": {
+    "url": "https://github.com/codecov/codecov-javascript-bundler-plugins/issues"
+  },
   "keywords": [
     "Codecov",
     "NextJS",

--- a/packages/nuxt-plugin/package.json
+++ b/packages/nuxt-plugin/package.json
@@ -4,6 +4,15 @@
   "description": "Official Codecov Nuxt plugin",
   "author": "Codecov",
   "license": "MIT",
+  "homepage": "https://github.com/codecov/codecov-javascript-bundler-plugins/tree/main/packages/nuxt-plugin",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codecov/codecov-javascript-bundler-plugins.git",
+    "directory": "packages/nuxt-plugin"
+  },
+  "bugs": {
+    "url": "https://github.com/codecov/codecov-javascript-bundler-plugins/issues"
+  },
   "keywords": [
     "Codecov",
     "Nuxt",

--- a/packages/remix-vite-plugin/package.json
+++ b/packages/remix-vite-plugin/package.json
@@ -4,6 +4,15 @@
   "description": "Official Codecov Remix plugin",
   "author": "Codecov",
   "license": "MIT",
+  "homepage": "https://github.com/codecov/codecov-javascript-bundler-plugins/tree/main/packages/remix-vite-plugin",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codecov/codecov-javascript-bundler-plugins.git",
+    "directory": "packages/remix-vite-plugin"
+  },
+  "bugs": {
+    "url": "https://github.com/codecov/codecov-javascript-bundler-plugins/issues"
+  },
   "keywords": [
     "Codecov",
     "Remix",

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -4,6 +4,15 @@
   "description": "Official Codecov Rollup plugin",
   "author": "Codecov",
   "license": "MIT",
+  "homepage": "https://github.com/codecov/codecov-javascript-bundler-plugins/tree/main/packages/rollup-plugin",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codecov/codecov-javascript-bundler-plugins.git",
+    "directory": "packages/rollup-plugin"
+  },
+  "bugs": {
+    "url": "https://github.com/codecov/codecov-javascript-bundler-plugins/issues"
+  },
   "keywords": [
     "Codecov",
     "Rollup",

--- a/packages/solidstart-plugin/package.json
+++ b/packages/solidstart-plugin/package.json
@@ -4,6 +4,15 @@
   "description": "Official Codecov SolidStart plugin",
   "author": "Codecov",
   "license": "MIT",
+  "homepage": "https://github.com/codecov/codecov-javascript-bundler-plugins/tree/main/packages/solidstart-plugin",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codecov/codecov-javascript-bundler-plugins.git",
+    "directory": "packages/solidstart-plugin"
+  },
+  "bugs": {
+    "url": "https://github.com/codecov/codecov-javascript-bundler-plugins/issues"
+  },
   "keywords": [
     "Codecov",
     "SolidStart",

--- a/packages/sveltekit-plugin/package.json
+++ b/packages/sveltekit-plugin/package.json
@@ -4,6 +4,15 @@
   "description": "Official Codecov SvelteKit plugin",
   "author": "Codecov",
   "license": "MIT",
+  "homepage": "https://github.com/codecov/codecov-javascript-bundler-plugins/tree/main/packages/sveltekit-plugin",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codecov/codecov-javascript-bundler-plugins.git",
+    "directory": "packages/sveltekit-plugin"
+  },
+  "bugs": {
+    "url": "https://github.com/codecov/codecov-javascript-bundler-plugins/issues"
+  },
   "keywords": [
     "Codecov",
     "SvelteKit",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -4,6 +4,15 @@
   "description": "Official Codecov Vite plugin",
   "author": "Codecov",
   "license": "MIT",
+  "homepage": "https://github.com/codecov/codecov-javascript-bundler-plugins/tree/main/packages/vite-plugin",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codecov/codecov-javascript-bundler-plugins.git",
+    "directory": "packages/vite-plugin"
+  },
+  "bugs": {
+    "url": "https://github.com/codecov/codecov-javascript-bundler-plugins/issues"
+  },
   "keywords": [
     "Codecov",
     "Vite",

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -4,6 +4,15 @@
   "description": "Official Codecov Webpack plugin",
   "author": "Codecov",
   "license": "MIT",
+  "homepage": "https://github.com/codecov/codecov-javascript-bundler-plugins/tree/main/packages/webpack-plugin",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codecov/codecov-javascript-bundler-plugins.git",
+    "directory": "packages/webpack-plugin"
+  },
+  "bugs": {
+    "url": "https://github.com/codecov/codecov-javascript-bundler-plugins/issues"
+  },
   "keywords": [
     "Codecov",
     "Webpack",


### PR DESCRIPTION
# Description

This has been slightly bothering me every time I've had update PRs from Dependabot: because most of the packages didn't include a proper repository or homepage URL, it couldn't figure out the release notes or the diffs.

This PR adds the missing `homepage`, `repository` and `bugs` fields to every `package.json` file in the monorepo.

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
