### PR TITLE
fix: add permissions to publish step

### DIFF
--- a/.github/workflows/prepare-publish.yml
+++ b/.github/workflows/prepare-publish.yml
@@ -4,7 +4,10 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
+  id-token: write
+  issues: read
+  packages: write
   pull-requests: write
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
# Description

# Code Example

# Notable Changes

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
