### PR TITLE
fix(package-metadata): include repository details in `package.json` for the rollup plugin

### DIFF
--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -29,6 +29,11 @@
   "files": [
     "dist"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codecov/codecov-javascript-bundler-plugins.git",
+    "directory": "packages/rollup-plugin"
+  },
   "scripts": {
     "type-check": "tsc --noEmit",
     "build": "unbuild",


### PR DESCRIPTION
# Description

the missing metadata prevents the package page on npmjs.com from linking to the repo and prevents renovate from finding the release notes for the package. i'm only updating the rollup plugin in this PR because that is the package i consume, but this could be used as a reference for similar updates to the other packages

# Code Example

# Notable Changes

<!--
  Sentry/Codecov employees and contractors can delete or ignore the following.
-->

# Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
