### PR TITLE
chore: Update changelog

### DIFF
--- a/.changeset/nasty-singers-cross.md
+++ b/.changeset/nasty-singers-cross.md
@@ -1,0 +1,15 @@
+---
+"@codecov/bundler-plugin-core": patch
+"@codecov/astro-plugin": patch
+"@codecov/bundle-analyzer": patch
+"@codecov/nextjs-webpack-plugin": patch
+"@codecov/nuxt-plugin": patch
+"@codecov/remix-vite-plugin": patch
+"@codecov/rollup-plugin": patch
+"@codecov/solidstart-plugin": patch
+"@codecov/sveltekit-plugin": patch
+"@codecov/vite-plugin": patch
+"@codecov/webpack-plugin": patch
+---
+
+Modifications to getPreSignedUrl errors


### PR DESCRIPTION
Update changelog for 2.0.2.

Changes for modifying getPreSignedUrl logged errors.