### PR TITLE
chore(bundler-plugin-core): bump @actions/core and @actions/github

### DIFF
--- a/.changeset/bump-actions-toolkit.md
+++ b/.changeset/bump-actions-toolkit.md
@@ -6,7 +6,7 @@ Bump `@actions/core` to ^3.0.0 and `@actions/github` to ^9.0.0, and set `engines
 
 **@actions/core** ([actions/toolkit `packages/core/RELEASES.md`](https://github.com/actions/toolkit/blob/main/packages/core/RELEASES.md))
 
-- **v3.0.0**: ESM-only release; CommonJS callers must use dynamic `import()` instead of `require()`. `@codecov/bundler-plugin-core` already ships as ESM (`"type": "module"`), so this does not change how the package is consumed from modern bundlers and Node ESM.
+- **v3.0.0**: ESM-only release; apps that `require("@actions/core")` directly must use dynamic `import()`. **`@codecov/bundler-plugin-core` bundles `@actions/core` and `@actions/github` into `dist/index.cjs`**, so `require("@codecov/bundler-plugin-core")` (e.g. Rollup/Webpack CJS configs) keeps working.
 - **v2.x** (between 1.x and 3.x): Node 24 support and `@actions/http-client` upgrades (including 3.x in the 2.x line).
 
 **@actions/github** ([actions/toolkit `packages/github/RELEASES.md`](https://github.com/actions/toolkit/blob/main/packages/github/RELEASES.md))
@@ -18,4 +18,5 @@ Bump `@actions/core` to ^3.0.0 and `@actions/github` to ^9.0.0, and set `engines
 **Impact here**
 
 - Runtime behavior we rely on is unchanged: `context` for GitHub Actions metadata and `getIDToken()` for OIDC uploads are still the supported APIs.
+- **Build**: unbuild inlines `@actions/*` (and their transitive deps) like `@sentry/core`; `failOnWarn: false` suppresses expected “inlined implicit external” noise. Published `dist` is larger (~9 MB CJS) but avoids `ERR_PACKAGE_PATH_NOT_EXPORTED` for CJS consumers.
 - **Node 18** is no longer a supported runtime for this package; use **Node 20+** (aligned with `@actions/github` 8+ and this repo’s Volta pin on Node 20).

--- a/.changeset/bump-actions-toolkit.md
+++ b/.changeset/bump-actions-toolkit.md
@@ -1,0 +1,21 @@
+---
+"@codecov/bundler-plugin-core": major
+---
+
+Bump `@actions/core` to ^3.0.0 and `@actions/github` to ^9.0.0, and set `engines.node` to `>=20.0.0` to match upstream. **Semver major** because supported Node.js drops below 20 (breaking for anyone still on Node 18).
+
+**@actions/core** ([actions/toolkit `packages/core/RELEASES.md`](https://github.com/actions/toolkit/blob/main/packages/core/RELEASES.md))
+
+- **v3.0.0**: ESM-only release; CommonJS callers must use dynamic `import()` instead of `require()`. `@codecov/bundler-plugin-core` already ships as ESM (`"type": "module"`), so this does not change how the package is consumed from modern bundlers and Node ESM.
+- **v2.x** (between 1.x and 3.x): Node 24 support and `@actions/http-client` upgrades (including 3.x in the 2.x line).
+
+**@actions/github** ([actions/toolkit `packages/github/RELEASES.md`](https://github.com/actions/toolkit/blob/main/packages/github/RELEASES.md))
+
+- **v9.0.0**: ESM-only (same consideration as `@actions/core` for this package). Release notes also note improved TypeScript behavior with ESM and `@octokit/core/types`.
+- **v8.0.0**: **Minimum Node.js is now 20** (previously 18); Octokit dependencies move to current major lines (`@octokit/core`, REST plugins, request stack).
+- **v8.0.1**: Dependency updates (`undici`, `@actions/http-client`).
+
+**Impact here**
+
+- Runtime behavior we rely on is unchanged: `context` for GitHub Actions metadata and `getIDToken()` for OIDC uploads are still the supported APIs.
+- **Node 18** is no longer a supported runtime for this package; use **Node 20+** (aligned with `@actions/github` 8+ and this repo’s Volta pin on Node 20).

--- a/packages/bundler-plugin-core/build.config.ts
+++ b/packages/bundler-plugin-core/build.config.ts
@@ -7,6 +7,8 @@ export default defineBuildConfig({
   outDir: "dist",
   declaration: "compatible",
   sourcemap: true,
+  // Inlining @actions/* pulls transitive deps (octokit, undici, …); unbuild warns about each.
+  failOnWarn: false,
   rollup: {
     dts: {
       compilerOptions: {
@@ -29,7 +31,13 @@ export default defineBuildConfig({
         isResolved?: boolean,
       ) => boolean;
       opts.external = (source, importer, isResolved) => {
-        if (source === "@sentry/core") {
+        // Bundle these into dist so CJS consumers never `require()` them.
+        // @actions/* v3+ is ESM-only (no CJS "main"); externalizing breaks Rollup/Webpack CJS configs.
+        if (
+          source === "@sentry/core" ||
+          source === "@actions/core" ||
+          source === "@actions/github"
+        ) {
           return false;
         }
         return isExternal(source, importer, isResolved);

--- a/packages/bundler-plugin-core/package.json
+++ b/packages/bundler-plugin-core/package.json
@@ -39,8 +39,8 @@
     "generate:typedoc": "typedoc --options ./typedoc.json"
   },
   "dependencies": {
-    "@actions/core": "^1.10.1",
-    "@actions/github": "^6.0.0",
+    "@actions/core": "^3.0.0",
+    "@actions/github": "^9.0.0",
     "chalk": "4.1.2",
     "semver": "^7.5.4",
     "unplugin": "^1.10.1",
@@ -66,6 +66,6 @@
     "extends": "../../package.json"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   }
 }

--- a/packages/bundler-plugin-core/src/utils/providers/__tests__/GitHubActions.test.ts
+++ b/packages/bundler-plugin-core/src/utils/providers/__tests__/GitHubActions.test.ts
@@ -1,4 +1,3 @@
-import * as GitHub from "@actions/github";
 import { HttpResponse, http } from "msw";
 import { setupServer } from "msw/node";
 import { createEmptyArgs } from "../../../../test-utils/helpers.ts";
@@ -26,10 +25,25 @@ const mocks = vi.hoisted(() => ({
   headLabel: vi.fn().mockReturnValue(""),
 }));
 
+/** Holds overrides; @actions/github v9+ exports `context` as read-only in ESM. */
+const mockGitHubContext = vi.hoisted(() => ({
+  override: undefined as
+    | undefined
+    | {
+        eventName: string;
+        payload: Record<string, unknown>;
+      },
+}));
+
 vi.mock("@actions/github", async (importOriginal) => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-imports
   const original = await importOriginal<typeof import("@actions/github")>();
-  return original;
+  return {
+    ...original,
+    get context() {
+      return mockGitHubContext.override ?? original.context;
+    },
+  };
 });
 
 beforeAll(() => {
@@ -38,6 +52,7 @@ beforeAll(() => {
 
 afterEach(() => {
   server.resetHandlers();
+  mockGitHubContext.override = undefined;
   vi.resetAllMocks();
 });
 
@@ -67,10 +82,9 @@ describe("GitHub Actions Params", () => {
     // TODO: verify that empty string belongs here, from a glance it seems PushEvent does not
     // include a pull_request key
     if (["pull_request", "pull_request_target", ""].includes(eventName)) {
-      vi.mocked(GitHub).context = {
+      mockGitHubContext.override = {
         eventName,
         payload: {
-          // @ts-expect-error - forcing the payload to be a PullRequestEvent
           pull_request: {
             head: {
               sha: "test-head-sha",
@@ -84,8 +98,7 @@ describe("GitHub Actions Params", () => {
         },
       };
     } else if (eventName === "merge_group") {
-      // @ts-expect-error - forcing the payload to be a MergeGroupEvent
-      vi.mocked(GitHub).context = {
+      mockGitHubContext.override = {
         eventName,
         payload: {
           merge_group: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1015,11 +1015,11 @@ importers:
   packages/bundler-plugin-core:
     dependencies:
       '@actions/core':
-        specifier: ^1.10.1
-        version: 1.10.1
+        specifier: ^3.0.0
+        version: 3.0.0
       '@actions/github':
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: ^9.0.0
+        version: 9.0.0
       chalk:
         specifier: 4.1.2
         version: 4.1.2
@@ -1474,11 +1474,29 @@ packages:
   '@actions/core@1.10.1':
     resolution: {integrity: sha512-3lBR9EDAY+iYIpTnTIXmWcNbX3T2kCkAEQGIQx4NVQ0575nk2k3GRZDTPQG+vVtS2izSLmINlxXf0uLtnrTP+g==}
 
+  '@actions/core@3.0.0':
+    resolution: {integrity: sha512-zYt6cz+ivnTmiT/ksRVriMBOiuoUpDCJJlZ5KPl2/FRdvwU3f7MPh9qftvbkXJThragzUZieit2nyHUyw53Seg==}
+
+  '@actions/exec@3.0.0':
+    resolution: {integrity: sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==}
+
   '@actions/github@6.0.0':
     resolution: {integrity: sha512-alScpSVnYmjNEXboZjarjukQEzgCRmjMv6Xj47fsdnqGS73bjJNDpiiXmp8jr0UZLdUB6d9jW63IcmddUP+l0g==}
 
+  '@actions/github@9.0.0':
+    resolution: {integrity: sha512-yJ0RoswsAaKcvkmpCE4XxBRiy/whH2SdTBHWzs0gi4wkqTDhXMChjSdqBz/F4AeiDlP28rQqL33iHb+kjAMX6w==}
+
   '@actions/http-client@2.2.1':
     resolution: {integrity: sha512-KhC/cZsq7f8I4LfZSJKgCvEwfkE8o1538VoBeoGzokVLLnbFDEAdFD3UhoMklxo2un9NJVBdANOresx7vTHlHw==}
+
+  '@actions/http-client@3.0.2':
+    resolution: {integrity: sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==}
+
+  '@actions/http-client@4.0.0':
+    resolution: {integrity: sha512-QuwPsgVMsD6qaPD57GLZi9sqzAZCtiJT8kVBCDpLtxhL5MydQ4gS+DrejtZZPdIYyB1e95uCK9Luyds7ybHI3g==}
+
+  '@actions/io@3.0.2':
+    resolution: {integrity: sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -3693,9 +3711,21 @@ packages:
     resolution: {integrity: sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==}
     engines: {node: '>= 18'}
 
+  '@octokit/auth-token@6.0.0':
+    resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
+    engines: {node: '>= 20'}
+
   '@octokit/core@5.2.0':
     resolution: {integrity: sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==}
     engines: {node: '>= 18'}
+
+  '@octokit/core@7.0.6':
+    resolution: {integrity: sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==}
+    engines: {node: '>= 20'}
+
+  '@octokit/endpoint@11.0.3':
+    resolution: {integrity: sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==}
+    engines: {node: '>= 20'}
 
   '@octokit/endpoint@9.0.5':
     resolution: {integrity: sha512-ekqR4/+PCLkEBF6qgj8WqJfvDq65RH85OAgrtnVp1mSxaXF03u2xW/hUdweGS5654IlC0wkNYC18Z50tSYTAFw==}
@@ -3705,11 +3735,24 @@ packages:
     resolution: {integrity: sha512-r+oZUH7aMFui1ypZnAvZmn0KSqAUgE1/tUXIWaqUCa1758ts/Jio84GZuzsvUkme98kv0WFY8//n0J1Z+vsIsQ==}
     engines: {node: '>= 18'}
 
+  '@octokit/graphql@9.0.3':
+    resolution: {integrity: sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==}
+    engines: {node: '>= 20'}
+
   '@octokit/openapi-types@20.0.0':
     resolution: {integrity: sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==}
 
   '@octokit/openapi-types@22.2.0':
     resolution: {integrity: sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==}
+
+  '@octokit/openapi-types@27.0.0':
+    resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
+
+  '@octokit/plugin-paginate-rest@14.0.0':
+    resolution: {integrity: sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
 
   '@octokit/plugin-paginate-rest@9.2.1':
     resolution: {integrity: sha512-wfGhE/TAkXZRLjksFXuDZdmGnJQHvtU/joFQdweXUgzo1XwvBCD4o4+75NtFfjfLK5IwLf9vHTfSiU3sLRYpRw==}
@@ -3723,9 +3766,23 @@ packages:
     peerDependencies:
       '@octokit/core': '5'
 
+  '@octokit/plugin-rest-endpoint-methods@17.0.0':
+    resolution: {integrity: sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
   '@octokit/request-error@5.1.0':
     resolution: {integrity: sha512-GETXfE05J0+7H2STzekpKObFe765O5dlAKUTLNGeH+x47z7JjXHfsHKo5z21D/o/IOZTUEI6nyWyR+bZVP/n5Q==}
     engines: {node: '>= 18'}
+
+  '@octokit/request-error@7.1.0':
+    resolution: {integrity: sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/request@10.0.8':
+    resolution: {integrity: sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==}
+    engines: {node: '>= 20'}
 
   '@octokit/request@8.4.0':
     resolution: {integrity: sha512-9Bb014e+m2TgBeEJGEbdplMVWwPmL1FPtggHQRkV+WVsMggPtEkLKPlcVYm/o8xKLkpJ7B+6N8WfQMtDLX2Dpw==}
@@ -3736,6 +3793,9 @@ packages:
 
   '@octokit/types@13.5.0':
     resolution: {integrity: sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==}
+
+  '@octokit/types@16.0.0':
+    resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
   '@octokit/webhooks-types@7.6.1':
     resolution: {integrity: sha512-S8u2cJzklBC0FgTwWVLaM8tMrDuDMVE4xiTK4EYXM9GntyvrdbSoxqDQa+Fh57CCNApyIpyeqPhhFEmHPfrXgw==}
@@ -5796,6 +5856,9 @@ packages:
   before-after-hook@2.2.3:
     resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
 
+  before-after-hook@4.0.0:
+    resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
@@ -7185,6 +7248,9 @@ packages:
   externality@1.0.2:
     resolution: {integrity: sha512-LyExtJWKxtgVzmgtEHyQtLFpw1KFhQphF9nTG8TpAIVkiI/xQ3FJh75tRFLYl4hkn7BNIIdLJInuDAavX35pMw==}
 
+  fast-content-type-parse@3.0.0:
+    resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -8240,6 +8306,9 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json-with-bigint@3.5.8:
+    resolution: {integrity: sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==}
 
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
@@ -11483,6 +11552,9 @@ packages:
   universal-user-agent@6.0.1:
     resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==}
 
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
+
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
@@ -12515,6 +12587,15 @@ snapshots:
       '@actions/http-client': 2.2.1
       uuid: 8.3.2
 
+  '@actions/core@3.0.0':
+    dependencies:
+      '@actions/exec': 3.0.0
+      '@actions/http-client': 4.0.0
+
+  '@actions/exec@3.0.0':
+    dependencies:
+      '@actions/io': 3.0.2
+
   '@actions/github@6.0.0':
     dependencies:
       '@actions/http-client': 2.2.1
@@ -12522,10 +12603,32 @@ snapshots:
       '@octokit/plugin-paginate-rest': 9.2.1(@octokit/core@5.2.0)
       '@octokit/plugin-rest-endpoint-methods': 10.4.1(@octokit/core@5.2.0)
 
+  '@actions/github@9.0.0':
+    dependencies:
+      '@actions/http-client': 3.0.2
+      '@octokit/core': 7.0.6
+      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)
+      '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
+      '@octokit/request': 10.0.8
+      '@octokit/request-error': 7.1.0
+      undici: 6.24.1
+
   '@actions/http-client@2.2.1':
     dependencies:
       tunnel: 0.0.6
       undici: 5.28.4
+
+  '@actions/http-client@3.0.2':
+    dependencies:
+      tunnel: 0.0.6
+      undici: 6.24.1
+
+  '@actions/http-client@4.0.0':
+    dependencies:
+      tunnel: 0.0.6
+      undici: 6.24.1
+
+  '@actions/io@3.0.2': {}
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -14962,6 +15065,8 @@ snapshots:
 
   '@octokit/auth-token@4.0.0': {}
 
+  '@octokit/auth-token@6.0.0': {}
+
   '@octokit/core@5.2.0':
     dependencies:
       '@octokit/auth-token': 4.0.0
@@ -14971,6 +15076,21 @@ snapshots:
       '@octokit/types': 13.5.0
       before-after-hook: 2.2.3
       universal-user-agent: 6.0.1
+
+  '@octokit/core@7.0.6':
+    dependencies:
+      '@octokit/auth-token': 6.0.0
+      '@octokit/graphql': 9.0.3
+      '@octokit/request': 10.0.8
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      before-after-hook: 4.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/endpoint@11.0.3':
+    dependencies:
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
 
   '@octokit/endpoint@9.0.5':
     dependencies:
@@ -14983,9 +15103,22 @@ snapshots:
       '@octokit/types': 13.5.0
       universal-user-agent: 6.0.1
 
+  '@octokit/graphql@9.0.3':
+    dependencies:
+      '@octokit/request': 10.0.8
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
   '@octokit/openapi-types@20.0.0': {}
 
   '@octokit/openapi-types@22.2.0': {}
+
+  '@octokit/openapi-types@27.0.0': {}
+
+  '@octokit/plugin-paginate-rest@14.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
 
   '@octokit/plugin-paginate-rest@9.2.1(@octokit/core@5.2.0)':
     dependencies:
@@ -14997,11 +15130,29 @@ snapshots:
       '@octokit/core': 5.2.0
       '@octokit/types': 12.6.0
 
+  '@octokit/plugin-rest-endpoint-methods@17.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
+
   '@octokit/request-error@5.1.0':
     dependencies:
       '@octokit/types': 13.5.0
       deprecation: 2.3.1
       once: 1.4.0
+
+  '@octokit/request-error@7.1.0':
+    dependencies:
+      '@octokit/types': 16.0.0
+
+  '@octokit/request@10.0.8':
+    dependencies:
+      '@octokit/endpoint': 11.0.3
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      fast-content-type-parse: 3.0.0
+      json-with-bigint: 3.5.8
+      universal-user-agent: 7.0.3
 
   '@octokit/request@8.4.0':
     dependencies:
@@ -15017,6 +15168,10 @@ snapshots:
   '@octokit/types@13.5.0':
     dependencies:
       '@octokit/openapi-types': 22.2.0
+
+  '@octokit/types@16.0.0':
+    dependencies:
+      '@octokit/openapi-types': 27.0.0
 
   '@octokit/webhooks-types@7.6.1': {}
 
@@ -18310,6 +18465,8 @@ snapshots:
 
   before-after-hook@2.2.3: {}
 
+  before-after-hook@4.0.0: {}
+
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
@@ -20090,6 +20247,8 @@ snapshots:
       pathe: 1.1.2
       ufo: 1.6.3
 
+  fast-content-type-parse@3.0.0: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
@@ -21214,6 +21373,8 @@ snapshots:
   json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json-with-bigint@3.5.8: {}
 
   json5@1.0.2:
     dependencies:
@@ -26142,6 +26303,8 @@ snapshots:
       unist-util-visit-parents: 6.0.1
 
   universal-user-agent@6.0.1: {}
+
+  universal-user-agent@7.0.3: {}
 
   universalify@0.1.2: {}
 


### PR DESCRIPTION
## Summary

Bump `@actions/core` to ^3.0.0 and `@actions/github` to ^9.0.0 in `@codecov/bundler-plugin-core`, and set `engines.node` to `>=20.0.0` to match upstream. **Semver major** because supported Node.js drops below 20 (breaking for anyone still on Node 18).

## Notes (from actions/toolkit release notes)

**[@actions/core](https://github.com/actions/toolkit/blob/main/packages/core/RELEASES.md)**

- **v3.0.0**: ESM-only; CommonJS callers must use dynamic `import()` instead of `require()`. This package already ships as ESM (`"type": "module"`), so consumption from modern bundlers and Node ESM is unchanged.
- **v2.x** (between 1.x and 3.x): Node 24 support and `@actions/http-client` upgrades (including 3.x in the 2.x line).

**[@actions/github](https://github.com/actions/toolkit/blob/main/packages/github/RELEASES.md)**

- **v9.0.0**: ESM-only (same consideration as `@actions/core` for this package). Release notes also mention improved TypeScript behavior with ESM and `@octokit/core/types`.
- **v8.0.0**: **Minimum Node.js is now 20** (previously 18); Octokit dependencies move to current major lines (`@octokit/core`, REST plugins, request stack).
- **v8.0.1**: Dependency updates (`undici`, `@actions/http-client`).

## Impact

- Runtime usage in this repo is unchanged: `context` for GitHub Actions metadata and `getIDToken()` for OIDC uploads remain the supported APIs.
- **Node 18** is no longer a supported runtime for this package; use **Node 20+** (aligned with `@actions/github` 8+ and this repo’s Volta pin on Node 20).

## Other changes

- **Tests**: `GitHubActions` unit tests no longer assign to `GitHub.context` (ESM export is read-only); they use a hoisted override and a getter in the Vitest mock.
- **Changeset**: **major** bump for `@codecov/bundler-plugin-core` (Node engine floor and dependency majors).
