### PR TITLE
feat: Add more observability to getPreSignedUrl errors and prevent retries f…

### DIFF
--- a/integration-tests/fixtures/generate-bundle-stats/astro/astro-base.config.mjs
+++ b/integration-tests/fixtures/generate-bundle-stats/astro/astro-base.config.mjs
@@ -16,8 +16,8 @@ export default defineConfig({
     rollupOptions: {
       output: {
         format: "esm",
-      }
-    }
+      },
+    },
   },
   integrations: [
     react(),

--- a/integration-tests/test-api/tsconfig.json
+++ b/integration-tests/test-api/tsconfig.json
@@ -2,6 +2,6 @@
   "compilerOptions": {
     "strict": true,
     "jsx": "react-jsx",
-    "jsxImportSource": "hono/jsx"
-  }
+    "jsxImportSource": "hono/jsx",
+  },
 }

--- a/packages/bundler-plugin-core/src/errors/AuthenticationError.ts
+++ b/packages/bundler-plugin-core/src/errors/AuthenticationError.ts
@@ -1,0 +1,5 @@
+export class AuthenticationError extends Error {
+  constructor(msg: string, options?: ErrorOptions) {
+    super(msg, options);
+  }
+}

--- a/packages/bundler-plugin-core/src/utils/Output.ts
+++ b/packages/bundler-plugin-core/src/utils/Output.ts
@@ -1,4 +1,4 @@
-import { type Client, type Scope, startSpan } from "@sentry/core";
+import { type Client, type Scope, startSpan, type Span } from "@sentry/core";
 import {
   type Asset,
   type Chunk,
@@ -8,6 +8,7 @@ import {
   type ProviderUtilInputs,
   type UploadOverrides,
 } from "../types.ts";
+import { AuthenticationError } from "../errors/AuthenticationError.ts";
 import { getPreSignedURL } from "./getPreSignedURL.ts";
 import { type NormalizedOptions } from "./normalizeOptions.ts";
 import { detectProvider } from "./provider.ts";
@@ -249,7 +250,7 @@ class Output {
               scope: this.sentryScope,
               parentSpan: outputWriteSpan,
             },
-            async (getPreSignedURLSpan) => {
+            async (getPreSignedURLSpan: Span | undefined) => {
               let url = "";
               try {
                 url = await getPreSignedURL({
@@ -264,19 +265,23 @@ class Output {
                 });
               } catch (error) {
                 if (this.sentryClient && this.sentryScope) {
-                  this.sentryScope.addBreadcrumb({
-                    category: "output.write.getPreSignedURL",
-                    level: "error",
-                    data: { error },
-                  });
-                  // only setting this as info because this could be caused by user error
-                  this.sentryClient.captureMessage(
-                    "Error in getPreSignedURL",
-                    "info",
-                    undefined,
-                    this.sentryScope,
-                  );
-                  await safeFlushTelemetry(this.sentryClient);
+                  // if the user gets an authentication error, something is wrong with their setup
+                  // so we don't want to log it to sentry
+                  if (!(error instanceof AuthenticationError)) {
+                    this.sentryScope.addBreadcrumb({
+                      category: "output.write.getPreSignedURL",
+                      level: "error",
+                      data: { error },
+                    });
+                    // only setting this as info because this could be caused by user error
+                    this.sentryClient.captureMessage(
+                      "Error in getPreSignedURL",
+                      "info",
+                      undefined,
+                      this.sentryScope,
+                    );
+                    await safeFlushTelemetry(this.sentryClient);
+                  }
                 }
 
                 if (emitError) {

--- a/packages/bundler-plugin-core/src/utils/__tests__/fetchWithRetry.test.ts
+++ b/packages/bundler-plugin-core/src/utils/__tests__/fetchWithRetry.test.ts
@@ -35,6 +35,7 @@ interface SetupArgs {
   retryCount?: number;
   sendError?: boolean;
   failFetch?: boolean;
+  retryFailureStatus?: number;
 }
 
 describe("fetchWithRetry", () => {
@@ -50,6 +51,7 @@ describe("fetchWithRetry", () => {
     sendError = false,
     failFetch = false,
     retryCount = 0,
+    retryFailureStatus = 503,
   }: SetupArgs) {
     consoleSpy = vi.spyOn(console, "log").mockImplementation(() => null);
 
@@ -64,7 +66,9 @@ describe("fetchWithRetry", () => {
         }
 
         retryCount -= 1;
-        return new HttpResponse("not found", { status: 404 });
+        return new HttpResponse("service unavailable", {
+          status: retryFailureStatus,
+        });
       }),
     );
   }
@@ -92,6 +96,7 @@ describe("fetchWithRetry", () => {
       setup({
         data: { url: "http://example.com" },
         retryCount: 2,
+        retryFailureStatus: 503,
       });
 
       const urlPromise = await fetchWithRetry({
@@ -105,12 +110,43 @@ describe("fetchWithRetry", () => {
     });
   });
 
+  describe("when the initial response is a 4xx error", () => {
+    it("returns the response without retrying", async () => {
+      let requestCount = 0;
+      consoleSpy = vi.spyOn(console, "log").mockImplementation(() => null);
+
+      server.use(
+        http.all("http://localhost", () => {
+          requestCount += 1;
+          return HttpResponse.json(
+            { message: "Bad Request", detail: "example error body" },
+            { status: 400 },
+          );
+        }),
+      );
+
+      const response = await fetchWithRetry({
+        url: "http://localhost",
+        requestData: {},
+        retryCount: 5,
+      });
+
+      expect(requestCount).toBe(1);
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        message: "Bad Request",
+        detail: "example error body",
+      });
+    });
+  });
+
   describe("retry count exceeds limit", () => {
     it("returns the response", async () => {
       setup({
         data: { url: "http://example.com" },
         retryCount: 2,
         failFetch: true,
+        retryFailureStatus: 503,
       });
 
       const response = await fetchWithRetry({
@@ -119,7 +155,7 @@ describe("fetchWithRetry", () => {
         retryCount: 1,
       });
 
-      expect(response.status).toBe(404);
+      expect(response.status).toBe(503);
     });
   });
 

--- a/packages/bundler-plugin-core/src/utils/__tests__/getPreSignedURL.test.ts
+++ b/packages/bundler-plugin-core/src/utils/__tests__/getPreSignedURL.test.ts
@@ -302,30 +302,85 @@ describe("getPreSignedURL", () => {
     });
 
     describe('http response is not "ok"', () => {
-      it("throws an error", async () => {
-        const { consoleSpy } = setup({
-          data: { url: "http://example.com" },
-          status: 400,
+      describe("4xx error", () => {
+        it("throws an error", async () => {
+          let requestCount = 0;
+          const consoleSpy = vi
+            .spyOn(console, "log")
+            .mockImplementation(() => null);
+
+          server.use(
+            http.post(
+              "http://localhost/upload/bundle_analysis/v1",
+              async ({ request }) => {
+                requestCount += 1;
+                const requestBody = await request.json();
+                requestBodyMock(requestBody);
+
+                if (request.headers.get("Authorization")) {
+                  requestTokenMock(request.headers.get("Authorization"));
+                }
+
+                return HttpResponse.json(
+                  { detail: "Bad Request" },
+                  { status: 400 },
+                );
+              },
+            ),
+          );
+
+          let error;
+          try {
+            await getPreSignedURL({
+              apiUrl: "http://localhost",
+              uploadToken: "cool-upload-token",
+              retryCount: 3,
+              serviceParams: {
+                commit: "123",
+              },
+            });
+          } catch (e) {
+            error = e;
+          }
+
+          expect(requestCount).toBe(1);
+          expect(error).toBeInstanceOf(FailedFetchError);
+          expect(consoleSpy).toHaveBeenCalledWith(
+            `[codecov] ${Chalk.red(
+              "Failed to get pre-signed URL, bad response: Bad Request",
+            )}`,
+          );
         });
+      });
 
-        let error;
-        try {
-          await getPreSignedURL({
-            apiUrl: "http://localhost",
-            uploadToken: "cool-upload-token",
-            retryCount: 0,
-            serviceParams: {
-              commit: "123",
-            },
+      describe("non-4xx error", () => {
+        it("throws an error", async () => {
+          const { consoleSpy } = setup({
+            data: { url: "http://example.com" },
+            status: 503,
           });
-        } catch (e) {
-          error = e;
-        }
 
-        expect(error).toBeInstanceOf(FailedFetchError);
-        expect(consoleSpy).toHaveBeenCalledWith(
-          `[codecov] ${Chalk.red('Failed to get pre-signed URL, bad response: "400 - Bad Request"')}`,
-        );
+          let error;
+          try {
+            await getPreSignedURL({
+              apiUrl: "http://localhost",
+              uploadToken: "cool-upload-token",
+              retryCount: 0,
+              serviceParams: {
+                commit: "123",
+              },
+            });
+          } catch (e) {
+            error = e;
+          }
+
+          expect(error).toBeInstanceOf(FailedFetchError);
+          expect(consoleSpy).toHaveBeenCalledWith(
+            `[codecov] ${Chalk.red(
+              "Failed to get pre-signed URL (server), bad response: 503 - Service Unavailable",
+            )}`,
+          );
+        });
       });
     });
 

--- a/packages/bundler-plugin-core/src/utils/fetchWithRetry.ts
+++ b/packages/bundler-plugin-core/src/utils/fetchWithRetry.ts
@@ -26,6 +26,11 @@ export const fetchWithRetry = async ({
       response = await fetch(url, requestData);
 
       if (!response.ok) {
+        // 4xx errors are permanent client errors - no need to retry
+        if (response.status >= 400 && response.status < 500) {
+          debug(`${name} received ${response.status} client error, not retrying`);
+          return response;
+        }
         throw new BadResponseError("Response not ok");
       }
       break;

--- a/packages/bundler-plugin-core/src/utils/fetchWithRetry.ts
+++ b/packages/bundler-plugin-core/src/utils/fetchWithRetry.ts
@@ -28,7 +28,9 @@ export const fetchWithRetry = async ({
       if (!response.ok) {
         // 4xx errors are permanent client errors - no need to retry
         if (response.status >= 400 && response.status < 500) {
-          debug(`${name} received ${response.status} client error, not retrying`);
+          debug(
+            `${name} received ${response.status} client error, not retrying`,
+          );
           return response;
         }
         throw new BadResponseError("Response not ok");

--- a/packages/bundler-plugin-core/src/utils/getPreSignedURL.ts
+++ b/packages/bundler-plugin-core/src/utils/getPreSignedURL.ts
@@ -7,6 +7,7 @@ import {
   type Span,
 } from "@sentry/core";
 import { z } from "zod";
+import { AuthenticationError } from "../errors/AuthenticationError.ts";
 import { FailedFetchError } from "../errors/FailedFetchError.ts";
 import { UploadLimitReachedError } from "../errors/UploadLimitReachedError.ts";
 import { type ProviderServiceParams } from "../types.ts";
@@ -119,7 +120,7 @@ export const getPreSignedURL = async ({
         scope: sentryScope,
         parentSpan: sentrySpan,
       },
-      async (getPreSignedURLSpan) => {
+      async (getPreSignedURLSpan: Span | undefined) => {
         let wrappedResponse: Response;
         const HTTP_METHOD = "POST";
         const URL = `${apiUrl}${API_ENDPOINT}`;
@@ -182,11 +183,41 @@ export const getPreSignedURL = async ({
     throw new UploadLimitReachedError("Upload limit reached");
   }
 
-  if (!response.ok) {
+  if (response.status >= 400 && response.status < 500) {
+    // Attempt to parse a server-provided error message to give users actionable feedback
+    let serverMessage = "";
+    try {
+      const errorBody = await response.clone().json();
+      serverMessage = errorBody?.message ?? "";
+    } catch {
+      // ignore parse failures
+    }
+    const responseStatusWithText = `${response.status} - ${response.statusText}`;
+    const msgDetail = serverMessage ?? responseStatusWithText;
     red(
-      `Failed to get pre-signed URL, bad response: "${response.status} - ${response.statusText}"`,
+      `Failed to get presigned URL, bad response: ${msgDetail}`,
     );
-    throw new FailedFetchError("Failed to get pre-signed URL");
+    if (
+      serverMessage.toLowerCase().includes("token") ||
+      response.status === 401 ||
+      response.status === 403
+    ) {
+      red(
+        "Set uploadToken in your Codecov plugin config or enable tokenless uploads for your public repository.",
+      );
+      throw new AuthenticationError(
+        serverMessage || `Authentication failed: ${responseStatusWithText}`,
+      );
+    }
+    throw new FailedFetchError(
+      `Failed to get presigned URL (client), bad response: ${responseStatusWithText}`,
+    );
+  }
+  
+  if (!response.ok) {
+    const msg = `Failed to get presigned URL (server), bad response: ${response.status} - ${response.statusText}`;
+    red(msg);
+    throw new FailedFetchError(msg);
   }
 
   let data;

--- a/packages/bundler-plugin-core/src/utils/getPreSignedURL.ts
+++ b/packages/bundler-plugin-core/src/utils/getPreSignedURL.ts
@@ -40,6 +40,10 @@ const PreSignedURLSchema = z.object({
   url: z.string(),
 });
 
+const ApiErrorBodySchema = z.object({
+  detail: z.string().optional(),
+});
+
 const API_ENDPOINT = "/upload/bundle_analysis/v1";
 
 export const getPreSignedURL = async ({
@@ -187,14 +191,15 @@ export const getPreSignedURL = async ({
     // Attempt to parse a server-provided error message to give users actionable feedback
     let serverMessage = "";
     try {
-      const errorBody = await response.clone().json();
-      serverMessage = errorBody?.message ?? "";
+      const raw: unknown = await response.clone().json();
+      const parsed = ApiErrorBodySchema.safeParse(raw);
+      serverMessage = parsed.success ? parsed.data.detail ?? "" : "";
     } catch {
       // ignore parse failures
     }
     const responseStatusWithText = `${response.status} - ${response.statusText}`;
-    const msgDetail = serverMessage ?? responseStatusWithText;
-    red(`Failed to get presigned URL, bad response: ${msgDetail}`);
+    const msgDetail = serverMessage || responseStatusWithText;
+    red(`Failed to get pre-signed URL, bad response: ${msgDetail}`);
     if (
       serverMessage.toLowerCase().includes("token") ||
       response.status === 401 ||
@@ -208,12 +213,12 @@ export const getPreSignedURL = async ({
       );
     }
     throw new FailedFetchError(
-      `Failed to get presigned URL (client), bad response: ${responseStatusWithText}`,
+      `Failed to get pre-signed URL (client), bad response: ${responseStatusWithText}`,
     );
   }
 
   if (!response.ok) {
-    const msg = `Failed to get presigned URL (server), bad response: ${response.status} - ${response.statusText}`;
+    const msg = `Failed to get pre-signed URL (server), bad response: ${response.status} - ${response.statusText}`;
     red(msg);
     throw new FailedFetchError(msg);
   }

--- a/packages/bundler-plugin-core/src/utils/getPreSignedURL.ts
+++ b/packages/bundler-plugin-core/src/utils/getPreSignedURL.ts
@@ -194,9 +194,7 @@ export const getPreSignedURL = async ({
     }
     const responseStatusWithText = `${response.status} - ${response.statusText}`;
     const msgDetail = serverMessage ?? responseStatusWithText;
-    red(
-      `Failed to get presigned URL, bad response: ${msgDetail}`,
-    );
+    red(`Failed to get presigned URL, bad response: ${msgDetail}`);
     if (
       serverMessage.toLowerCase().includes("token") ||
       response.status === 401 ||
@@ -213,7 +211,7 @@ export const getPreSignedURL = async ({
       `Failed to get presigned URL (client), bad response: ${responseStatusWithText}`,
     );
   }
-  
+
   if (!response.ok) {
     const msg = `Failed to get presigned URL (server), bad response: ${response.status} - ${response.statusText}`;
     red(msg);


### PR DESCRIPTION
…or client auth errors

Related to https://github.com/codecov/core-engineering/issues/96

According to the Sentry instances of this issue, there are instances of both "tokenless" and "token", "vite" vs "webpack", with and w/o git_service set, and across versions. The error is logged as the response for `getPresignedUrl` request which returns with `ok === False` as the server is returning a 4xx status codes.

- I've added code to pull out body messaging from the 4xx server responses to hopefully give more information into why these requests are erroring on the server
- Added code to prevent retrying the request multiple times if the response is 4xx response as this will have the same result each time
- Not logging to Sentry for 401/403 for authentication errors as the problem is in user's setup
- Ran prettier command which formatted a couple of unrelated files