### PR TITLE
chore: replace Codecov by Sentry logo with Codecov by Harness logo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://about.codecov.io" target="_blank">
-    <img src="https://about.codecov.io/wp-content/themes/codecov/assets/brand/sentry-cobranding/logos/codecov-by-sentry-logo.svg" alt="Codecov by Sentry logo" width="280" height="84">
+    <img src="https://about.codecov.io/wp-content/themes/codecov/assets/brand/harness-cobranding/logos/codecov-by-harness-logo.png" alt="Codecov by Harness logo" width="280" height="84">
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://about.codecov.io" target="_blank">
-    <img src="https://about.codecov.io/wp-content/themes/codecov/assets/brand/sentry-cobranding/logos/codecov-by-sentry-logo.svg" alt="Codecov by Sentry logo" width="280" height="84">
+    <img src="https://about.codecov.io/wp-content/themes/codecov/assets/brand/harness-cobranding/logos/codecov-by-harness-logo.png" alt="Codecov by Harness logo" width="280" height="84">
   </a>
 </p>
 

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://about.codecov.io" target="_blank">
-    <img src="https://about.codecov.io/wp-content/themes/codecov/assets/brand/sentry-cobranding/logos/codecov-by-sentry-logo.svg" alt="Codecov by Sentry logo" width="280" height="84">
+    <img src="https://about.codecov.io/wp-content/themes/codecov/assets/brand/harness-cobranding/logos/codecov-by-harness-logo.png" alt="Codecov by Harness logo" width="280" height="84">
   </a>
 </p>
 

--- a/packages/astro-plugin/README.md
+++ b/packages/astro-plugin/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://about.codecov.io" target="_blank">
-    <img src="https://about.codecov.io/wp-content/themes/codecov/assets/brand/sentry-cobranding/logos/codecov-by-sentry-logo.svg" alt="Codecov by Sentry logo" width="280" height="84">
+    <img src="https://about.codecov.io/wp-content/themes/codecov/assets/brand/harness-cobranding/logos/codecov-by-harness-logo.png" alt="Codecov by Harness logo" width="280" height="84">
   </a>
 </p>
 

--- a/packages/bundle-analyzer/README.md
+++ b/packages/bundle-analyzer/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://about.codecov.io" target="_blank">
-    <img src="https://about.codecov.io/wp-content/themes/codecov/assets/brand/sentry-cobranding/logos/codecov-by-sentry-logo.svg" alt="Codecov by Sentry logo" width="280" height="84">
+    <img src="https://about.codecov.io/wp-content/themes/codecov/assets/brand/harness-cobranding/logos/codecov-by-harness-logo.png" alt="Codecov by Harness logo" width="280" height="84">
   </a>
 </p>
 

--- a/packages/bundler-plugin-core/README.md
+++ b/packages/bundler-plugin-core/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://about.codecov.io" target="_blank">
-    <img src="https://about.codecov.io/wp-content/themes/codecov/assets/brand/sentry-cobranding/logos/codecov-by-sentry-logo.svg" alt="Codecov by Sentry logo" width="280" height="84">
+    <img src="https://about.codecov.io/wp-content/themes/codecov/assets/brand/harness-cobranding/logos/codecov-by-harness-logo.png" alt="Codecov by Harness logo" width="280" height="84">
   </a>
 </p>
 

--- a/packages/nextjs-webpack-plugin/README.md
+++ b/packages/nextjs-webpack-plugin/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://about.codecov.io" target="_blank">
-    <img src="https://about.codecov.io/wp-content/themes/codecov/assets/brand/sentry-cobranding/logos/codecov-by-sentry-logo.svg" alt="Codecov by Sentry logo" width="280" height="84">
+    <img src="https://about.codecov.io/wp-content/themes/codecov/assets/brand/harness-cobranding/logos/codecov-by-harness-logo.png" alt="Codecov by Harness logo" width="280" height="84">
   </a>
 </p>
 

--- a/packages/nuxt-plugin/README.md
+++ b/packages/nuxt-plugin/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://about.codecov.io" target="_blank">
-    <img src="https://about.codecov.io/wp-content/themes/codecov/assets/brand/sentry-cobranding/logos/codecov-by-sentry-logo.svg" alt="Codecov by Sentry logo" width="280" height="84">
+    <img src="https://about.codecov.io/wp-content/themes/codecov/assets/brand/harness-cobranding/logos/codecov-by-harness-logo.png" alt="Codecov by Harness logo" width="280" height="84">
   </a>
 </p>
 

--- a/packages/remix-vite-plugin/README.md
+++ b/packages/remix-vite-plugin/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://about.codecov.io" target="_blank">
-    <img src="https://about.codecov.io/wp-content/themes/codecov/assets/brand/sentry-cobranding/logos/codecov-by-sentry-logo.svg" alt="Codecov by Sentry logo" width="280" height="84">
+    <img src="https://about.codecov.io/wp-content/themes/codecov/assets/brand/harness-cobranding/logos/codecov-by-harness-logo.png" alt="Codecov by Harness logo" width="280" height="84">
   </a>
 </p>
 

--- a/packages/rollup-plugin/README.md
+++ b/packages/rollup-plugin/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://about.codecov.io" target="_blank">
-    <img src="https://about.codecov.io/wp-content/themes/codecov/assets/brand/sentry-cobranding/logos/codecov-by-sentry-logo.svg" alt="Codecov by Sentry logo" width="280" height="84">
+    <img src="https://about.codecov.io/wp-content/themes/codecov/assets/brand/harness-cobranding/logos/codecov-by-harness-logo.png" alt="Codecov by Harness logo" width="280" height="84">
   </a>
 </p>
 

--- a/packages/solidstart-plugin/README.md
+++ b/packages/solidstart-plugin/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://about.codecov.io" target="_blank">
-    <img src="https://about.codecov.io/wp-content/themes/codecov/assets/brand/sentry-cobranding/logos/codecov-by-sentry-logo.svg" alt="Codecov by Sentry logo" width="280" height="84">
+    <img src="https://about.codecov.io/wp-content/themes/codecov/assets/brand/harness-cobranding/logos/codecov-by-harness-logo.png" alt="Codecov by Harness logo" width="280" height="84">
   </a>
 </p>
 

--- a/packages/sveltekit-plugin/README.md
+++ b/packages/sveltekit-plugin/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://about.codecov.io" target="_blank">
-    <img src="https://about.codecov.io/wp-content/themes/codecov/assets/brand/sentry-cobranding/logos/codecov-by-sentry-logo.svg" alt="Codecov by Sentry logo" width="280" height="84">
+    <img src="https://about.codecov.io/wp-content/themes/codecov/assets/brand/harness-cobranding/logos/codecov-by-harness-logo.png" alt="Codecov by Harness logo" width="280" height="84">
   </a>
 </p>
 

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://about.codecov.io" target="_blank">
-    <img src="https://about.codecov.io/wp-content/themes/codecov/assets/brand/sentry-cobranding/logos/codecov-by-sentry-logo.svg" alt="Codecov by Sentry logo" width="280" height="84">
+    <img src="https://about.codecov.io/wp-content/themes/codecov/assets/brand/harness-cobranding/logos/codecov-by-harness-logo.png" alt="Codecov by Harness logo" width="280" height="84">
   </a>
 </p>
 

--- a/packages/webpack-plugin/README.md
+++ b/packages/webpack-plugin/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://about.codecov.io" target="_blank">
-    <img src="https://about.codecov.io/wp-content/themes/codecov/assets/brand/sentry-cobranding/logos/codecov-by-sentry-logo.svg" alt="Codecov by Sentry logo" width="280" height="84">
+    <img src="https://about.codecov.io/wp-content/themes/codecov/assets/brand/harness-cobranding/logos/codecov-by-harness-logo.png" alt="Codecov by Harness logo" width="280" height="84">
   </a>
 </p>
 


### PR DESCRIPTION
Replace the "Codecov by Sentry" co-branding logo with the new "Codecov by Harness" logo across all README and CONTRIBUTING files.

- Updates logo URL from `sentry-cobranding/logos/codecov-by-sentry-logo.svg` to `harness-cobranding/logos/codecov-by-harness-logo.png`
- Updates alt text from "Codecov by Sentry logo" to "Codecov by Harness logo"
- 14 files updated: `README.md`, `CONTRIBUTING.md`, `integration-tests/README.md`, and all `packages/*/README.md`

Made with [Cursor](https://cursor.com)