### PR TITLE
security: bump solid-js to ^1.9.4 in SolidStart apps

### DIFF
--- a/examples/solidstart/package.json
+++ b/examples/solidstart/package.json
@@ -12,7 +12,7 @@
     "@solidjs/meta": "^0.29.4",
     "@solidjs/router": "^0.14.1",
     "@solidjs/start": "^1.0.10",
-    "solid-js": "^1.8.18",
+    "solid-js": "^1.9.4",
     "vinxi": "^0.4.3",
     "vite-plugin-solid": "^2.11.0"
   },

--- a/integration-tests/test-apps/solidstart/package.json
+++ b/integration-tests/test-apps/solidstart/package.json
@@ -11,7 +11,7 @@
     "@solidjs/meta": "^0.29.4",
     "@solidjs/router": "^0.14.1",
     "@solidjs/start": "^1.0.10",
-    "solid-js": "^1.8.18",
+    "solid-js": "^1.9.4",
     "vinxi": "^0.4.3",
     "vite-plugin-solid": "^2.11.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,7 +234,7 @@ importers:
     dependencies:
       nuxt:
         specifier: ^3.16.0
-        version: 3.16.2(@parcel/watcher@2.5.6)(@types/node@20.12.12)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.10.1)(magicast@0.3.5)(rollup@4.60.1)(terser@5.27.0)(typescript@5.7.2)(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))(yaml@2.8.3)
+        version: 3.16.2(@parcel/watcher@2.5.6)(@types/node@20.12.12)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.10.1)(magicast@0.5.2)(rollup@4.60.1)(terser@5.27.0)(typescript@5.7.2)(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))(yaml@2.8.3)
       vue:
         specifier: ^3.5.13
         version: 3.5.13(typescript@5.7.2)
@@ -400,22 +400,22 @@ importers:
         version: link:../../packages/solidstart-plugin
       '@solidjs/meta':
         specifier: ^0.29.4
-        version: 0.29.4(solid-js@1.8.19)
+        version: 0.29.4(solid-js@1.9.12)
       '@solidjs/router':
         specifier: ^0.14.1
-        version: 0.14.1(solid-js@1.8.19)
+        version: 0.14.1(solid-js@1.9.12)
       '@solidjs/start':
         specifier: ^1.0.10
-        version: 1.0.10(solid-js@1.8.19)(vinxi@0.4.3(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0)(typescript@5.7.2))(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
+        version: 1.0.10(solid-js@1.9.12)(vinxi@0.4.3(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0)(typescript@5.7.2))(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
       solid-js:
-        specifier: ^1.8.18
-        version: 1.8.19
+        specifier: ^1.9.4
+        version: 1.9.12
       vinxi:
         specifier: ^0.4.3
         version: 0.4.3(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0)(typescript@5.7.2)
       vite-plugin-solid:
         specifier: ^2.11.0
-        version: 2.11.0(solid-js@1.8.19)(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
+        version: 2.11.0(solid-js@1.9.12)(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
 
   examples/sveltekit:
     devDependencies:
@@ -614,7 +614,7 @@ importers:
         version: 15.2.3(rollup@4.60.1)
       '@solidjs/start':
         specifier: ^1.0.10
-        version: 1.0.10(solid-js@1.8.19)(vinxi@0.5.1(@types/node@20.11.15)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.1)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))(vite@6.3.5(@types/node@20.11.15)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
+        version: 1.0.10(solid-js@1.9.12)(vinxi@0.5.1(@types/node@20.11.15)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.1)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))(vite@6.3.5(@types/node@20.11.15)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
       '@sveltejs/kit':
         specifier: ^2.12.1
         version: 2.12.1(@sveltejs/vite-plugin-svelte@5.0.2(svelte@5.14.1)(vite@6.3.5(@types/node@20.11.15)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3)))(svelte@5.14.1)(vite@6.3.5(@types/node@20.11.15)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
@@ -650,7 +650,7 @@ importers:
         version: 10.9.2(@types/node@20.11.15)(typescript@5.7.2)
       vite-plugin-solid:
         specifier: ^2.11.0
-        version: 2.11.0(solid-js@1.8.19)(vite@6.3.5(@types/node@20.11.15)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
+        version: 2.11.0(solid-js@1.9.12)(vite@6.3.5(@types/node@20.11.15)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
       viteV4:
         specifier: npm:vite@4.5.14
         version: vite@4.5.14(@types/node@20.11.15)(terser@5.27.0)
@@ -870,22 +870,22 @@ importers:
     dependencies:
       '@solidjs/meta':
         specifier: ^0.29.4
-        version: 0.29.4(solid-js@1.8.19)
+        version: 0.29.4(solid-js@1.9.12)
       '@solidjs/router':
         specifier: ^0.14.1
-        version: 0.14.1(solid-js@1.8.19)
+        version: 0.14.1(solid-js@1.9.12)
       '@solidjs/start':
         specifier: ^1.0.10
-        version: 1.0.10(solid-js@1.8.19)(vinxi@0.4.3(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.10.1)(terser@5.27.0)(typescript@5.7.2))(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
+        version: 1.0.10(solid-js@1.9.12)(vinxi@0.4.3(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.10.1)(terser@5.27.0)(typescript@5.7.2))(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
       solid-js:
-        specifier: ^1.8.18
-        version: 1.8.19
+        specifier: ^1.9.4
+        version: 1.9.12
       vinxi:
         specifier: ^0.4.3
         version: 0.4.3(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.10.1)(terser@5.27.0)(typescript@5.7.2)
       vite-plugin-solid:
         specifier: ^2.11.0
-        version: 2.11.0(solid-js@1.8.19)(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
+        version: 2.11.0(solid-js@1.9.12)(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
 
   integration-tests/test-apps/sveltekit:
     devDependencies:
@@ -1282,7 +1282,7 @@ importers:
         version: link:../vite-plugin
       '@solidjs/start':
         specifier: 1.x
-        version: 1.0.10(solid-js@1.8.19)(vinxi@0.5.1(@types/node@20.12.12)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.1)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
+        version: 1.0.10(solid-js@1.9.12)(vinxi@0.5.1(@types/node@20.12.12)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.1)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
       unplugin:
         specifier: ^1.10.1
         version: 1.10.1
@@ -10517,8 +10517,18 @@ packages:
     peerDependencies:
       seroval: ^1.0
 
+  seroval-plugins@1.5.1:
+    resolution: {integrity: sha512-4FbuZ/TMl02sqv0RTFexu0SP6V+ywaIe5bAWCCEik0fk17BhALgwvUDVF7e3Uvf9pxmwCEJsRPmlkUE6HdzLAw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
   seroval@1.1.0:
     resolution: {integrity: sha512-74Wpe+hhPx4V8NFe00I2Fu9gTJopKoH5vE7nCqFzVgKOXV8AnN23T58K79QLYQotzGpH93UZ+UN2Y11j9huZJg==}
+    engines: {node: '>=10'}
+
+  seroval@1.5.1:
+    resolution: {integrity: sha512-OwrZRZAfhHww0WEnKHDY8OM0U/Qs8OTfIDWhUD4BLpNJUfXK4cGmjiagGze086m+mhI+V2nD0gfbHEnJjb9STA==}
     engines: {node: '>=10'}
 
   serve-handler@6.1.5:
@@ -10676,8 +10686,8 @@ packages:
   smob@1.5.0:
     resolution: {integrity: sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig==}
 
-  solid-js@1.8.19:
-    resolution: {integrity: sha512-h8z/TvTQYsf894LM9Iau/ZW2iAKrCzAWDwjPhMcXnonmW1OIIihc28wp82b1wwei1p81fH5+gnfNOe8RzLbDRQ==}
+  solid-js@1.9.12:
+    resolution: {integrity: sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw==}
 
   solid-refresh@0.6.3:
     resolution: {integrity: sha512-F3aPsX6hVw9ttm5LYlth8Q15x6MlI/J3Dn+o3EQyRTtTxidepSTwAYdozt01/YA+7ObcciagGEyXIopGZzQtbA==}
@@ -14487,44 +14497,6 @@ snapshots:
     dependencies:
       which: 3.0.1
 
-  '@nuxt/cli@3.34.0(@nuxt/schema@3.16.2)(cac@6.7.14)(magicast@0.3.5)':
-    dependencies:
-      '@bomb.sh/tab': 0.0.14(cac@6.7.14)(citty@0.2.2)
-      '@clack/prompts': 1.2.0
-      c12: 3.3.4(magicast@0.3.5)
-      citty: 0.2.2
-      confbox: 0.2.4
-      consola: 3.4.2
-      debug: 4.4.3
-      defu: 6.1.6
-      exsolve: 1.0.8
-      fuse.js: 7.2.0
-      fzf: 0.5.2
-      giget: 3.2.0
-      jiti: 2.6.1
-      listhen: 1.9.1
-      nypm: 0.6.5
-      ofetch: 1.5.1
-      ohash: 2.0.11
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      pkg-types: 2.3.0
-      scule: 1.3.0
-      semver: 7.7.4
-      srvx: 0.11.15
-      std-env: 3.10.0
-      tinyclip: 0.1.12
-      tinyexec: 1.0.4
-      ufo: 1.6.3
-      youch: 4.1.1
-    optionalDependencies:
-      '@nuxt/schema': 3.16.2
-    transitivePeerDependencies:
-      - cac
-      - commander
-      - magicast
-      - supports-color
-
   '@nuxt/cli@3.34.0(@nuxt/schema@3.16.2)(cac@6.7.14)(magicast@0.5.2)':
     dependencies:
       '@bomb.sh/tab': 0.0.14(cac@6.7.14)(citty@0.2.2)
@@ -14715,33 +14687,6 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@nuxt/kit@3.16.2(magicast@0.3.5)':
-    dependencies:
-      c12: 3.3.4(magicast@0.3.5)
-      consola: 3.4.2
-      defu: 6.1.6
-      destr: 2.0.5
-      errx: 0.1.0
-      exsolve: 1.0.8
-      globby: 14.1.0
-      ignore: 7.0.5
-      jiti: 2.6.1
-      klona: 2.0.6
-      knitwork: 1.3.0
-      mlly: 1.8.2
-      ohash: 2.0.11
-      pathe: 2.0.3
-      pkg-types: 2.3.0
-      scule: 1.3.0
-      semver: 7.7.4
-      std-env: 3.10.0
-      ufo: 1.6.3
-      unctx: 2.5.0
-      unimport: 4.2.0
-      untyped: 2.0.0
-    transitivePeerDependencies:
-      - magicast
-
   '@nuxt/kit@3.16.2(magicast@0.5.2)':
     dependencies:
       c12: 3.3.4(magicast@0.5.2)
@@ -14827,15 +14772,6 @@ snapshots:
       defu: 6.1.6
       pathe: 2.0.3
       std-env: 3.10.0
-
-  '@nuxt/telemetry@2.8.0(@nuxt/kit@3.16.2(magicast@0.3.5))':
-    dependencies:
-      '@nuxt/kit': 3.16.2(magicast@0.3.5)
-      citty: 0.2.2
-      consola: 3.4.2
-      ofetch: 2.0.0-alpha.3
-      rc9: 3.0.1
-      std-env: 4.0.0
 
   '@nuxt/telemetry@2.8.0(@nuxt/kit@3.16.2(magicast@0.5.2))':
     dependencies:
@@ -14941,67 +14877,6 @@ snapshots:
       vite: 6.3.5(@types/node@20.11.15)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3)
       vite-node: 3.2.4(@types/node@20.11.15)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3)
       vite-plugin-checker: 0.9.3(eslint@8.56.0)(typescript@5.7.2)(vite@6.3.5(@types/node@20.11.15)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
-      vue: 3.5.13(typescript@5.7.2)
-      vue-bundle-renderer: 2.1.1
-    transitivePeerDependencies:
-      - '@biomejs/biome'
-      - '@types/node'
-      - eslint
-      - less
-      - lightningcss
-      - magicast
-      - meow
-      - optionator
-      - rolldown
-      - rollup
-      - sass
-      - sass-embedded
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - vls
-      - vti
-      - vue-tsc
-      - yaml
-
-  '@nuxt/vite-builder@3.16.2(@types/node@20.12.12)(eslint@8.56.0)(magicast@0.3.5)(rollup@4.60.1)(terser@5.27.0)(typescript@5.7.2)(vue@3.5.13(typescript@5.7.2))(yaml@2.8.3)':
-    dependencies:
-      '@nuxt/kit': 3.16.2(magicast@0.3.5)
-      '@rollup/plugin-replace': 6.0.3(rollup@4.60.1)
-      '@vitejs/plugin-vue': 5.2.4(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))(vue@3.5.13(typescript@5.7.2))
-      '@vitejs/plugin-vue-jsx': 4.2.0(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))(vue@3.5.13(typescript@5.7.2))
-      autoprefixer: 10.4.27(postcss@8.5.8)
-      consola: 3.4.2
-      cssnano: 7.0.6(postcss@8.5.8)
-      defu: 6.1.6
-      esbuild: 0.25.3
-      escape-string-regexp: 5.0.0
-      exsolve: 1.0.8
-      externality: 1.0.2
-      get-port-please: 3.2.0
-      h3: 1.15.11
-      jiti: 2.6.1
-      knitwork: 1.3.0
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      mocked-exports: 0.1.1
-      ohash: 2.0.11
-      pathe: 2.0.3
-      perfect-debounce: 1.0.0
-      pkg-types: 2.3.0
-      postcss: 8.5.8
-      rollup-plugin-visualizer: 5.14.0(rollup@4.60.1)
-      std-env: 3.10.0
-      ufo: 1.6.3
-      unenv: 2.0.0-rc.24
-      unplugin: 2.3.11
-      vite: 6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3)
-      vite-node: 3.2.4(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3)
-      vite-plugin-checker: 0.9.3(eslint@8.56.0)(typescript@5.7.2)(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
       vue: 3.5.13(typescript@5.7.2)
       vue-bundle-renderer: 2.1.1
     transitivePeerDependencies:
@@ -16309,15 +16184,15 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@solidjs/meta@0.29.4(solid-js@1.8.19)':
+  '@solidjs/meta@0.29.4(solid-js@1.9.12)':
     dependencies:
-      solid-js: 1.8.19
+      solid-js: 1.9.12
 
-  '@solidjs/router@0.14.1(solid-js@1.8.19)':
+  '@solidjs/router@0.14.1(solid-js@1.9.12)':
     dependencies:
-      solid-js: 1.8.19
+      solid-js: 1.9.12
 
-  '@solidjs/start@1.0.10(solid-js@1.8.19)(vinxi@0.4.3(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.10.1)(terser@5.27.0)(typescript@5.7.2))(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))':
+  '@solidjs/start@1.0.10(solid-js@1.9.12)(vinxi@0.4.3(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.10.1)(terser@5.27.0)(typescript@5.7.2))(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))':
     dependencies:
       '@vinxi/plugin-directives': 0.4.3(vinxi@0.4.3(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.10.1)(terser@5.27.0)(typescript@5.7.2))
       '@vinxi/server-components': 0.4.3(vinxi@0.4.3(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.10.1)(terser@5.27.0)(typescript@5.7.2))
@@ -16330,9 +16205,9 @@ snapshots:
       seroval-plugins: 1.1.0(seroval@1.1.0)
       shikiji: 0.9.19
       source-map-js: 1.2.1
-      terracotta: 1.0.5(solid-js@1.8.19)
+      terracotta: 1.0.5(solid-js@1.9.12)
       tinyglobby: 0.2.10
-      vite-plugin-solid: 2.11.0(solid-js@1.8.19)(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
+      vite-plugin-solid: 2.11.0(solid-js@1.9.12)(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - '@testing-library/jest-dom'
       - solid-js
@@ -16340,7 +16215,7 @@ snapshots:
       - vinxi
       - vite
 
-  '@solidjs/start@1.0.10(solid-js@1.8.19)(vinxi@0.4.3(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0)(typescript@5.7.2))(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))':
+  '@solidjs/start@1.0.10(solid-js@1.9.12)(vinxi@0.4.3(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0)(typescript@5.7.2))(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))':
     dependencies:
       '@vinxi/plugin-directives': 0.4.3(vinxi@0.4.3(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0)(typescript@5.7.2))
       '@vinxi/server-components': 0.4.3(vinxi@0.4.3(@types/node@20.12.12)(encoding@0.1.13)(ioredis@5.4.1)(terser@5.27.0)(typescript@5.7.2))
@@ -16353,9 +16228,9 @@ snapshots:
       seroval-plugins: 1.1.0(seroval@1.1.0)
       shikiji: 0.9.19
       source-map-js: 1.2.1
-      terracotta: 1.0.5(solid-js@1.8.19)
+      terracotta: 1.0.5(solid-js@1.9.12)
       tinyglobby: 0.2.10
-      vite-plugin-solid: 2.11.0(solid-js@1.8.19)(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
+      vite-plugin-solid: 2.11.0(solid-js@1.9.12)(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - '@testing-library/jest-dom'
       - solid-js
@@ -16363,7 +16238,7 @@ snapshots:
       - vinxi
       - vite
 
-  '@solidjs/start@1.0.10(solid-js@1.8.19)(vinxi@0.5.1(@types/node@20.11.15)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.1)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))(vite@6.3.5(@types/node@20.11.15)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))':
+  '@solidjs/start@1.0.10(solid-js@1.9.12)(vinxi@0.5.1(@types/node@20.11.15)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.1)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))(vite@6.3.5(@types/node@20.11.15)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))':
     dependencies:
       '@vinxi/plugin-directives': 0.4.3(vinxi@0.5.1(@types/node@20.11.15)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.1)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
       '@vinxi/server-components': 0.4.3(vinxi@0.5.1(@types/node@20.11.15)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.1)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
@@ -16376,9 +16251,9 @@ snapshots:
       seroval-plugins: 1.1.0(seroval@1.1.0)
       shikiji: 0.9.19
       source-map-js: 1.2.1
-      terracotta: 1.0.5(solid-js@1.8.19)
+      terracotta: 1.0.5(solid-js@1.9.12)
       tinyglobby: 0.2.10
-      vite-plugin-solid: 2.11.0(solid-js@1.8.19)(vite@6.3.5(@types/node@20.11.15)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
+      vite-plugin-solid: 2.11.0(solid-js@1.9.12)(vite@6.3.5(@types/node@20.11.15)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - '@testing-library/jest-dom'
       - solid-js
@@ -16386,7 +16261,7 @@ snapshots:
       - vinxi
       - vite
 
-  '@solidjs/start@1.0.10(solid-js@1.8.19)(vinxi@0.5.1(@types/node@20.12.12)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.1)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))':
+  '@solidjs/start@1.0.10(solid-js@1.9.12)(vinxi@0.5.1(@types/node@20.12.12)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.1)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))':
     dependencies:
       '@vinxi/plugin-directives': 0.4.3(vinxi@0.5.1(@types/node@20.12.12)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.1)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
       '@vinxi/server-components': 0.4.3(vinxi@0.5.1(@types/node@20.12.12)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.1)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
@@ -16399,9 +16274,9 @@ snapshots:
       seroval-plugins: 1.1.0(seroval@1.1.0)
       shikiji: 0.9.19
       source-map-js: 1.2.1
-      terracotta: 1.0.5(solid-js@1.8.19)
+      terracotta: 1.0.5(solid-js@1.9.12)
       tinyglobby: 0.2.10
-      vite-plugin-solid: 2.11.0(solid-js@1.8.19)(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
+      vite-plugin-solid: 2.11.0(solid-js@1.9.12)(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - '@testing-library/jest-dom'
       - solid-js
@@ -23294,130 +23169,6 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@3.16.2(@parcel/watcher@2.5.6)(@types/node@20.12.12)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.10.1)(magicast@0.3.5)(rollup@4.60.1)(terser@5.27.0)(typescript@5.7.2)(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))(yaml@2.8.3):
-    dependencies:
-      '@nuxt/cli': 3.34.0(@nuxt/schema@3.16.2)(cac@6.7.14)(magicast@0.3.5)
-      '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 2.7.0(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))(vue@3.5.13(typescript@5.7.2))
-      '@nuxt/kit': 3.16.2(magicast@0.3.5)
-      '@nuxt/schema': 3.16.2
-      '@nuxt/telemetry': 2.8.0(@nuxt/kit@3.16.2(magicast@0.3.5))
-      '@nuxt/vite-builder': 3.16.2(@types/node@20.12.12)(eslint@8.56.0)(magicast@0.3.5)(rollup@4.60.1)(terser@5.27.0)(typescript@5.7.2)(vue@3.5.13(typescript@5.7.2))(yaml@2.8.3)
-      '@oxc-parser/wasm': 0.60.0
-      '@unhead/vue': 2.1.12(vue@3.5.13(typescript@5.7.2))
-      '@vue/shared': 3.5.32
-      c12: 3.3.4(magicast@0.3.5)
-      chokidar: 4.0.3
-      compatx: 0.1.8
-      consola: 3.4.2
-      cookie-es: 2.0.1
-      defu: 6.1.6
-      destr: 2.0.5
-      devalue: 5.1.1
-      errx: 0.1.0
-      esbuild: 0.25.3
-      escape-string-regexp: 5.0.0
-      estree-walker: 3.0.3
-      exsolve: 1.0.8
-      globby: 14.1.0
-      h3: 1.15.11
-      hookable: 5.5.3
-      ignore: 7.0.5
-      impound: 0.2.2(rollup@4.60.1)
-      jiti: 2.6.1
-      klona: 2.0.6
-      knitwork: 1.3.0
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      mocked-exports: 0.1.1
-      nanotar: 0.2.1
-      nitropack: 2.13.3(encoding@0.1.13)
-      nypm: 0.6.5
-      ofetch: 1.5.1
-      ohash: 2.0.11
-      on-change: 5.0.1
-      oxc-parser: 0.56.5
-      pathe: 2.0.3
-      perfect-debounce: 1.0.0
-      pkg-types: 2.3.0
-      radix3: 1.1.2
-      scule: 1.3.0
-      semver: 7.7.4
-      std-env: 3.10.0
-      strip-literal: 3.1.0
-      tinyglobby: 0.2.12
-      ufo: 1.6.3
-      ultrahtml: 1.6.0
-      uncrypto: 0.1.3
-      unctx: 2.5.0
-      unimport: 4.2.0
-      unplugin: 2.3.11
-      unplugin-vue-router: 0.12.0(vue-router@4.5.0(vue@3.5.13(typescript@5.7.2)))(vue@3.5.13(typescript@5.7.2))
-      unstorage: 1.17.5(db0@0.3.4)(ioredis@5.10.1)
-      untyped: 2.0.0
-      vue: 3.5.13(typescript@5.7.2)
-      vue-bundle-renderer: 2.1.1
-      vue-devtools-stub: 0.1.0
-      vue-router: 4.5.0(vue@3.5.13(typescript@5.7.2))
-    optionalDependencies:
-      '@parcel/watcher': 2.5.6
-      '@types/node': 20.12.12
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@biomejs/biome'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - better-sqlite3
-      - bufferutil
-      - cac
-      - commander
-      - db0
-      - drizzle-orm
-      - encoding
-      - eslint
-      - idb-keyval
-      - ioredis
-      - less
-      - lightningcss
-      - magicast
-      - meow
-      - mysql2
-      - optionator
-      - rolldown
-      - rollup
-      - sass
-      - sass-embedded
-      - sqlite3
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - vite
-      - vls
-      - vti
-      - vue-tsc
-      - xml2js
-      - yaml
-
   nuxt@3.16.2(@parcel/watcher@2.5.6)(@types/node@20.12.12)(cac@6.7.14)(db0@0.3.4)(encoding@0.1.13)(eslint@8.56.0)(ioredis@5.10.1)(magicast@0.5.2)(rollup@4.60.1)(terser@5.27.0)(typescript@5.7.2)(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))(yaml@2.8.3):
     dependencies:
       '@nuxt/cli': 3.34.0(@nuxt/schema@3.16.2)(cac@6.7.14)(magicast@0.5.2)
@@ -25056,7 +24807,13 @@ snapshots:
     dependencies:
       seroval: 1.1.0
 
+  seroval-plugins@1.5.1(seroval@1.5.1):
+    dependencies:
+      seroval: 1.5.1
+
   seroval@1.1.0: {}
+
+  seroval@1.5.1: {}
 
   serve-handler@6.1.5:
     dependencies:
@@ -25285,24 +25042,24 @@ snapshots:
 
   smob@1.5.0: {}
 
-  solid-js@1.8.19:
+  solid-js@1.9.12:
     dependencies:
       csstype: 3.1.3
-      seroval: 1.1.0
-      seroval-plugins: 1.1.0(seroval@1.1.0)
+      seroval: 1.5.1
+      seroval-plugins: 1.5.1(seroval@1.5.1)
 
-  solid-refresh@0.6.3(solid-js@1.8.19):
+  solid-refresh@0.6.3(solid-js@1.9.12):
     dependencies:
       '@babel/generator': 7.26.2
       '@babel/helper-module-imports': 7.25.9
       '@babel/types': 7.26.0
-      solid-js: 1.8.19
+      solid-js: 1.9.12
     transitivePeerDependencies:
       - supports-color
 
-  solid-use@0.8.0(solid-js@1.8.19):
+  solid-use@0.8.0(solid-js@1.9.12):
     dependencies:
-      solid-js: 1.8.19
+      solid-js: 1.9.12
 
   source-map-js@1.2.0: {}
 
@@ -25720,10 +25477,10 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terracotta@1.0.5(solid-js@1.8.19):
+  terracotta@1.0.5(solid-js@1.9.12):
     dependencies:
-      solid-js: 1.8.19
-      solid-use: 0.8.0(solid-js@1.8.19)
+      solid-js: 1.9.12
+      solid-use: 0.8.0(solid-js@1.9.12)
 
   terser-webpack-plugin@5.3.10(webpack@5.96.1):
     dependencies:
@@ -27233,27 +26990,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-solid@2.11.0(solid-js@1.8.19)(vite@6.3.5(@types/node@20.11.15)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3)):
+  vite-plugin-solid@2.11.0(solid-js@1.9.12)(vite@6.3.5(@types/node@20.11.15)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.26.0
       '@types/babel__core': 7.20.5
       babel-preset-solid: 1.8.19(@babel/core@7.26.0)
       merge-anything: 5.1.7
-      solid-js: 1.8.19
-      solid-refresh: 0.6.3(solid-js@1.8.19)
+      solid-js: 1.9.12
+      solid-refresh: 0.6.3(solid-js@1.9.12)
       vite: 6.3.5(@types/node@20.11.15)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3)
       vitefu: 1.0.4(vite@6.3.5(@types/node@20.11.15)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-solid@2.11.0(solid-js@1.8.19)(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3)):
+  vite-plugin-solid@2.11.0(solid-js@1.9.12)(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3)):
     dependencies:
       '@babel/core': 7.26.0
       '@types/babel__core': 7.20.5
       babel-preset-solid: 1.8.19(@babel/core@7.26.0)
       merge-anything: 5.1.7
-      solid-js: 1.8.19
-      solid-refresh: 0.6.3(solid-js@1.8.19)
+      solid-js: 1.9.12
+      solid-refresh: 0.6.3(solid-js@1.9.12)
       vite: 6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3)
       vitefu: 1.0.4(vite@6.3.5(@types/node@20.12.12)(jiti@2.6.1)(terser@5.27.0)(yaml@2.8.3))
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

Sets `solid-js` to **^1.9.4** in `examples/solidstart` and `integration-tests/test-apps/solidstart` for [GHSA-3qxh-p7jc-5xh6](https://github.com/advisories/GHSA-3qxh-p7jc-5xh6) (XSS in JSX fragments).

## Test plan

- [ ] CI passes for this branch.

Made with [Cursor](https://cursor.com)